### PR TITLE
Fix issue #72 from 3.2

### DIFF
--- a/decoders/0275-sendmail_decoders.xml
+++ b/decoders/0275-sendmail_decoders.xml
@@ -19,6 +19,17 @@
   from [200.121.73.169] [200.121.73.169] due to pre-greeting traffic
   - sendmail[7818]: j6KKHo2d007818: rejecting commands from sv.e103gng.com [66.62.19.10] due to pre-greeting traffic
  -->
+
+ <!--
+   Sep 29 17:11:02 ramp sendmail[21549]: v8TLB2x7021549: from=<vonfal@ramp.org>, size=909, class=0, nrcpts=1, msgid=<201709292111.v8TLB1Nj021545@ramp.org>, proto=ESMTP, daemon=MTA, relay=localhost.localdomain [127.0.0.1]
+
+   Sep 29 17:11:02 ramp sendmail[21549]: v8TLB2x7021549: from=<vonfal@ramp.org>, size=909, class=0, nrcpts=1, msgid=<201709292111.v8TLB1Nj021545@ramp.org>, proto=ESMTP, daemon=MTA, relay=[127.0.0.1]
+
+   Sep 29 17:11:02 ramp sendmail[21549]: v8TLB2x7021549: from=<vonfal@ramp.org>, size=909, class=0, nrcpts=1, msgid=<201709292111.v8TLB1Nj021545@ramp.org>, proto=ESMTP, daemon=MTA, relay=localhost.localdomain [12001:0db8:::0d0b]
+   
+   Sep 29 17:11:02 ramp sendmail[21549]: v8TLB2x7021549: from=<vonfal@ramp.org>, size=909, class=0, nrcpts=1, msgid=<201709292111.v8TLB1Nj021545@ramp.org>, proto=ESMTP, daemon=MTA, relay=[2001:0db8:85a3:0000:0000:8a2e:0370:7334]
+ -->
+
 <decoder name="sendmail-reject">
   <program_name>^sendmail|^sm-mta|^sm-msp-queue</program_name>
 </decoder>
@@ -33,14 +44,14 @@
 <decoder name="sendmail-reject-nodns">
   <parent>sendmail-reject</parent>
   <prematch>relay=[</prematch>
-  <regex offset="after_prematch">^(\S+)]</regex>
+  <regex offset="after_prematch">^(\d+.\d+.\d+.\d+)]|^(\w*:\w*:\w*)]|^(\w*:\w*:\w*:\w*)]|^(\w*:\w*:\w*:\w*:\w*)]|^(\w*:\w*:\w*:\w*:\w*:\w*)]|^(\w*:\w*:\w*:\w*:\w*:\w*:\w*)]|^(\w*:\w*:\w*:\w*:\w*:\w*:\w*:\w*)]</regex>
   <order>srcip</order>
 </decoder>
 
 <decoder name="sendmail-reject-dns">
   <parent>sendmail-reject</parent>
   <prematch>relay=\S+ [</prematch>
-  <regex offset="after_prematch">^(\S+)]</regex>
+  <regex offset="after_prematch">^(\d+.\d+.\d+.\d+)]|^(\w*:\w*:\w*)]|^(\w*:\w*:\w*:\w*)]|^(\w*:\w*:\w*:\w*:\w*)]|^(\w*:\w*:\w*:\w*:\w*:\w*)]|^(\w*:\w*:\w*:\w*:\w*:\w*:\w*)]|^(\w*:\w*:\w*:\w*:\w*:\w*:\w*:\w*)]</regex>
   <order>srcip</order>
 </decoder>
 

--- a/decoders/0275-sendmail_decoders.xml
+++ b/decoders/0275-sendmail_decoders.xml
@@ -21,13 +21,13 @@
  -->
 
  <!--
-   Sep 29 17:11:02 ramp sendmail[21549]: v8TLB2x7021549: from=<example@email.com>, size=909, class=0, nrcpts=1, msgid=<201709292111.v8TLB1Nj021545@ramp.org>, proto=ESMTP, daemon=MTA, relay=localhost.localdomain [127.0.0.1]
+   Sep 29 17:11:02 ramp sendmail[21549]: v8TLB2x7021549: from=<example@email.com>, size=909, class=0, nrcpts=1, msgid=<201709292111.v8TLB1Nj021545@email.com>, proto=ESMTP, daemon=MTA, relay=localhost.localdomain [127.0.0.1]
 
-   Sep 29 17:11:02 ramp sendmail[21549]: v8TLB2x7021549: from=<example@email.com>, size=909, class=0, nrcpts=1, msgid=<201709292111.v8TLB1Nj021545@ramp.org>, proto=ESMTP, daemon=MTA, relay=[127.0.0.1]
+   Sep 29 17:11:02 ramp sendmail[21549]: v8TLB2x7021549: from=<example@email.com>, size=909, class=0, nrcpts=1, msgid=<201709292111.v8TLB1Nj021545@email.com>, proto=ESMTP, daemon=MTA, relay=[127.0.0.1]
 
-   Sep 29 17:11:02 ramp sendmail[21549]: v8TLB2x7021549: from=<example@email.com>, size=909, class=0, nrcpts=1, msgid=<201709292111.v8TLB1Nj021545@ramp.org>, proto=ESMTP, daemon=MTA, relay=localhost.localdomain [12001:0db8:::0d0b]
+   Sep 29 17:11:02 ramp sendmail[21549]: v8TLB2x7021549: from=<example@email.com>, size=909, class=0, nrcpts=1, msgid=<201709292111.v8TLB1Nj021545@email.com>, proto=ESMTP, daemon=MTA, relay=localhost.localdomain [12001:0db8:::0d0b]
    
-   Sep 29 17:11:02 ramp sendmail[21549]: v8TLB2x7021549: from=<example@email.com>, size=909, class=0, nrcpts=1, msgid=<201709292111.v8TLB1Nj021545@ramp.org>, proto=ESMTP, daemon=MTA, relay=[2001:0db8:85a3:0000:0000:8a2e:0370:7334]
+   Sep 29 17:11:02 ramp sendmail[21549]: v8TLB2x7021549: from=<example@email.com>, size=909, class=0, nrcpts=1, msgid=<201709292111.v8TLB1Nj021545@email.com>, proto=ESMTP, daemon=MTA, relay=[2001:0db8:85a3:0000:0000:8a2e:0370:7334]
  -->
 
 <decoder name="sendmail-reject">

--- a/decoders/0275-sendmail_decoders.xml
+++ b/decoders/0275-sendmail_decoders.xml
@@ -21,13 +21,13 @@
  -->
 
  <!--
-   Sep 29 17:11:02 ramp sendmail[21549]: v8TLB2x7021549: from=<vonfal@ramp.org>, size=909, class=0, nrcpts=1, msgid=<201709292111.v8TLB1Nj021545@ramp.org>, proto=ESMTP, daemon=MTA, relay=localhost.localdomain [127.0.0.1]
+   Sep 29 17:11:02 ramp sendmail[21549]: v8TLB2x7021549: from=<example@email.com>, size=909, class=0, nrcpts=1, msgid=<201709292111.v8TLB1Nj021545@ramp.org>, proto=ESMTP, daemon=MTA, relay=localhost.localdomain [127.0.0.1]
 
-   Sep 29 17:11:02 ramp sendmail[21549]: v8TLB2x7021549: from=<vonfal@ramp.org>, size=909, class=0, nrcpts=1, msgid=<201709292111.v8TLB1Nj021545@ramp.org>, proto=ESMTP, daemon=MTA, relay=[127.0.0.1]
+   Sep 29 17:11:02 ramp sendmail[21549]: v8TLB2x7021549: from=<example@email.com>, size=909, class=0, nrcpts=1, msgid=<201709292111.v8TLB1Nj021545@ramp.org>, proto=ESMTP, daemon=MTA, relay=[127.0.0.1]
 
-   Sep 29 17:11:02 ramp sendmail[21549]: v8TLB2x7021549: from=<vonfal@ramp.org>, size=909, class=0, nrcpts=1, msgid=<201709292111.v8TLB1Nj021545@ramp.org>, proto=ESMTP, daemon=MTA, relay=localhost.localdomain [12001:0db8:::0d0b]
+   Sep 29 17:11:02 ramp sendmail[21549]: v8TLB2x7021549: from=<example@email.com>, size=909, class=0, nrcpts=1, msgid=<201709292111.v8TLB1Nj021545@ramp.org>, proto=ESMTP, daemon=MTA, relay=localhost.localdomain [12001:0db8:::0d0b]
    
-   Sep 29 17:11:02 ramp sendmail[21549]: v8TLB2x7021549: from=<vonfal@ramp.org>, size=909, class=0, nrcpts=1, msgid=<201709292111.v8TLB1Nj021545@ramp.org>, proto=ESMTP, daemon=MTA, relay=[2001:0db8:85a3:0000:0000:8a2e:0370:7334]
+   Sep 29 17:11:02 ramp sendmail[21549]: v8TLB2x7021549: from=<example@email.com>, size=909, class=0, nrcpts=1, msgid=<201709292111.v8TLB1Nj021545@ramp.org>, proto=ESMTP, daemon=MTA, relay=[2001:0db8:85a3:0000:0000:8a2e:0370:7334]
  -->
 
 <decoder name="sendmail-reject">


### PR DESCRIPTION
There is a bug with regular expressions.

When you have an event that ends in the character "]"  and for example, you want to extract a previous field, you will also extract the character "]" if you use the regular expression "\S+".

For example, you have this event:

Sep 29 17:11:02 ramp sendmail[21549]: v8TLB2x7021549: from=<example@email.com>, size=909, class=0, nrcpts=1, msgid=<201709292111.v8TLB1Nj021545@email.com>, proto=ESMTP, daemon=MTA, relay=[127.0.0.1]

And you want to extract the source IP. If you use something like this:

...relay=[(\S+)]

to obtain the source IP, you will obtain:

srcip= "127.0.0.1]"

This can be problematic.

To solve it we have to use the following regular expressions, where we will establish conditions based on the structure of the IP:

For IPv4: (\d+.\d+.\d+.\d+)

For IPv6: (\w*:\w*:\w*)|(\w*:\w*:\w*:\w*)|(\w*:\w*:\w*:\w*:\w*)|(\w*:\w*:\w*:\w*:\w*:\w*)|(\w*:\w*:\w*:\w*:\w*:\w*:\w*)|(\w*:\w*:\w*:\w*:\w*:\w*:\w*:\w*)

 The resulting regular expression will be something like this:

`<regex offset="after_prematch"> ^(\d+.\d+.\d+.\d+)]|^(\w*:\w*:\w*)]|^(\w*:\w*:\w*:\w*)]|^(\w*:\w*:\w*:\w*:\w*)]|^(\w*:\w*:\w*:\w*:\w*:\w*)]|^(\w*:\w*:\w*:\w*:\w*:\w*:\w*)]|^(\w*:\w*:\w*:\w*:\w*:\w*:\w*:\w*)] </regex>`





