### PR TITLE
Update sshd decoder to match line including port.

### DIFF
--- a/decoders/0310-ssh_decoders.xml
+++ b/decoders/0310-ssh_decoders.xml
@@ -144,25 +144,22 @@
   <order>srcip</order>
 </decoder>
 
-<decoder name="ssh-scan2">
-  <parent>sshd</parent>
-  <prematch>^Did not receive identification</prematch>
-  <regex offset="after_prematch"> from (\S+)$</regex>
-  <order>srcip</order>
-</decoder>
-
 <!--
 Jul 12 16:10:26 cloud sshd[14486]: Bad protocol version identification 'GET http://m.search.yahoo.com/ HTTP/1.1' from 112.98.69.104 port 3533
 Jul 12 16:10:41 cloud sshd[14530]: Bad protocol version identification 'GET http://check2.zennolab.com/proxy.php HTTP/1.1' from 46.182.129.46 port 60866
 Jul 12 16:11:31 cloud sshd[14582]: Bad protocol version identification 'GET http://www.msftncsi.com/ncsi.txt HTTP/1.1' from 88.244.115.169 port 62240
 Jul 12 16:12:15 cloud sshd[14662]: Bad protocol version identification 'GET http://m.search.yahoo.com/ HTTP/1.1' from 118.76.116.187 port 54513
+e.g. OpenSSH > 7.2:
+Sep  4 21:13:05 example sshd[12853]: Did not receive identification string from 192.168.0.1 port 33021
+e.g. OpenSSH <= 7.2:
+Sep  4 21:14:25 example sshd[18368]: Did not receive identification string from 192.168.0.1
 -->
 
-<decoder name="ssh-scan3">
+<decoder name="ssh-scan2">
   <parent>sshd</parent>
-  <prematch>^Bad protocol version </prematch>
-  <regex offset="after_prematch">\w* from (\S+)</regex>
-  <order>srcip</order>
+  <prematch>^Did not receive identification |^Bad protocol version </prematch>
+  <regex offset="after_prematch"> from (\S+)$| from (\S+) port (\d+)$</regex>
+  <order>srcip,srcport</order>
 </decoder>
 
 <decoder name="ssh-osx-refuse">


### PR DESCRIPTION
Same as https://github.com/ossec/ossec-hids/pull/1249:

This is a follow-up of https://github.com/wazuh/wazuh-ruleset/issues/61 and partly reverts the commit https://github.com/wazuh/wazuh-ruleset/commit/c5e351aaa9da1fe1ce6574dd43f9769ee3cf4b78 (Pulled from https://github.com/ossec/ossec-hids/pull/1194).

Between OpenSSH 7.2 and 7.3 the "Did not receive identification string" message changed as well and now also contains the port:

https://github.com/openssh/openssh-portable/blob/V_7_2_P1/sshd.c#L450-L451
https://github.com/openssh/openssh-portable/blob/V_7_3_P1/sshd.c#L452-L453

*Edit*

Also updated to catch the srcport if it exists.