### PR TITLE
issue #67 fixed. Updated ruleset

### DIFF
--- a/decoders/0220-postfix_decoders.xml
+++ b/decoders/0220-postfix_decoders.xml
@@ -45,6 +45,6 @@
   <use_own_name>true</use_own_name>
   <parent>postfix</parent>
   <prematch>^warning:</prematch>
-  <regex>^warning: (\S+):|warning: Illegal address syntax from unknown[(\S+)]</regex>
+  <regex>^warning: (\S+):|warning: Illegal address syntax from unknown[(\S+)]|warning: hostname \S+ does not resolve to address (\S+): </regex>
   <order>srcip</order>
 </decoder>

--- a/rules/0030-postfix_rules.xml
+++ b/rules/0030-postfix_rules.xml
@@ -189,7 +189,7 @@
 
   <rule id="3398" level="6">
     <if_sid>3395</if_sid>
-    <match>MAIL</match>
+    <match>MAIL|hostname</match>
     <description>Postfix: Illegal address from unknown sender</description>
     <group>spam,pci_dss_10.6.1,pci_dss_11.4,</group>
   </rule>

--- a/rules/0030-postfix_rules.xml
+++ b/rules/0030-postfix_rules.xml
@@ -189,7 +189,7 @@
 
   <rule id="3398" level="6">
     <if_sid>3395</if_sid>
-    <match>MAIL|hostname</match>
+    <match>MAIL|does not resolve to address</match>
     <description>Postfix: Illegal address from unknown sender</description>
     <group>spam,pci_dss_10.6.1,pci_dss_11.4,</group>
   </rule>


### PR DESCRIPTION
Updated decoders\0220-postfix_decoders.xml:
New use case added to decoder "postfix-warning" to obtain the srcip field.

Updated rules\0030-postfix_rules.xml:
New match case added to rule 3398, to be triggered with the new use case.