### PR TITLE
Update sshd rules

### DIFF
--- a/rules/0095-sshd_rules.xml
+++ b/rules/0095-sshd_rules.xml
@@ -368,7 +368,7 @@
 
   <rule id="5753" level="2">
     <if_sid>5750</if_sid>
-    <match>no matching cipher found.</match>
+    <match>no matching cipher found</match>
     <description>sshd: could not negotiate with client, no matching cipher.</description>
   </rule>
 
@@ -402,6 +402,12 @@
     <match>^error: maximum authentication attempts exceeded </match>
     <description>Maximum authentication attempts exceeded.</description>
     <group>authentication_failed,</group>
+  </rule>
+
+  <rule id="5759" level="2">
+    <if_sid>5750</if_sid>
+    <match>no matching mac found</match>
+    <description>sshd: could not negotiate with client, no matching mac.</description>
   </rule>
 
 </group>


### PR DESCRIPTION
Add in a rule for `no matching mac`

Remove the trailing `.` from `no matching cipher` as some systems use a `:` instead


Both of these are commonly triggered if you are running a hardened SSH configuration