### PR TITLE
Do not send emails with alerts under level 3 by default

### DIFF
--- a/rules/0020-syslog_rules.xml
+++ b/rules/0020-syslog_rules.xml
@@ -23,7 +23,6 @@
 
   <rule id="1002" level="2">
     <match>$BAD_WORDS</match>
-    <options>alert_by_email</options>
     <description>Unknown problem somewhere in the system.</description>
     <group>gpg13_4.3,</group>
   </rule>
@@ -605,7 +604,7 @@
 <group name="syslog,dpkg,">
   <rule id="2900" level="0">
     <decoded_as>windows-date-format</decoded_as>
-    <regex offet="after_parent">^startup |^status |^remove |^configure |^install |^purge |^trigproc </regex> 
+    <regex offet="after_parent">^startup |^status |^remove |^configure |^install |^purge |^trigproc </regex>
     <description>Dpkg (Debian Package) log.</description>
   </rule>
 

--- a/rules/0155-dovecot_rules.xml
+++ b/rules/0155-dovecot_rules.xml
@@ -36,7 +36,6 @@
 <rule id="9704" level="2">
   <if_sid>9700</if_sid>
   <match>^Fatal: </match>
-  <options>alert_by_email</options>
   <description>Dovecot Fatal Failure.</description>
 </rule>
 


### PR DESCRIPTION
These rules:
- 1002 (bad words in syslog messages)
- 9704 (fatal failure in Dovecot logs)

have level 2 but are marked to be sent by email. We propose to remove this behavior by default: low-level alerts shouldn't appear in emails.

Thanks to @branchnetconsulting for his feedback!