### PR TITLE
Fix SID syntax for group membership changes

### DIFF
--- a/rules/0220-msauth_rules.xml
+++ b/rules/0220-msauth_rules.xml
@@ -495,7 +495,7 @@
 
   <rule id="18218" level="5">
     <if_sid>18207,18208</if_sid>
-    <regex> ID:\s+%{S-1-1-0}</regex>
+    <regex> ID:\s+%{S-1-1-0}| ID:\s+S-1-1-0</regex>
     <description>Windows: Everyone Group Changed</description>
     <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,</group>
     <info>http://support.microsoft.com/kb/243330</info>
@@ -503,7 +503,7 @@
 
   <rule id="18219" level="12">
     <if_sid>18207,18208</if_sid>
-    <regex> ID:\s+%{S-1-5-9}</regex>
+    <regex> ID:\s+%{S-1-5-9}| ID:\s+S-1-5-9</regex>
     <description>Windows: Enterprise Domain Controllers Group Changed</description>
     <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,</group>
     <info>http://support.microsoft.com/kb/243330</info>
@@ -511,7 +511,7 @@
 
   <rule id="18220" level="5">
     <if_sid>18207,18208</if_sid>
-    <regex> ID:\s+%{S-1-5-11}</regex>
+    <regex> ID:\s+%{S-1-5-11}| ID:\s+S-1-5-11</regex>
     <description>Windows: Authenticated Users Group Changed</description>
     <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,</group>
     <info>http://support.microsoft.com/kb/243330</info>
@@ -519,7 +519,7 @@
 
   <rule id="18221" level="5">
     <if_sid>18207,18208</if_sid>
-    <regex> ID:\s+%{S-1-5-13}</regex>
+    <regex> ID:\s+%{S-1-5-13}| ID:\s+S-1-5-13</regex>
     <description>Windows: Terminal Server Users Group Changed</description>
     <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,</group>
     <info>http://support.microsoft.com/kb/243330</info>
@@ -527,7 +527,7 @@
 
   <rule id="18222" level="12">
     <if_sid>18203,18204</if_sid>
-    <regex> ID:\s+%{S-1-5-21\S+-512}</regex>
+    <regex> ID:\s+%{S-1-5-21\S+-512}| ID:\s+S-1-5-21\S+-512</regex>
     <description>Windows: Domain Admins Group Changed</description>
     <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,</group>
     <info>http://support.microsoft.com/kb/243330</info>
@@ -535,22 +535,22 @@
 
   <rule id="18223" level="5">
     <if_sid>18203,18204</if_sid>
-    <regex> ID:\s+%{S-1-5-21\S+-513}</regex>
+    <regex> ID:\s+%{S-1-5-21\S+-513}| ID:\s+S-1-5-21\S+-513</regex>
     <description>Windows: Domain Users Group Changed</description>
     <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,</group>
     <info>http://support.microsoft.com/kb/243330</info>
   </rule>
 
-    <rule id="18224" level="0">
-      <if_sid>18223,18203</if_sid>
-      <match>Target Account Name: None</match>
-      <description>Windows: Local User Group NONE</description>
-      <info>Bogus group user added to upon creation</info>
-    </rule>
+  <rule id="18224" level="0">
+    <if_sid>18223,18203</if_sid>
+    <match>Target Account Name: None</match>
+    <description>Windows: Local User Group NONE</description>
+    <info>Bogus group user added to upon creation</info>
+  </rule>
 
   <rule id="18225" level="12">
     <if_sid>18203,18204</if_sid>
-    <regex> ID:\s+%{S-1-5-21\S+-514}</regex>
+    <regex> ID:\s+%{S-1-5-21\S+-514}| ID:\s+S-1-5-21\S+-514</regex>
     <description>Windows: Domain Guests Group Changed</description>
     <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,</group>
     <info>http://support.microsoft.com/kb/243330</info>
@@ -558,7 +558,7 @@
 
   <rule id="18226" level="5">
     <if_sid>18203,18204</if_sid>
-    <regex> ID:\s+%{S-1-5-21\S+-515}</regex>
+    <regex> ID:\s+%{S-1-5-21\S+-515}| ID:\s+S-1-5-21\S+-515</regex>
     <description>Windows: Domain Computers Group Changed</description>
     <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,</group>
     <info>http://support.microsoft.com/kb/243330</info>
@@ -566,7 +566,7 @@
 
   <rule id="18227" level="12">
     <if_sid>18203,18204</if_sid>
-    <regex> ID:\s+%{S-1-5-21\S+-516}</regex>
+    <regex> ID:\s+%{S-1-5-21\S+-516}| ID:\s+S-1-5-21\S+-516</regex>
     <description>Windows: Domain Controllers Group Changed</description>
     <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,</group>
     <info>http://support.microsoft.com/kb/243330</info>
@@ -574,7 +574,7 @@
 
   <rule id="18228" level="10">
     <if_sid>18207,18208</if_sid>
-    <regex> ID:\s+%{S-1-5-21\S+-517}</regex>
+    <regex> ID:\s+%{S-1-5-21\S+-517}| ID:\s+S-1-5-21\S+-517</regex>
     <description>Windows: Cert Publishers Group Changed</description>
     <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,</group>
     <info>http://support.microsoft.com/kb/243330</info>
@@ -582,7 +582,7 @@
 
   <rule id="18229" level="12">
     <if_sid>18203,18204</if_sid>
-    <regex> ID:\s+%{S-1-5-21\.+-518}</regex>
+    <regex> ID:\s+%{S-1-5-21\.+-518}| ID:\s+S-1-5-21\.+-518</regex>
     <description>Windows: Schema Admins Group Changed</description>
     <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,</group>
     <info>http://support.microsoft.com/kb/243330</info>
@@ -590,7 +590,7 @@
 
   <rule id="18230" level="12">
     <if_sid>18203,18204</if_sid>
-    <regex> ID:\s+%{S-1-5-21\S+-519}</regex>
+    <regex> ID:\s+%{S-1-5-21\S+-519}| ID:\s+S-1-5-21\S+-519</regex>
     <description>Windows: Enterprise Admins Group Changed</description>
     <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,</group>
     <info>http://support.microsoft.com/kb/243330</info>
@@ -598,7 +598,7 @@
 
   <rule id="18231" level="10">
     <if_sid>18203,18204</if_sid>
-    <regex> ID:\s+%{S-1-5-21\S+-520}</regex>
+    <regex> ID:\s+%{S-1-5-21\S+-520}| ID:\s+S-1-5-21\S+-520</regex>
     <description>Windows: Group Policy Creator Owners Group Changed</description>
     <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,</group>
     <info>http://support.microsoft.com/kb/243330</info>
@@ -606,7 +606,7 @@
 
   <rule id="18232" level="10">
     <if_sid>18207,18208</if_sid>
-    <regex>\w* ID:\s+%{S-1-5-21\S+-553}</regex>
+    <regex> ID:\s+%{S-1-5-21\S+-553}| ID:\s+S-1-5-21\S+-553</regex>
     <description>Windows: RAS and IAS Servers Group Changed</description>
     <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,</group>
     <info>http://support.microsoft.com/kb/243330</info>
@@ -614,7 +614,7 @@
 
   <rule id="18233" level="5">
     <if_sid>18207,18208</if_sid>
-    <regex> ID:\s+%{S-1-5-32-545}</regex>
+    <regex> ID:\s+%{S-1-5-32-545}| ID:\s+S-1-5-32-545</regex>
     <description>Windows: Users Group Changed</description>
     <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,</group>
     <info>http://support.microsoft.com/kb/243330</info>
@@ -622,7 +622,7 @@
 
   <rule id="18234" level="12">
     <if_sid>18207,18208</if_sid>
-    <regex> ID:\s+%{S-1-5-32-546}</regex>
+    <regex> ID:\s+%{S-1-5-32-546}| ID:\s+S-1-5-32-546</regex>
     <description>Windows: Guests Group Changed</description>
     <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,</group>
     <info>http://support.microsoft.com/kb/243330</info>
@@ -630,7 +630,7 @@
 
   <rule id="18235" level="10">
     <if_sid>18207,18208</if_sid>
-    <regex> ID:\s+%{S-1-5-32-547}</regex>
+    <regex> ID:\s+%{S-1-5-32-547}| ID:\s+S-1-5-32-547</regex>
     <description>Windows: Power Users Group Changed</description>
     <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,</group>
     <info>http://support.microsoft.com/kb/243330</info>
@@ -638,7 +638,7 @@
 
   <rule id="18236" level="10">
     <if_sid>18207,18208</if_sid>
-    <regex> ID:\s+%{S-1-5-32-548}</regex>
+    <regex> ID:\s+%{S-1-5-32-548}| ID:\s+S-1-5-32-548</regex>
     <description>Windows: Account Operators Group Changed</description>
     <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,</group>
     <info>http://support.microsoft.com/kb/243330</info>
@@ -646,7 +646,7 @@
 
   <rule id="18237" level="10">
     <if_sid>18207,18208</if_sid>
-    <regex> ID:\s+%{S-1-5-32-549}</regex>
+    <regex> ID:\s+%{S-1-5-32-549}| ID:\s+S-1-5-32-549</regex>
     <description>Windows: Server Operators Group Changed</description>
     <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,</group>
     <info>http://support.microsoft.com/kb/243330</info>
@@ -654,7 +654,7 @@
 
   <rule id="18238" level="8">
     <if_sid>18207,18208</if_sid>
-    <regex>\w* ID:\s+%{S-1-5-32-550}</regex>
+    <regex> ID:\s+%{S-1-5-32-550}| ID:\s+S-1-5-32-550</regex>
     <description>Windows: Print Operators Group Changed</description>
     <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,</group>
     <info>http://support.microsoft.com/kb/243330</info>
@@ -662,7 +662,7 @@
 
   <rule id="18239" level="12">
     <if_sid>18207,18208</if_sid>
-    <regex> ID:\s+%{S-1-5-32-551}</regex>
+    <regex> ID:\s+%{S-1-5-32-551}| ID:\s+S-1-5-32-551</regex>
     <description>Windows: Backup Operators Group Changed</description>
     <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,</group>
     <info>http://support.microsoft.com/kb/243330</info>
@@ -670,7 +670,7 @@
 
   <rule id="18240" level="10">
     <if_sid>18207,18208</if_sid>
-    <regex> ID:\s+%{S-1-5-32-552}</regex>
+    <regex> ID:\s+%{S-1-5-32-552}| ID:\s+S-1-5-32-552</regex>
     <description>Windows: Replicators Group Changed</description>
     <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,</group>
     <info>http://support.microsoft.com/kb/243330</info>
@@ -678,7 +678,7 @@
 
   <rule id="18241" level="8">
     <if_sid>18207,18208</if_sid>
-    <regex> ID:\s+%{S-1-5-32-554}</regex>
+    <regex> ID:\s+%{S-1-5-32-554}| ID:\s+S-1-5-32-554</regex>
     <description>Pre-Windows 2000 Compatible Access Group Changed</description>
     <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,</group>
     <info>http://support.microsoft.com/kb/243330</info>
@@ -686,7 +686,7 @@
 
   <rule id="18242" level="10">
     <if_sid>18207,18208</if_sid>
-    <regex> ID:\s+%{S-1-5-32-555}</regex>
+    <regex> ID:\s+%{S-1-5-32-555}| ID:\s+S-1-5-32-555</regex>
     <description>Windows: Remote Desktop Users Group Changed</description>
     <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,</group>
     <info>http://support.microsoft.com/kb/243330</info>
@@ -694,7 +694,7 @@
 
   <rule id="18243" level="10">
     <if_sid>18207,18208</if_sid>
-    <regex> ID:\s+%{S-1-5-32-556}</regex>
+    <regex> ID:\s+%{S-1-5-32-556}| ID:\s+S-1-5-32-556</regex>
     <description>Windows: Network Configuration Operators Group Changed</description>
     <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,</group>
     <info>http://support.microsoft.com/kb/243330</info>
@@ -702,7 +702,7 @@
 
   <rule id="18244" level="10">
     <if_sid>18207,18208</if_sid>
-    <regex> ID:\s+%{S-1-5-32-557}</regex>
+    <regex> ID:\s+%{S-1-5-32-557}| ID:\s+S-1-5-32-557</regex>
     <description>Windows: Incoming Forest Trust Builders Group Changed</description>
     <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,</group>
     <info>http://support.microsoft.com/kb/243330</info>
@@ -710,7 +710,7 @@
 
   <rule id="18245" level="8">
     <if_sid>18207,18208</if_sid>
-    <regex> ID:\s+%{S-1-5-32-558}</regex>
+    <regex> ID:\s+%{S-1-5-32-558}| ID:\s+S-1-5-32-558</regex>
     <description>Windows: Performance Monitor Users Group Changed</description>
     <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,</group>
     <info>http://support.microsoft.com/kb/243330</info>
@@ -718,7 +718,7 @@
 
   <rule id="18246" level="8">
     <if_sid>18207,18208</if_sid>
-    <regex> ID:\s+%{S-1-5-32-559}</regex>
+    <regex> ID:\s+%{S-1-5-32-559}| ID:\s+S-1-5-32-559</regex>
     <description>Windows: Performance Log Users Group Changed</description>
     <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,</group>
     <info>http://support.microsoft.com/kb/243330</info>
@@ -726,7 +726,7 @@
 
   <rule id="18247" level="8">
     <if_sid>18207,18208</if_sid>
-    <regex> ID:\s+%{S-1-5-32-560}</regex>
+    <regex> ID:\s+%{S-1-5-32-560}| ID:\s+S-1-5-32-560</regex>
     <description>Windows Authorization Access Group Changed</description>
     <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,</group>
     <info>http://support.microsoft.com/kb/243330</info>
@@ -734,7 +734,7 @@
 
   <rule id="18248" level="8">
     <if_sid>18207,18208</if_sid>
-    <regex> ID:\s+%{S-1-5-32-561}</regex>
+    <regex> ID:\s+%{S-1-5-32-561}| ID:\s+S-1-5-32-561</regex>
     <description>Windows: Terminal Server License Servers Group Changed</description>
     <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,</group>
     <info>http://support.microsoft.com/kb/243330</info>
@@ -742,7 +742,7 @@
 
   <rule id="18249" level="8">
     <if_sid>18207,18208</if_sid>
-    <regex> ID:\s+%{S-1-5-32-562}</regex>
+    <regex> ID:\s+%{S-1-5-32-562}| ID:\s+S-1-5-32-562</regex>
     <description>Windows: Distributed COM Users Group Changed</description>
     <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,</group>
     <info>http://support.microsoft.com/kb/243330</info>
@@ -750,7 +750,7 @@
 
   <rule id="18250" level="12">
     <if_sid>18207,18208</if_sid>
-    <regex> ID:\s+%{S-1-5-\s*21\.+\s*-498}</regex>
+    <regex> ID:\s+%{S-1-5-\s*21\.+\s*-498}| ID:\s+S-1-5-\s*21\.+\s*-498</regex>
     <description>Windows: Enterprise Read-only Domain Controllers Group Changed</description>
     <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,</group>
     <info>http://support.microsoft.com/kb/243330</info>
@@ -758,7 +758,7 @@
 
   <rule id="18251" level="12">
     <if_sid>18207,18208</if_sid>
-    <regex> ID:\s+%{S-1-5-\s*21\.+\s*-529}</regex>
+    <regex> ID:\s+%{S-1-5-\s*21\.+\s*-529}| ID:\s+S-1-5-\s*21\.+\s*-529</regex>
     <description>Windows: Read-only Domain Controllers Group Changed</description>
     <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,</group>
     <info>http://support.microsoft.com/kb/243330</info>
@@ -766,7 +766,7 @@
 
   <rule id="18252" level="12">
     <if_sid>18207,18208</if_sid>
-    <regex> ID:\s+%{S-1-5-32-569}</regex>
+    <regex> ID:\s+%{S-1-5-32-569}| ID:\s+S-1-5-32-569</regex>
     <description>Windows: Cryptographic Operators Group Changed</description>
     <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,</group>
     <info>http://support.microsoft.com/kb/243330</info>
@@ -774,7 +774,7 @@
 
   <rule id="18253" level="10">
     <if_sid>18207,18208</if_sid>
-    <regex> ID:\s+%{S-1-5-\s*21\.+\s*-571}</regex>
+    <regex> ID:\s+%{S-1-5-\s*21\.+\s*-571}| ID:\s+S-1-5-\s*21\.+\s*-571</regex>
     <description>Windows: Allowed RODC Password Replication Group Changed</description>
     <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,</group>
     <info>http://support.microsoft.com/kb/243330</info>
@@ -782,7 +782,7 @@
 
   <rule id="18254" level="10">
     <if_sid>18207,18208</if_sid>
-    <regex> ID:\s+%{S-1-5-\s*21\.+\s*-572}</regex>
+    <regex> ID:\s+%{S-1-5-\s*21\.+\s*-572}| ID:\s+S-1-5-\s*21\.+\s*-572</regex>
     <description>Windows: Denied RODC Password Replication Group Changed</description>
     <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,</group>
     <info>http://support.microsoft.com/kb/243330</info>
@@ -790,7 +790,7 @@
 
   <rule id="18255" level="10">
     <if_sid>18207,18208</if_sid>
-    <regex> ID:\s+%{S-1-5-32-573}</regex>
+    <regex> ID:\s+%{S-1-5-32-573}| ID:\s+S-1-5-32-573</regex>
     <description>Windows: Event Log Readers Group Changed</description>
     <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,</group>
     <info>http://support.microsoft.com/kb/243330</info>
@@ -798,7 +798,7 @@
 
   <rule id="18256" level="10">
     <if_sid>18207,18208</if_sid>
-    <regex> ID:\s+%{S-1-5-32-574}</regex>
+    <regex> ID:\s+%{S-1-5-32-574}| ID:\s+S-1-5-32-574</regex>
     <description>Windows: Certificate Service DCOM Access Group Changed</description>
     <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,</group>
     <info>http://support.microsoft.com/kb/243330</info>


### PR DESCRIPTION
SIDs in logs from Active Directory are not contained within curly brackets, nor are they prefixed with a %. Perhaps this is from old NT days. This is an example log:

2018 Mar 01 00:00:00 WinEvtLog: Security: AUDIT_SUCCESS(4728): Microsoft-Windows-Security-Auditing: (no user): no domain: domaincontroller.lan.local: A member was added to a security-enabled global group. Subject:  Security ID:  S-1-5-21-0000000000-0000000000-000000000-00012  Account Name:  admin_account  Account Domain:  LAN  Logon ID:  0x11cc0174  Member:  Security ID:  S-1-5-21-0000000000-000000000-000000000-00675  Account Name:  CN=added_account,OU=lan,DC=lan,DC=local  Group:  Security ID:  S-1-5-21-0000000000-0000000000-000000000-512  Group Name:  Domain Admins  Group Domain:  LAN  Additional Information:  Privileges:  -

Retaining old syntax and added fixed syntax as an OR regex.