### PR TITLE
getawslogs.py - fix JSON reformat

### DIFF
--- a/tools/amazon/getawslog.py
+++ b/tools/amazon/getawslog.py
@@ -110,13 +110,14 @@ def main(argv):
                 if "Records" in j:
                     records = j["Records"]
                     for item in records:
+                        log.write("\"AmazonAWS\":")
                         newline = 0
                         for field in item:
                             if newline > 0:
                                 log.write(",")
                             newline = 1
                             log.write("\"%s\":\"%s\"" % (field, item[field]))
-                        log.write("\n\"AmazonAWS\":")
+                        log.write("\n")
             log.close()
 
             try:


### PR DESCRIPTION
Insert "AmazonAWS" at the beginning for each record rather than at the end. This should fix the insert on first line as well as the very last dangling insert