### PR TITLE
Rules/decoders for Proxmox VE

### DIFF
--- a/decoders/0440-proxmox-ve_decoders.xml
+++ b/decoders/0440-proxmox-ve_decoders.xml
@@ -1,0 +1,65 @@
+<!--
+  -  Proxmox Virtual Environment (Proxmox VE) decoders
+  -  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2.
+-->
+
+<!--
+- Will extract username and src IP from the logs, when available.
+
+- Examples syslog:
+Sep 10 22:12:41 example pvedaemon[6427]: authentication failure; rhost=192.168.0.1 user=root@pam msg=Authentication failure
+Sep 10 22:12:49 example pvedaemon[6428]: authentication failure; rhost=192.168.0.1 user=root@pve msg=no such user ('root@pve')
+Sep 10 22:12:54 example pvedaemon[6428]: <root@pam> successful auth for user 'root@pam'
+Sep 10 22:13:44 example pvedaemon[6427]: <root@pam> starting task UPID:example:00000000:11111111:22222222:vzstart:100:root@pam:
+Sep 10 22:13:44 example pvedaemon[13735]: starting CT 100: UPID:example:00000000:11111111:22222222:vzstart:100:root@pam:
+Sep 10 22:13:46 example pvedaemon[6427]: <root@pam> end task UPID:example:00000000:11111111:22222222:vzstart:100:root@pam: OK
+Sep 10 22:13:47 example pvestatd[1892]: modified cpu set for lxc/100: 4
+Sep 10 06:25:44 example pveproxy[15342]: received signal TERM
+Sep 10 06:25:44 example pveproxy[15342]: server closing
+Sep 10 06:25:44 example pveproxy[15345]: worker exit
+Sep 10 06:25:44 example pveproxy[15344]: worker exit
+Sep 10 06:25:44 example pveproxy[15343]: worker exit
+Sep 10 06:25:44 example pveproxy[15342]: worker 15343 finished
+Sep 10 06:25:44 example pveproxy[15342]: worker 15344 finished
+Sep 10 06:25:44 example pveproxy[15342]: worker 15345 finished
+Sep 10 06:25:44 example pveproxy[15342]: server stopped
+Sep 10 06:25:45 example pveproxy[22375]: Using '/etc/pve/local/pveproxy-ssl.pem' as certificate for the web interface.
+Sep 10 06:25:45 example pveproxy[22413]: starting server
+Sep 10 06:25:45 example pveproxy[22413]: starting 3 worker(s)
+Sep 10 06:25:45 example pveproxy[22413]: worker 22414 started
+Sep 10 06:25:45 example pveproxy[22413]: worker 22415 started
+Sep 10 06:25:45 example pveproxy[22413]: worker 22416 started
+Sep 10 06:25:47 example pvepw-logger[15428]: received terminate request (signal)
+Sep 10 06:25:47 example pvepw-logger[15428]: stopping pvefw logger
+Sep 10 06:25:48 example pvepw-logger[22551]: starting pvefw logger
+-->
+
+<decoder name="pvedaemon">
+  <program_name>^pvedaemon</program_name>
+</decoder>
+
+<decoder name="pvestatd">
+  <program_name>^pvestatd</program_name>
+</decoder>
+
+<decoder name="pveproxy">
+  <program_name>^pveproxy</program_name>
+</decoder>
+
+<decoder name="pvepw-logger">
+  <program_name>^pvepw-logger</program_name>
+</decoder>
+
+<decoder name="pvedaemon-auth-failed">
+  <parent>pvedaemon</parent>
+  <prematch>authentication failure; </prematch>
+  <regex offset="after_prematch">^rhost=(\S+) user=(\S+)@pam msg=|^rhost=(\S+) user=(\S+)@pve msg=</regex>
+  <order>srcip, user</order>
+</decoder>
+
+<decoder name="pvedaemon-auth-success">
+  <parent>pvedaemon</parent>
+  <prematch>successful auth for user '</prematch>
+  <regex offset="after_prematch">^(\S+)@pam'$|^(\S+)@pve'$</regex>
+  <order>user</order>
+</decoder>

--- a/rules/0495-proxmox-ve_rules.xml
+++ b/rules/0495-proxmox-ve_rules.xml
@@ -1,0 +1,34 @@
+<!--
+  -  Proxmox Virtual Environment (Proxmox VE) rules
+  -  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2.
+-->
+
+<!-- ID: 87200 - 87300 -->
+<group name="syslog,proxmox-ve,">
+  <rule id="87200" level="0">
+    <decoded_as>pvedaemon</decoded_as>
+    <description>pvedaemon messages grouped.</description>
+  </rule>
+
+  <rule id="87201" level="6">
+    <if_sid>87200</if_sid>
+    <match>authentication failure; </match>
+    <description>Proxmox VE authentication failed.</description>
+    <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,</group>
+  </rule>
+
+  <rule id="87202" level="10" frequency="6" timeframe="120">
+    <if_matched_sid>87201</if_matched_sid>
+    <same_source_ip />
+    <description>Proxmox VE brute force (multiple failed logins).</description>
+    <group>authentication_failures,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,</group>
+  </rule>
+
+  <rule id="87203" level="3">
+    <if_sid>87200</if_sid>
+    <match> successful auth for user </match>
+    <description>Proxmox VE authentication succeeded.</description>
+    <group>authentication_success,pci_dss_10.2.5,</group>
+  </rule>
+
+</group>


### PR DESCRIPTION
Cross-Ref: https://github.com/ossec/ossec-hids/pull/1268

*Edit*

I havn't included any rules / decoders besides the ones for failed / successful logins. Not quite sure how much more useful info could be gathered from the other example logfiles.