### PR TITLE
skips cloudtrail digest files if found

### DIFF
--- a/tools/amazon/getawslog.py
+++ b/tools/amazon/getawslog.py
@@ -16,6 +16,7 @@ import gzip
 import json
 import os
 import os
+import re
 import signal
 import sys
 from optparse import OptionParser
@@ -85,8 +86,10 @@ def main(argv):
         print "Bucket %s access error: %s" % (options.logBucket, e)
         sys.exit(3)
     for f in c.list():
-
         newFile = os.path.basename(str(f.key))
+        if re.match('.+_CloudTrail-Digest_.+', newFile):
+            if options.debug: print "Skipping digest file: %s" % newFile
+            continue
         if newFile != "":
             if already_processed(newFile, state_tracker):
                 if options.debug:


### PR DESCRIPTION
Hi!

First off, thanks for all the work the team does on Wazuh and it's rulesets. It is greatly appreciated.

This is small change to allow those of us that have validation enabled (i.e. the 'digest files') on our CloudTrail to be ignored during the process.

If this is not helpful, no problem. It was just something I am going to use locally and wanted to make sure to pass it back upstream.

Thanks,

Harlan