### PR TITLE
fix to catch IAM login failures

### DIFF
--- a/rules/0350-amazon_rules.xml
+++ b/rules/0350-amazon_rules.xml
@@ -75,7 +75,7 @@ ID: 80200 - 80499
 
     <rule id="80254" level="5">
         <if_sid>80253</if_sid>
-        <field name="aws.ConsoleLogin">Failure</field>
+        <field name="aws.responseElements.ConsoleLogin">Failure</field>
         <description>Amazon: $(aws.eventSource) - $(aws.eventName) - User Login failed.</description>
         <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,</group>
     </rule>


### PR DESCRIPTION
With IAM login failures, the JSON record from CloudTrail contains the field "aws.responseElements.ConsoleLogin" with the value "Failure".  That field name was previously being imported as "aws.ConsoleLogin" so without this fix, all IAM login failures are reporting as login success events.  

I also checked, and all the other CloudTrail fields presently used as criteria in Wazuh Amazon rules, are correctly matched to the JSON field names coming from CloudTrail.