### PR TITLE
Silence Vuls integration starting and ending alerts

### DIFF
--- a/rules/0015-ossec_rules.xml
+++ b/rules/0015-ossec_rules.xml
@@ -95,7 +95,8 @@
     <match>^Starting rootcheck scan|^Ending rootcheck scan.|</match>
     <match>^Starting syscheck scan|^Ending syscheck scan.|</match>
     <match>^Starting OpenSCAP scan|^Ending OpenSCAP scan.|</match>
-    <match>^Starting CIS-CAT scan|^Ending CIS-CAT scan.</match>
+    <match>^Starting CIS-CAT scan|^Ending CIS-CAT scan.|</match>
+    <match>^Starting vulnerability scan|^Ending vulnerability scan.</match>
     <description>Ignoring scan messages.</description>
     <group>rootcheck,syscheck,pci_dss_10.6.1,</group>
   </rule>


### PR DESCRIPTION
(Related to PR https://github.com/wazuh/wazuh/pull/541)

The Vuls integration made this alert fire:
```
** Alert 1523756607.3400683: - ossec,rootcheck,
2018 Apr 15 01:43:27 (ag-redhat) 10.0.0.166->rootcheck
Rule: 510 (level 7) -> 'Host-based anomaly detection event (rootcheck).'
{'event': 'Ending vulnerability scan.'}
title: {'event': 'Ending vulnerability scan.'}
```

This is due to a rootcheck-type notification when the scan starts and ends. This alert should be in plain-text and ignored by default.