### PR TITLE
update_ruleset.py: extract directory name from zip file dynamically

### DIFF
--- a/update_ruleset.py
+++ b/update_ruleset.py
@@ -271,12 +271,13 @@ def get_new_ruleset(source, url):
         # Extract
         try:
             with contextlib.closing(ZipFile(ruleset_zip)) as z:
+                zip_dir = search('^wazuh-ruleset-{0}([0-9a-z-]+)?$'.format(branch), z.namelist()[0].strip('/')).group(0)
                 z.extractall(update_downloads)
         except Exception as e:
             exit(2, "\tError extracting file '{0}': {1}.".format(ruleset_zip, e))
 
         # Rename
-        rename("{0}/wazuh-ruleset-{1}".format(update_downloads, branch), update_ruleset)
+        rename("{0}/{1}".format(update_downloads, zip_dir), update_ruleset)
 
     else:
         # New ruleset

--- a/update_ruleset.py
+++ b/update_ruleset.py
@@ -595,4 +595,4 @@ if __name__ == "__main__":
     try:
         main()
     except Exception as e:
-        exit(2, "Unkown: {0}.\nExiting.".format(e))
+        exit(2, "Unknown: {0}.\nExiting.".format(e))


### PR DESCRIPTION
When using other git platforms than github (e.g. gitlab), the path in the downloaded zip file may contain commit hashes.

Example:
github:
`wazuh-ruleset-stable/VERSION`
gitlab:
`wazuh-ruleset-stable-4fcaef3a104dff5749b76b830cf251abf288bd47/VERSION`