### PR TITLE
Updated Windows auth failure rules

### DIFF
--- a/rules/0220-msauth_rules.xml
+++ b/rules/0220-msauth_rules.xml
@@ -49,7 +49,7 @@
 
   <rule id="18106" level="5">
     <if_sid>18105</if_sid>
-    <id>^529$|^530$|^531$|^532$|^533$|^534$|^535$|^536$|^537$|^539$|^4625$</id>
+    <id>^529$|^530$|^531$|^532$|^533$|^534$|^535$|^536$|^537$|^539$|^4625$|^4556$|^4771$</id>
     <description>Windows Logon Failure.</description>
     <group>win_authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,</group>
   </rule>


### PR DESCRIPTION
Windows events 4556 and 4771 were missing from the Windows Logon Failure rule