### PR TITLE
Make users information for S3 access show up.

### DIFF
--- a/decoders/0020-amazon_decoders.xml
+++ b/decoders/0020-amazon_decoders.xml
@@ -27,6 +27,6 @@
 <decoder name="AmazonAWS-generic-fields">
     <parent>AmazonAWS</parent>
     <prematch>"eventName":</prematch>
-    <regex>"eventName":"(\S+)"\.+"userIdentity":"{u'\.+': u'(\S+)'\.+'accessKeyId': u'(\S+)'</regex>
-    <order>action,user,id</order>
+    <regex>"eventName":"(\S+)"\.+"userIdentity":"{u'\.+': u'(\S+)'</regex>
+    <order>action,user</order>
 </decoder>


### PR DESCRIPTION
This change allows users that interact with S3 buckets to be identified.  Credit goes to my friend Marcus Ahle (marcus@pazien.com).