### PR TITLE
McAfee and Percona MySQL audit log rules

### DIFF
--- a/rules/0520-mysql_audit_rules.xml
+++ b/rules/0520-mysql_audit_rules.xml
@@ -1,0 +1,126 @@
+<!--
+  -  Wazuh rules
+  -  Created by Wazuh, Inc. <support@wazuh.com>.
+  -  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2.
+-->
+
+<group name="mysql_audit,">
+
+    <rule id="88000" level="0">
+      <decoded_as>json</decoded_as>
+      <field name="mysql_audit_log">percona</field>
+      <description>Percona Server audit events grouped.</description>
+    </rule>
+
+    <rule id="88001" level="3">
+      <if_sid>88000</if_sid>
+      <field name="audit_record.name">^Connect$</field>
+      <field name="audit_record.status">^0$</field>
+      <description>Percona audit: authentication success.</description>
+      <group>authentication_success,pci_dss_10.2.5,pci_dss_8.7,gpg13_7.1,gpg13_7.2,</group>
+    </rule>
+
+    <rule id="88002" level="3">
+      <if_sid>88000</if_sid>
+      <field name="audit_record.name">^Quit$</field>
+      <description>Percona audit: user logout.</description>
+      <group>pci_dss_10.2.5,pci_dss_8.7,gpg13_7.1,gpg13_7.2,</group>
+    </rule>
+
+    <rule id="88003" level="9">
+      <if_sid>88000</if_sid>
+      <field name="audit_record.name">^Connect$</field>
+      <field name="audit_record.status">^1</field>
+      <description>Percona audit: authentication failure.</description>
+      <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_8.7,gpg13_7.1,</group>
+    </rule>
+
+    <rule id="88004" level="3">
+      <if_sid>88000</if_sid>
+      <field name="audit_record.name">^Query$</field>
+      <field name="audit_record.status">^0$</field>
+      <description>Percona audit success: $(audit_record.command_class) statement.</description>
+      <group>pci_dss_8.7,gpg13_7.1</group>
+    </rule>
+
+    <rule id="88005" level="5">
+      <if_sid>88004</if_sid>
+      <field name="audit_record.name">^Query$</field>
+      <field name="audit_record.command_class">^drop|^alter|^insert|^update|^grant|^delete</field>
+      <description>Percona audit success: $(audit_record.command_class) statement.</description>
+      <group>pci_dss_8.7,gpg13_7.1</group>
+    </rule>
+
+    <rule id="88006" level="3">
+      <if_sid>88000</if_sid>
+      <field name="audit_record.name">^Query$</field>
+      <field name="audit_record.status">^1</field>
+      <description>Percona audit failed: $(audit_record.command_class) statement.</description>
+      <group>pci_dss_8.7,gpg13_7.1</group>
+    </rule>
+
+    <rule id="88007" level="5">
+      <if_sid>88006</if_sid>
+      <field name="audit_record.name">^Query$</field>
+      <field name="audit_record.command_class">^drop|^alter|^insert|^update|^grant|^delete</field>
+      <description>Percona audit failed: $(audit_record.command_class) statement.</description>
+      <group>pci_dss_8.7,gpg13_7.1</group>
+    </rule>
+
+    <rule id="89000" level="0">
+      <decoded_as>json</decoded_as>
+      <field name="mysql_audit_log">mcafee</field>
+      <description>McAfee AUDIT Plugin for MySQL events grouped.</description>
+    </rule>
+
+    <rule id="89001" level="3">
+      <if_sid>89000</if_sid>
+      <field name="cmd">^Connect$</field>
+      <description>McAfee MySQL audit: authentication attempt.</description>
+      <group>pci_dss_10.2.5,pci_dss_8.7,gpg13_7.1,gpg13_7.2,</group>
+    </rule>
+
+    <rule id="89002" level="3">
+      <if_sid>89000</if_sid>
+      <field name="cmd">^Quit$</field>
+      <description>McAfee MySQL audit: user logout.</description>
+      <group>pci_dss_10.2.5,pci_dss_8.7,gpg13_7.1,gpg13_7.2,</group>
+    </rule>
+
+    <rule id="89003" level="9">
+      <if_sid>89000</if_sid>
+      <field name="cmd">^Failed Login$</field>
+      <description>McAfee MySQL audit: authentication failure.</description>
+      <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_8.7,gpg13_7.1,</group>
+    </rule>
+
+    <rule id="89004" level="3">
+      <if_sid>89000</if_sid>
+      <status>^0$</status>
+      <description>McAfee MySQL audit success: $(cmd) statement.</description>
+      <group>pci_dss_8.7,gpg13_7.1</group>
+    </rule>
+
+    <rule id="89005" level="5">
+      <if_sid>89004</if_sid>
+      <field name="cmd">^drop|^alter|^insert|^update|^grant|^delete</field>
+      <description>McAfee MySQL audit success: $(cmd) statement.</description>
+      <group>pci_dss_8.7,gpg13_7.1</group>
+    </rule>
+
+    <rule id="89006" level="3">
+      <if_sid>89000</if_sid>
+      <status>^1</status>
+      <description>McAfee MySQL audit failed: $(cmd) statement.</description>
+      <group>pci_dss_8.7,gpg13_7.1</group>
+    </rule>
+
+    <rule id="89007" level="5">
+      <if_sid>89006</if_sid>
+      <field name="cmd">^drop|^alter|^insert|^update|^grant|^delete</field>
+      <description>McAfee MySQL audit failed: $(cmd) statement.</description>
+      <group>pci_dss_8.7,gpg13_7.1</group>
+    </rule>
+
+</group>
+


### PR DESCRIPTION
Hi,

This adds a set of rules for [McAfee ](https://github.com/mcafee/mysql-audit) and [Percona ](https://www.percona.com/doc/percona-server/LATEST/management/audit_log_plugin.html) Mysql audit logs, this is intended to be used with JSON formatted log files. In order to avoid a false match, logcollector must be configured with the following labels:

```
<localfile>
  <location>/var/log/mysql/mcafee.json</location>
  <log_format>json</log_format>
  <label key="mysql_audit_log">mcafee</label>
</localfile>

<localfile>
  <location>/var/log/mysql/percona.json</location>
  <log_format>json</log_format>
  <label key="mysql_audit_log">percona</label>
</localfile>
```

Next, some log samples:

- McAfee:

`{"msg-type":"activity","date":"1516567908029","thread-id":"26","query-id":"424","user":"root","priv_user":"root","ip":"","host":"localhost","connect_attrs":{"_os":"Linux","_client_name":"libmysql","_pid":"23090","_client_version":"5.6.38","_platform":"x86_64","program_name":"mysql"},"pid":"23090","os_user":"root","appname":"mysql","rows":"1","status":"0","cmd":"select","query":"select @@version_comment limit 1"}`

- Percona:

`{"audit_record":{"name":"Query","record":"4707_2014-08-27T10:43:52","timestamp":"2014-08-27T10:44:19 UTC","command_class":"show_databases","connection_id":"37","status":0,"sqltext":"show databases","user":"root[root] @ localhost []","host":"localhost","os_user":"","ip":""}}`

Thanks in advance.

Best regards,
