### PR TITLE
Revision pci groups

### DIFF
--- a/rules/0015-ossec_rules.xml
+++ b/rules/0015-ossec_rules.xml
@@ -19,7 +19,7 @@
     <options>alert_by_email</options>
     <match>Agent started</match>
     <description>New ossec agent connected.</description>
-    <group>pci_dss_10.6.1,gpg13_10.1,</group>
+    <group>pci_dss_10.6.1,gpg13_10.1,gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="502" level="3">
@@ -27,7 +27,7 @@
     <options>alert_by_email</options>
     <match>Ossec started</match>
     <description>Ossec server started.</description>
-    <group>pci_dss_10.6.1,gpg13_10.1,</group>
+    <group>pci_dss_10.6.1,gpg13_10.1,gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="503" level="3">
@@ -35,7 +35,7 @@
     <options>alert_by_email</options>
     <match>Agent started</match>
     <description>Ossec agent started.</description>
-    <group>pci_dss_10.6.1,pci_dss_10.2.6,gpg13_10.1,</group>
+    <group>pci_dss_10.6.1,pci_dss_10.2.6,gpg13_10.1,gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="504" level="3">
@@ -43,7 +43,7 @@
     <options>alert_by_email</options>
     <match>Agent disconnected</match>
     <description>Ossec agent disconnected.</description>
-    <group>pci_dss_10.6.1,pci_dss_10.2.6,gpg13_10.1,</group>
+    <group>pci_dss_10.6.1,pci_dss_10.2.6,gpg13_10.1,gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="509" level="0">
@@ -56,7 +56,7 @@
   <rule id="510" level="7">
     <if_sid>509</if_sid>
     <description>Host-based anomaly detection event (rootcheck).</description>
-    <group>rootcheck,</group>
+    <group>rootcheck,gdpr_IV_35.7.d,</group>
    <!-- <if_fts />  -->
   </rule>
 
@@ -80,7 +80,7 @@
     <if_sid>510</if_sid>
     <match>^Windows Malware</match>
     <description>Windows malware detected.</description>
-    <group>rootcheck,gpg13_4.2,</group>
+    <group>rootcheck,gpg13_4.2,gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="514" level="2">
@@ -97,35 +97,35 @@
     <match>^Starting OpenSCAP scan|^Ending OpenSCAP scan.|</match>
     <match>^Starting CIS-CAT scan|^Ending CIS-CAT scan.</match>
     <description>Ignoring scan messages.</description>
-    <group>rootcheck,syscheck,pci_dss_10.6.1,</group>
+    <group>rootcheck,syscheck,pci_dss_10.6.1,gdpr_IV_35.7.d,gdpr_IV_30.1.g,</group>
   </rule>
 
   <rule id="516" level="3">
     <if_sid>510</if_sid>
     <match>^System Audit</match>
     <description>System Audit event.</description>
-    <group>rootcheck,</group>
+    <group>rootcheck,gdpr_IV_30.1.g,</group>
   </rule>
 
   <rule id="518" level="9">
     <if_sid>514</if_sid>
     <match>Adware|Spyware</match>
     <description>Windows Adware/Spyware application found.</description>
-    <group>rootcheck,gpg13_4.2,</group>
+    <group>rootcheck,gpg13_4.2,gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="519" level="7">
     <if_sid>516</if_sid>
     <match>^System Audit: Web vulnerability</match>
     <description>System Audit: Vulnerable web application found.</description>
-    <group>rootcheck,</group>
+    <group>rootcheck,gdpr_IV_35.7.d,gdpr_IV_30.1.g,</group>
   </rule>
 
   <rule id="520" level="3">
     <if_sid>500</if_sid>
     <match>Duplicated IP</match>
     <description>Trying to add an agent with duplicated IP.</description>
-    <group>pci_dss_10.6.1,gpg13_10.1,</group>
+    <group>pci_dss_10.6.1,gpg13_10.1,gdpr_IV_35.7.d,</group>
   </rule>
 
 
@@ -142,7 +142,7 @@
     <match>ossec: output: 'df -P': /dev/</match>
     <regex>100%</regex>
     <description>Partition usage reached 100% (disk space monitor).</description>
-    <group>low_diskspace,pci_dss_10.6.1,gpg13_10.1,</group>
+    <group>low_diskspace,pci_dss_10.6.1,gpg13_10.1,gdpr_IV_35.7.d,</group>
   </rule>
 
  <rule id="532" level="0">
@@ -156,7 +156,7 @@
     <match>ossec: output: 'netstat listening ports</match>
     <check_diff />
     <description>Listened ports status (netstat) changed (new port opened or closed).</description>
-    <group>pci_dss_10.2.7,pci_dss_10.6.1,gpg13_10.1,</group>
+    <group>pci_dss_10.2.7,pci_dss_10.6.1,gpg13_10.1,gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="534" level="1">
@@ -179,42 +179,42 @@
     <category>ossec</category>
     <decoded_as>syscheck_integrity_changed</decoded_as>
     <description>Integrity checksum changed.</description>
-    <group>syscheck,pci_dss_11.5,gpg13_4.11,</group>
+    <group>syscheck,pci_dss_11.5,gpg13_4.11,gdpr_II_5.1.f,</group>
   </rule>
 
   <rule id="551" level="7">
     <category>ossec</category>
     <decoded_as>syscheck_integrity_changed_2nd</decoded_as>
     <description>Integrity checksum changed again (2nd time).</description>
-    <group>syscheck,pci_dss_11.5,gpg13_4.11,</group>
+    <group>syscheck,pci_dss_11.5,gpg13_4.11,gdpr_II_5.1.f,</group>
   </rule>
 
   <rule id="552" level="7">
     <category>ossec</category>
     <decoded_as>syscheck_integrity_changed_3rd</decoded_as>
     <description>Integrity checksum changed again (3rd time).</description>
-    <group>syscheck,pci_dss_11.5,gpg13_4.11,</group>
+    <group>syscheck,pci_dss_11.5,gpg13_4.11,gdpr_II_5.1.f,</group>
   </rule>
 
   <rule id="553" level="7">
     <category>ossec</category>
     <decoded_as>syscheck_deleted</decoded_as>
     <description>File deleted. Unable to retrieve checksum.</description>
-    <group>syscheck,pci_dss_11.5,gpg13_4.11,</group>
+    <group>syscheck,pci_dss_11.5,gpg13_4.11,gdpr_II_5.1.f,</group>
   </rule>
 
   <rule id="554" level="5">
     <category>ossec</category>
     <decoded_as>syscheck_new_entry</decoded_as>
     <description>File added to the system.</description>
-    <group>syscheck,pci_dss_11.5,gpg13_4.11,</group>
+    <group>syscheck,pci_dss_11.5,gpg13_4.11,gdpr_II_5.1.f,</group>
   </rule>
 
   <rule id="555" level="7">
     <if_sid>500</if_sid>
     <match>^ossec: agentless: </match>
     <description>Integrity checksum for agentless device changed.</description>
-    <group>syscheck,agentless,pci_dss_11.5,pci_dss_10.6.1,gpg13_4.11,</group>
+    <group>syscheck,agentless,pci_dss_11.5,pci_dss_10.6.1,gpg13_4.11,gdpr_II_5.1.f,gdpr_IV_35.7.d,</group>
   </rule>
 
   <!-- Hostinfo rules -->
@@ -222,7 +222,7 @@
     <category>ossec</category>
     <decoded_as>hostinfo_modified</decoded_as>
     <description>Host information changed.</description>
-    <group>hostinfo,pci_dss_10.2.7,gpg13_4.13,</group>
+    <group>hostinfo,pci_dss_10.2.7,gpg13_4.13,gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="581" level="8">
@@ -238,28 +238,28 @@
     <if_sid>500</if_sid>
     <match>^ossec: File rotated </match>
     <description>Log file rotated.</description>
-    <group>pci_dss_10.5.2,pci_dss_10.5.5,gpg13_10.1,</group>
+    <group>pci_dss_10.5.2,pci_dss_10.5.5,gpg13_10.1,gdpr_II_5.1.f,gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="592" level="8">
     <if_sid>500</if_sid>
     <match>^ossec: File size reduced</match>
     <description>Log file size reduced.</description>
-    <group>attacks,pci_dss_10.5.2,pci_dss_11.4,gpg13_10.1,</group>
+    <group>attacks,pci_dss_10.5.2,pci_dss_11.4,gpg13_10.1,gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="593" level="9">
     <if_sid>500</if_sid>
     <match>^ossec: Event log cleared</match>
     <description>Microsoft Event log cleared.</description>
-    <group>logs_cleared,pci_dss_10.5.2,gpg13_10.1,</group>
+    <group>logs_cleared,pci_dss_10.5.2,gpg13_10.1,gdpr_II_5.1.f,gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="594" level="5">
     <category>ossec</category>
     <if_sid>550</if_sid>
     <hostname>syscheck-registry</hostname>
-    <group>syscheck,pci_dss_11.5,gpg13_4.13,</group>
+    <group>syscheck,pci_dss_11.5,gpg13_4.13,gdpr_II_5.1.f,</group>
     <description>Registry Integrity Checksum Changed</description>
   </rule>
 
@@ -267,7 +267,7 @@
     <category>ossec</category>
     <if_sid>551</if_sid>
     <hostname>syscheck-registry</hostname>
-    <group>syscheck,pci_dss_11.5,gpg13_4.13,</group>
+    <group>syscheck,pci_dss_11.5,gpg13_4.13,gdpr_II_5.1.f,</group>
     <description>Registry Integrity Checksum Changed Again (2nd time)</description>
   </rule>
 
@@ -275,7 +275,7 @@
     <category>ossec</category>
     <if_sid>552</if_sid>
     <hostname>syscheck-registry</hostname>
-    <group>syscheck,pci_dss_11.5,gpg13_4.13,</group>
+    <group>syscheck,pci_dss_11.5,gpg13_4.13,gdpr_II_5.1.f,</group>
     <description>Registry Integrity Checksum Changed Again (3rd time)</description>
   </rule>
 
@@ -283,7 +283,7 @@
     <category>ossec</category>
     <if_sid>553</if_sid>
     <hostname>syscheck-registry</hostname>
-    <group>syscheck,pci_dss_11.5,gpg13_4.13,</group>
+    <group>syscheck,pci_dss_11.5,gpg13_4.13,gdpr_II_5.1.f,</group>
     <description>Registry Entry Deleted. Unable to Retrieve Checksum</description>
   </rule>
 
@@ -291,7 +291,7 @@
     <category>ossec</category>
     <if_sid>554</if_sid>
     <hostname>syscheck-registry</hostname>
-    <group>syscheck,pci_dss_11.5,gpg13_4.13,</group>
+    <group>syscheck,pci_dss_11.5,gpg13_4.13,gdpr_II_5.1.f,</group>
     <description>Registry Entry Added to the System</description>
   </rule>
 
@@ -311,7 +311,7 @@
     <field name="script">firewall-drop.sh</field>
     <field name="type">add</field>
     <description>Host Blocked by firewall-drop.sh Active Response</description>
-    <group>active_response,pci_dss_11.4,gpg13_4.13,</group>
+    <group>active_response,pci_dss_11.4,gpg13_4.13,gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="602" level="3">
@@ -319,7 +319,7 @@
     <field name="script">firewall-drop.sh</field>
     <field name="type">delete</field>
     <description>Host Unblocked by firewall-drop.sh Active Response</description>
-    <group>active_response,pci_dss_11.4,gpg13_4.13,</group>
+    <group>active_response,pci_dss_11.4,gpg13_4.13,gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="603" level="3">
@@ -327,7 +327,7 @@
     <field name="script">host-deny.sh</field>
     <field name="type">add</field>
     <description>Host Blocked by host-deny.sh Active Response</description>
-    <group>active_response,pci_dss_11.4,gpg13_4.13,</group>
+    <group>active_response,pci_dss_11.4,gpg13_4.13,gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="604" level="3">
@@ -335,7 +335,7 @@
     <field name="script">host-deny.sh</field>
     <field name="type">delete</field>
     <description>Host Unblocked by host-deny.sh Active Response</description>
-    <group>active_response,pci_dss_11.4,gpg13_4.13,</group>
+    <group>active_response,pci_dss_11.4,gpg13_4.13,gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="605" level="3">
@@ -343,7 +343,7 @@
     <field name="script">route-null</field>
     <field name="type">add</field>
     <description>Host Blocked by $(script) Active Response</description>
-    <group>active_response,pci_dss_11.4,gpg13_4.13,</group>
+    <group>active_response,pci_dss_11.4,gpg13_4.13,gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="606" level="3">
@@ -351,13 +351,13 @@
     <field name="script">route-null</field>
     <field name="type">delete</field>
     <description>Host Unblocked by $(script) Active Response</description>
-    <group>active_response,pci_dss_11.4,gpg13_4.13,</group>
+    <group>active_response,pci_dss_11.4,gpg13_4.13,gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="607" level="3">
     <if_sid>600</if_sid>
     <description>Active response: $(script) - $(type)</description>
-    <group>active_response,pci_dss_11.4,</group>
+    <group>active_response,pci_dss_11.4,gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="700" level="0">

--- a/rules/0015-ossec_rules.xml
+++ b/rules/0015-ossec_rules.xml
@@ -56,7 +56,7 @@
   <rule id="510" level="7">
     <if_sid>509</if_sid>
     <description>Host-based anomaly detection event (rootcheck).</description>
-    <group>rootcheck,gdpr_IV_35.7.d,</group>
+    <group>rootcheck,pci_dss_10.6.1,gdpr_IV_35.7.d,</group>
    <!-- <if_fts />  -->
   </rule>
 
@@ -80,7 +80,7 @@
     <if_sid>510</if_sid>
     <match>^Windows Malware</match>
     <description>Windows malware detected.</description>
-    <group>rootcheck,gpg13_4.2,gdpr_IV_35.7.d,</group>
+    <group>rootcheck,pci_dss_10.6.1,gpg13_4.2,gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="514" level="2">
@@ -111,14 +111,14 @@
     <if_sid>514</if_sid>
     <match>Adware|Spyware</match>
     <description>Windows Adware/Spyware application found.</description>
-    <group>rootcheck,gpg13_4.2,gdpr_IV_35.7.d,</group>
+    <group>rootcheck,pci_dss_10.6.1,gpg13_4.2,gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="519" level="7">
     <if_sid>516</if_sid>
     <match>^System Audit: Web vulnerability</match>
     <description>System Audit: Vulnerable web application found.</description>
-    <group>rootcheck,gdpr_IV_35.7.d,gdpr_IV_30.1.g,</group>
+    <group>rootcheck,pci_dss_10.6.1,gdpr_IV_35.7.d,gdpr_IV_30.1.g,</group>
   </rule>
 
   <rule id="520" level="3">

--- a/rules/0016-wazuh_rules.xml
+++ b/rules/0016-wazuh_rules.xml
@@ -22,21 +22,21 @@
     <if_sid>201</if_sid>
     <field name="level">%</field>
     <description>Agent event queue is $(level) full.</description>
-    <group>agent_flooding,</group>
+    <group>agent_flooding,gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="203" level="9">
     <if_sid>201</if_sid>
     <field name="level">full</field>
     <description>Agent event queue is full. Events may be lost.</description>
-    <group>agent_flooding,</group>
+    <group>agent_flooding,gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="204" level="12">
     <if_sid>201</if_sid>
     <field name="level">flooded</field>
     <description>Agent event queue is flooded. Check the agent configuration.</description>
-    <group>agent_flooding,</group>
+    <group>agent_flooding,gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="205" level="3">

--- a/rules/0016-wazuh_rules.xml
+++ b/rules/0016-wazuh_rules.xml
@@ -22,21 +22,21 @@
     <if_sid>201</if_sid>
     <field name="level">%</field>
     <description>Agent event queue is $(level) full.</description>
-    <group>agent_flooding,gdpr_IV_35.7.d,</group>
+    <group>agent_flooding,pci_dss_10.6.1,gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="203" level="9">
     <if_sid>201</if_sid>
     <field name="level">full</field>
     <description>Agent event queue is full. Events may be lost.</description>
-    <group>agent_flooding,gdpr_IV_35.7.d,</group>
+    <group>agent_flooding,pci_dss_10.6.1,gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="204" level="12">
     <if_sid>201</if_sid>
     <field name="level">flooded</field>
     <description>Agent event queue is flooded. Check the agent configuration.</description>
-    <group>agent_flooding,gdpr_IV_35.7.d,</group>
+    <group>agent_flooding,pci_dss_10.6.1,gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="205" level="3">

--- a/rules/0020-syslog_rules.xml
+++ b/rules/0020-syslog_rules.xml
@@ -18,7 +18,7 @@
   <rule id="1001" level="2">
     <match>^Couldn't open /etc/securetty</match>
     <description>File missing. Root access unrestricted.</description>
-    <group>pci_dss_10.2.4,gpg13_4.1,</group>
+    <group>pci_dss_10.2.4,gpg13_4.1,gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="1002" level="2">
@@ -35,32 +35,32 @@
   <rule id="1004" level="5">
     <match>^exiting on signal</match>
     <description>Syslogd exiting (logging stopped).</description>
-    <group>pci_dss_10.6.1,gpg13_10.1,gpg13_4.14,</group>
+    <group>pci_dss_10.6.1,gpg13_10.1,gpg13_4.14,gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="1005" level="5">
     <program_name>syslogd</program_name>
     <match>^restart</match>
     <description>Syslogd restarted.</description>
-    <group>pci_dss_10.6.1,gpg13_10.1,gpg13_4.14,</group>
+    <group>pci_dss_10.6.1,gpg13_10.1,gpg13_4.14,gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="1006" level="5">
     <regex>^syslogd \S+ restart</regex>
     <description>Syslogd restarted.</description>
-    <group>pci_dss_10.6.1,gpg13_10.1,gpg13_4.14,</group>
+    <group>pci_dss_10.6.1,gpg13_10.1,gpg13_4.14,gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="1007" level="7">
     <match>file system full|No space left on device</match>
     <description>File system full.</description>
-    <group>low_diskspace,pci_dss_10.6.1,gpg13_4.1,</group>
+    <group>low_diskspace,pci_dss_10.6.1,gpg13_4.1,gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="1008" level="5">
     <match>killed by SIGTERM</match>
     <description>Process exiting (killed).</description>
-    <group>service_availability,pci_dss_10.6.1,gpg13_4.3,gpg13_4.14,</group>
+    <group>service_availability,pci_dss_10.6.1,gpg13_4.3,gpg13_4.14,gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="1009" level="0">
@@ -73,7 +73,7 @@
   <rule id="1010" level="5">
     <match>segfault at </match>
     <description>Process segfaulted.</description>
-    <group>service_availability,</group>
+    <group>service_availability,gdpr_IV_35.7.d,</group>
   </rule>
 
 </group> <!-- SYSLOG,ERRORS -->
@@ -119,7 +119,7 @@
   <rule id="2301" level="10">
     <match>^Deactivating service </match>
     <description>xinetd: Excessive number connections to a service.</description>
-    <group>pci_dss_10.6.1,</group>
+    <group>pci_dss_10.6.1,gdpr_IV_35.7.d,</group>
   </rule>
 </group> <!-- SYSLOG,XINETD -->
 
@@ -134,14 +134,14 @@
     <match>authinternal failed|Failed to authorize|</match>
     <match>Wrong password given for|login failed|Auth: Login incorrect|</match>
     <match>Failed to authenticate user</match>
-    <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.8,</group>
+    <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.8,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
     <description>syslog: User authentication failure.</description>
   </rule>
 
   <rule id="2502" level="10">
     <match>more authentication failures;|REPEATED login failures</match>
     <description>syslog: User missed the password more than one time</description>
-    <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.8,</group>
+    <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.8,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
   </rule>
 
   <rule id="2503" level="5">
@@ -149,25 +149,25 @@
     <regex>^libwrap refused connection|</regex>
     <regex>Connection from \S+ denied</regex>
     <description>syslog: Connection blocked by Tcp Wrappers.</description>
-    <group>access_denied,pci_dss_10.2.4,</group>
+    <group>access_denied,pci_dss_10.2.4,gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="2504" level="9">
     <match>ILLEGAL ROOT LOGIN|ROOT LOGIN REFUSED</match>
     <description>syslog: Illegal root login. </description>
-    <group>invalid_login,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_10.2.2,gpg13_7.8,</group>
+    <group>invalid_login,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_10.2.2,gpg13_7.8,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
   </rule>
 
   <rule id="2505" level="3">
     <match>^ROOT LOGIN  on</match>
     <description>syslog: Physical root login.</description>
-    <group>pci_dss_10.2.2,gpg13_7.8,</group>
+    <group>pci_dss_10.2.2,gpg13_7.8,gdpr_IV_32.2,</group>
   </rule>
 
   <rule id="2506" level="3">
     <match>^Authentication passed</match>
     <description>syslog: Pop3 Authentication passed.</description>
-    <group>pci_dss_10.2.5,gpg13_7.1,</group>
+    <group>pci_dss_10.2.5,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
   </rule>
 
   <rule id="2507" level="0">
@@ -179,6 +179,7 @@
     <if_sid>2507</if_sid>
     <match>ACCEPT from</match>
     <description>OpenLDAP connection open.</description>
+    <group>gdpr_IV_32.2,</group>
   </rule>
 
   <rule id="2509" level="5" timeframe="10" frequency="0">
@@ -187,7 +188,7 @@
     <same_id />
     <match>RESULT tag=97 err=49</match>
     <description>OpenLDAP authentication failed.</description>
-    <group>pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,</group>
+    <group>pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
   </rule>
 
 </group> <!-- SYSLOG,ACESSCONTROL -->
@@ -205,7 +206,7 @@
     <if_sid>2550</if_sid>
     <regex>^Connection from \S+ on illegal port$</regex>
     <description>Connection to rshd from unprivileged port. Possible network scan.</description>
-    <group>connection_attempt,pci_dss_10.6.1,gpg13_7.1,</group>
+    <group>connection_attempt,pci_dss_10.6.1,gpg13_7.1,gdpr_IV_35.7.d,</group>
   </rule>
 </group>
 
@@ -273,6 +274,7 @@
     <match>Oversized packet received from</match>
     <description>Error message from the kernel. </description>
     <description>Ping of death attack.</description>
+    <group>gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="5104" level="8">
@@ -280,7 +282,7 @@
     <regex>Promiscuous mode enabled|</regex>
     <regex>device \S+ entered promiscuous mode</regex>
     <description>Interface entered in promiscuous(sniffing) mode.</description>
-    <group>promisc,pci_dss_10.6.1,pci_dss_11.4,gpg13_4.13,</group>
+    <group>promisc,pci_dss_10.6.1,pci_dss_11.4,gpg13_4.13,gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="5105" level="0">
@@ -307,7 +309,7 @@
     <match>Out of Memory: </match>
     <description>System running out of memory. </description>
     <description>Availability of the system is in risk.</description>
-    <group>service_availability,pci_dss_10.6.1,gpg13_4.12,</group>
+    <group>service_availability,pci_dss_10.6.1,gpg13_4.12,gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="5109" level="4">
@@ -337,7 +339,7 @@
   <rule id="5113" level="7">
     <if_sid>5100</if_sid>
     <match>Kernel log daemon terminating</match>
-    <group>system_shutdown,pci_dss_10.6.1,gpg13_4.14,</group>
+    <group>system_shutdown,pci_dss_10.6.1,gpg13_4.14,gdpr_IV_35.7.d,</group>
     <description>System is shutting down.</description>
   </rule>
 
@@ -384,14 +386,14 @@
     <if_sid>2830</if_sid>
     <match>REPLACE</match>
     <description>Crontab entry changed.</description>
-    <group>pci_dss_10.2.7,pci_dss_10.6.1,gpg13_4.13,</group>
+    <group>pci_dss_10.2.7,pci_dss_10.6.1,gpg13_4.13,gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="2833" level="8">
     <if_sid>2832</if_sid>
     <match>^(root)</match>
     <description>Root's crontab entry changed.</description>
-    <group>pci_dss_10.2.7,pci_dss_10.6.1,pci_dss_10.2.2,gpg13_4.13,</group>
+    <group>pci_dss_10.2.7,pci_dss_10.6.1,pci_dss_10.2.2,gpg13_4.13,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
   </rule>
 
 </group> <!-- SYSLOG,CRON -->
@@ -409,14 +411,14 @@
    <if_sid>5300</if_sid>
    <match>authentication failure; |failed|BAD su|^-</match>
    <description>User missed the password to change UID (user id).</description>
-   <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.8,</group>
+   <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.8,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
   </rule>
 
   <rule id="5302" level="9">
     <if_sid>5301</if_sid>
     <user>^root</user>
     <description>User missed the password to change UID to root.</description>
-    <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.8,</group>
+    <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.8,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
   </rule>
 
   <rule id="5303" level="3">
@@ -424,7 +426,7 @@
     <regex>session opened for user root|^'su root'|</regex>
     <regex>^+ \S+ \S+\proot$|^\S+ to root on|^SU \S+ \S+ + \S+ \S+-root$</regex>
     <description>User successfully changed UID to root.</description>
-    <group>authentication_success,pci_dss_10.2.5,gpg13_7.6,gpg13_7.8,gpg13_7.9</group>
+    <group>authentication_success,pci_dss_10.2.5,gpg13_7.6,gpg13_7.8,gpg13_7.9,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
   </rule>
 
   <rule id="5304" level="3">
@@ -432,7 +434,7 @@
     <regex>session opened for user|succeeded for|</regex>
     <regex>^+|^\S+ to |^SU \S+ \S+ + </regex>
     <description>User successfully changed UID.</description>
-    <group>authentication_success,pci_dss_10.2.5,gpg13_7.6,gpg13_7.8</group>
+    <group>authentication_success,pci_dss_10.2.5,gpg13_7.6,gpg13_7.8,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
   </rule>
 
   <rule id="5305" level="4">
@@ -458,7 +460,7 @@
   <rule id="7101" level="8">
     <match>Integrity Check failed: File could not</match>
     <description>Problems with the tripwire checking</description>
-    <group>pci_dss_10.5.5,pci_dss_10.6.1,</group>
+    <group>pci_dss_10.5.5,pci_dss_10.6.1,gdpr_II_5.1.f,gdpr_IV_35.7.d,</group>
   </rule>
 </group> <!-- SYSLOG,TRIPWIRE -->
 
@@ -469,25 +471,25 @@
   <rule id="5901" level="8">
     <match>^new group</match>
     <description>New group added to the system</description>
-    <group>pci_dss_10.2.7,pci_dss_10.2.5,pci_dss_8.1.2,gpg13_4.13,</group>
+    <group>pci_dss_10.2.7,pci_dss_10.2.5,pci_dss_8.1.2,gpg13_4.13,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
   </rule>
 
   <rule id="5902" level="8">
     <match>^new user|^new account added</match>
     <description>New user added to the system</description>
-    <group>pci_dss_10.2.7,pci_dss_10.2.5,pci_dss_8.1.2,gpg13_4.13,</group>
+    <group>pci_dss_10.2.7,pci_dss_10.2.5,pci_dss_8.1.2,gpg13_4.13,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
   </rule>
 
   <rule id="5903" level="3">
     <match>^delete user|^account deleted|^remove group</match>
     <description>Group (or user) deleted from the system</description>
-    <group>pci_dss_10.2.7,pci_dss_10.2.5,pci_dss_8.1.2,gpg13_4.13,</group>
+    <group>pci_dss_10.2.7,pci_dss_10.2.5,pci_dss_8.1.2,gpg13_4.13,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
   </rule>
 
   <rule id="5904" level="8">
     <match>^changed user</match>
     <description>Information from the user was changed</description>
-    <group>pci_dss_10.2.7,pci_dss_10.2.5,pci_dss_8.1.2,gpg13_4.13,</group>
+    <group>pci_dss_10.2.7,pci_dss_10.2.5,pci_dss_8.1.2,gpg13_4.13,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
   </rule>
 
   <rule id="5905" level="0">
@@ -510,14 +512,14 @@
     <if_sid>5400</if_sid>
     <match>incorrect password attempt</match>
     <description>Failed attempt to run sudo</description>
-    <group>pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.8</group>
+    <group>pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.8,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
   </rule>
 
   <rule id="5402" level="3">
     <if_sid>5400</if_sid>
     <regex> ; USER=root ; COMMAND=| ; USER=root ; TSID=\S+ ; COMMAND=</regex>
     <description>Successful sudo to ROOT executed</description>
-    <group>pci_dss_10.2.5,pci_dss_10.2.2,gpg13_7.6,gpg13_7.8,gpg13_7.13,</group>
+    <group>pci_dss_10.2.5,pci_dss_10.2.2,gpg13_7.6,gpg13_7.8,gpg13_7.13,gdpr_IV_32.2,</group>
   </rule>
 
   <rule id="5403" level="4">
@@ -531,21 +533,21 @@
     <if_sid>5401</if_sid>
     <match>3 incorrect password attempts</match>
     <description>Three failed attempts to run sudo</description>
-    <group>pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.8,</group>
+    <group>pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.8,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
   </rule>
 
   <rule id="5405" level="5">
     <if_sid>5400</if_sid>
     <match>user NOT in sudoers</match>
     <description>Unauthorized user attempted to use sudo.</description>
-    <group>pci_dss_10.2.2,pci_dss_10.2.5,gpg13_7.8,</group>
+    <group>pci_dss_10.2.2,pci_dss_10.2.5,gpg13_7.8,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
   </rule>
 
   <rule id="5406" level="5">
     <if_sid>5400</if_sid>
     <match>command not allowed</match>
     <description>Sudo: Command not allowed</description>
-    <group>pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.8,</group>
+    <group>pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.8,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
   </rule>
 
 </group> <!-- SYSLOG, SUDO -->
@@ -612,14 +614,14 @@
     <if_sid>2900</if_sid>
     <regex>^\d\d\d\d-\d\d-\d\d \d\d:\d\d:\d\d install</regex>
     <description>New dpkg (Debian Package) requested to install.</description>
-    <group>pci_dss_10.6.1,gpg13_4.10,</group>
+    <group>pci_dss_10.6.1,gpg13_4.10,gdpr_IV_35.7.d,</group>
   </rule>
 
  <rule id="2902" level="7">
     <if_sid>2900</if_sid>
     <regex>^\d\d\d\d-\d\d-\d\d \d\d:\d\d:\d\d status installed</regex>
     <description>New dpkg (Debian Package) installed.</description>
-    <group>config_changed,pci_dss_10.6.1,pci_dss_10.2.7,gpg13_4.10,</group>
+    <group>config_changed,pci_dss_10.6.1,pci_dss_10.2.7,gpg13_4.10,gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="2903" level="7">
@@ -627,7 +629,7 @@
     <regex>^\d\d\d\d-\d\d-\d\d \d\d:\d\d:\d\d remove|</regex>
     <regex>^\d\d\d\d-\d\d-\d\d \d\d:\d\d:\d\d purge</regex>
     <description>Dpkg (Debian Package) removed.</description>
-    <group>config_changed,pci_dss_10.6.1,pci_dss_10.2.7,gpg13_4.10,</group>
+    <group>config_changed,pci_dss_10.6.1,pci_dss_10.2.7,gpg13_4.10,gdpr_IV_35.7.d,</group>
   </rule>
 </group>
 
@@ -647,21 +649,21 @@
   <rule id="2932" level="7">
     <if_sid>2930,2931</if_sid>
     <match>^Installed</match>
-    <group>config_changed,pci_dss_10.6.1,pci_dss_10.2.7,gpg13_4.10,</group>
+    <group>config_changed,pci_dss_10.6.1,pci_dss_10.2.7,gpg13_4.10,gdpr_IV_35.7.d,</group>
     <description>New Yum package installed.</description>
   </rule>
 
   <rule id="2933" level="7">
     <if_sid>2930,2931</if_sid>
     <match>^Updated</match>
-    <group>config_changed,pci_dss_10.6.1,pci_dss_10.2.7,gpg13_4.10,</group>
+    <group>config_changed,pci_dss_10.6.1,pci_dss_10.2.7,gpg13_4.10,gdpr_IV_35.7.d,</group>
     <description>Yum package updated.</description>
   </rule>
 
   <rule id="2934" level="7">
     <if_sid>2930,2931</if_sid>
     <match>^Erased</match>
-    <group>config_changed,pci_dss_10.6.1,pci_dss_10.2.7,gpg13_4.10,</group>
+    <group>config_changed,pci_dss_10.6.1,pci_dss_10.2.7,gpg13_4.10,gdpr_IV_35.7.d,</group>
     <description>Yum package deleted.</description>
   </rule>
 
@@ -682,21 +684,21 @@
     <if_sid>2935</if_sid>
     <status>FAILED</status>
     <description>Possible Disk failure. SCSI controller error.</description>
-    <group>pci_dss_10.6.1,gpg13_4.3,</group>
+    <group>pci_dss_10.6.1,gpg13_4.3,gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="2938" level="12">
     <if_sid>2936</if_sid>
     <action>failed</action>
     <description>SCSI RAID ARRAY ERROR, drive failed.</description>
-    <group>pci_dss_10.6.1,gpg13_4.3,</group>
+    <group>pci_dss_10.6.1,gpg13_4.3,gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="2939" level="12">
     <if_sid>2936</if_sid>
     <action>degraded</action>
     <description>SCSI RAID is now in a degraded status.</description>
-    <group>pci_dss_10.6.1,gpg13_4.3,</group>
+    <group>pci_dss_10.6.1,gpg13_4.3,gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="2940" level="0">
@@ -738,14 +740,14 @@
     <decoded_as>gpasswd</decoded_as>
     <match>added by</match>
     <description>User added to group.</description>
-    <group>gpg13_7.9,gpg13_4.13,</group>
+    <group>gpg13_7.9,gpg13_4.13,gdpr_IV_32.2,</group>
   </rule>
 
   <rule id="2961" level="5">
     <if_sid>2960</if_sid>
     <field name="group">sudo</field>
     <description>User added to group sudo.</description>
-    <group>gpg13_7.9,gpg13_4.13,</group>
+    <group>gpg13_7.9,gpg13_4.13,gdpr_IV_32.2,</group>
   </rule>
 
 </group>

--- a/rules/0020-syslog_rules.xml
+++ b/rules/0020-syslog_rules.xml
@@ -179,7 +179,7 @@
     <if_sid>2507</if_sid>
     <match>ACCEPT from</match>
     <description>OpenLDAP connection open.</description>
-    <group>gdpr_IV_32.2,</group>
+    <group>pci_dss_10.2.5,gdpr_IV_32.2,</group>
   </rule>
 
   <rule id="2509" level="5" timeframe="10" frequency="0">
@@ -740,14 +740,14 @@
     <decoded_as>gpasswd</decoded_as>
     <match>added by</match>
     <description>User added to group.</description>
-    <group>gpg13_7.9,gpg13_4.13,gdpr_IV_32.2,</group>
+    <group>pci_dss_10.2.5,gpg13_7.9,gpg13_4.13,gdpr_IV_32.2,</group>
   </rule>
 
   <rule id="2961" level="5">
     <if_sid>2960</if_sid>
     <field name="group">sudo</field>
     <description>User added to group sudo.</description>
-    <group>gpg13_7.9,gpg13_4.13,gdpr_IV_32.2,</group>
+    <group>pci_dss_10.2.5,gpg13_7.9,gpg13_4.13,gdpr_IV_32.2,</group>
   </rule>
 
 </group>

--- a/rules/0025-sendmail_rules.xml
+++ b/rules/0025-sendmail_rules.xml
@@ -24,7 +24,7 @@
     <match>reject=451 4.1.8 </match>
     <description>sendmail: Sender domain does not have any valid </description>
     <description>MX record (Requested action aborted).</description>
-    <group>spam,pci_dss_11.4,</group>
+    <group>spam,pci_dss_11.4,gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="3103" level="6">
@@ -32,7 +32,7 @@
     <match>reject=550 5.0.0 |reject=553 5.3.0</match>
     <description>sendmail: Rejected by access list </description>
     <description>(55x: Requested action not taken).</description>
-    <group>spam,pci_dss_11.4,</group>
+    <group>spam,pci_dss_11.4,gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="3104" level="6">
@@ -40,7 +40,7 @@
     <match>reject=550 5.7.1 </match>
     <description>sendmail: Attempt to use mail server as relay </description>
     <description>(550: Requested action not taken).</description>
-    <group>spam,pci_dss_11.4,</group>
+    <group>spam,pci_dss_11.4,gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="3105" level="5">
@@ -48,7 +48,7 @@
     <match>reject=553 5.1.8 </match>
     <description>sendmail: Sender domain is not found </description>
     <description> (553: Requested action not taken).</description>
-    <group>spam,pci_dss_11.4,</group>
+    <group>spam,pci_dss_11.4,gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="3106" level="5">
@@ -56,7 +56,7 @@
     <match>reject=553 5.5.4 </match>
     <description>sendmail: Sender address does not have domain </description>
     <description>(553: Requested action not taken).</description>
-    <group>spam,pci_dss_11.4,</group>
+    <group>spam,pci_dss_11.4,gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="3107" level="4">
@@ -68,14 +68,14 @@
     <if_sid>3100</if_sid>
     <match>rejecting commands from</match>
     <description>sendmail: Sendmail rejected due to pre-greeting.</description>
-    <group>spam,pci_dss_11.4,</group>
+    <group>spam,pci_dss_11.4,gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="3109" level="8">
     <if_sid>3100</if_sid>
     <match>savemail panic</match>
     <description>sendmail: Sendmail save mail panic.</description>
-    <group>system_error,</group>
+    <group>system_error,gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="3151" level="10" frequency="6" timeframe="120">
@@ -83,7 +83,7 @@
     <same_source_ip />
     <description>sendmail: Sender domain has bogus MX record. </description>
     <description>It should not be sending e-mail.</description>
-    <group>multiple_spam,pci_dss_11.4,</group>
+    <group>multiple_spam,pci_dss_11.4,gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="3152" level="6" frequency="6" timeframe="120">
@@ -91,14 +91,14 @@
     <same_source_ip />
     <description>sendmail: Multiple attempts to send e-mail from a </description>
     <description>previously rejected sender (access).</description>
-    <group>multiple_spam,pci_dss_11.4,</group>
+    <group>multiple_spam,pci_dss_11.4,gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="3153" level="6" frequency="6" timeframe="120">
     <if_matched_sid>3104</if_matched_sid>
     <same_source_ip />
     <description>sendmail: Multiple relaying attempts of spam.</description>
-    <group>multiple_spam,pci_dss_11.4,</group>
+    <group>multiple_spam,pci_dss_11.4,gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="3154" level="10" frequency="6" timeframe="120">
@@ -106,7 +106,7 @@
     <same_source_ip />
     <description>sendmail: Multiple attempts to send e-mail </description>
     <description>from invalid/unknown sender domain.</description>
-    <group>multiple_spam,pci_dss_11.4,</group>
+    <group>multiple_spam,pci_dss_11.4,gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="3155" level="10" frequency="6" timeframe="120">
@@ -114,21 +114,21 @@
     <same_source_ip />
     <description>sendmail: Multiple attempts to send e-mail from </description>
     <description>invalid/unknown sender.</description>
-    <group>multiple_spam,pci_dss_11.4,</group>
+    <group>multiple_spam,pci_dss_11.4,gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="3156" level="10" frequency="10" timeframe="120">
     <if_matched_sid>3107</if_matched_sid>
     <same_source_ip />
     <description>sendmail: Multiple rejected e-mails from same source ip.</description>
-    <group>multiple_spam,pci_dss_11.4,</group>
+    <group>multiple_spam,pci_dss_11.4,gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="3158" level="10" frequency="6" timeframe="120">
     <if_matched_sid>3108</if_matched_sid>
     <same_source_ip />
     <description>sendmail: Multiple pre-greetings rejects.</description>
-    <group>multiple_spam,pci_dss_11.4,</group>
+    <group>multiple_spam,pci_dss_11.4,gdpr_IV_35.7.d,</group>
   </rule>
 
 
@@ -144,7 +144,7 @@
      <match>^sender check failed|^sender check tempfailed</match>
      <description>sendmail: SMF-SAV sendmail milter unable to verify </description>
      <description>address (REJECTED).</description>
-     <group>smf-sav,spam,pci_dss_11.4,</group>
+     <group>smf-sav,spam,pci_dss_11.4,gdpr_IV_35.7.d,</group>
    </rule>
 
 </group>

--- a/rules/0030-postfix_rules.xml
+++ b/rules/0030-postfix_rules.xml
@@ -20,7 +20,7 @@
     <id>^554$</id>
     <description>Postfix: Attempt to use mail server as relay </description>
     <description>(client host rejected).</description>
-    <group>spam,pci_dss_10.6.1,pci_dss_11.4,</group>
+    <group>spam,pci_dss_10.6.1,pci_dss_11.4,gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="3302" level="6">
@@ -28,7 +28,7 @@
     <id>^550$</id>
     <description>Postfix: Rejected by access list </description>
     <description>(Requested action not taken).</description>
-    <group>spam,pci_dss_10.6.1,pci_dss_11.4,</group>
+    <group>spam,pci_dss_10.6.1,pci_dss_11.4,gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="3303" level="5">
@@ -36,7 +36,7 @@
     <id>^450$</id>
     <description>Postfix: Sender domain is not found </description>
     <description>(450: Requested mail action not taken).</description>
-    <group>spam,pci_dss_10.6.1,pci_dss_11.4,</group>
+    <group>spam,pci_dss_10.6.1,pci_dss_11.4,gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="3304" level="5">
@@ -44,7 +44,7 @@
     <id>^503$</id>
     <description>Postfix: Improper use of SMTP command pipelining </description>
     <description>(503: Bad sequence of commands).</description>
-    <group>spam,pci_dss_10.6.1,pci_dss_11.4,</group>
+    <group>spam,pci_dss_10.6.1,pci_dss_11.4,gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="3305" level="5">
@@ -52,14 +52,14 @@
     <id>^504$</id>
     <description>Postfix: Recipient address must contain FQDN </description>
     <description>(504: Command parameter not implemented).</description>
-    <group>spam,pci_dss_10.6.1,pci_dss_11.4,</group>
+    <group>spam,pci_dss_10.6.1,pci_dss_11.4,gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="3306" level="6">
     <if_sid>3301, 3302</if_sid>
     <match> blocked using </match>
     <description>Postfix: IP Address black-listed by anti-spam (blocked).</description>
-    <group>spam,pci_dss_10.6.1,pci_dss_11.4,</group>
+    <group>spam,pci_dss_10.6.1,pci_dss_11.4,gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="3320" level="0">
@@ -72,48 +72,49 @@
     <match>defer service failure|Resource temporarily unavailable|</match>
     <match>^fatal: the Postfix mail system is not running</match>
     <description>Postfix process error.</description>
-    <group>service_availability,pci_dss_10.6.1,</group>
+    <group>service_availability,pci_dss_10.6.1,gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="3332" level="5">
     <if_sid>3320</if_sid>
     <match> authentication failed</match>
     <description>Postfix SASL authentication failure.</description>
-    <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,</group>
+    <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
   </rule>
 
   <rule id="3331" level="10" ignore="120">
     <if_sid>3300</if_sid>
     <id>^452</id>
     <description>Postfix insufficient disk space error.</description>
-    <group>service_availability,pci_dss_10.6.1,</group>
+    <group>service_availability,pci_dss_10.6.1,gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="3334" level="3">
     <if_sid>3320</if_sid>
     <match>^daemon started </match>
     <description>Postfix started.</description>
+    <group></group>
   </rule>
 
   <rule id="3335" level="6">
     <if_sid>3320</if_sid>
     <match>^too many </match>
     <description>Postfix: too many errors after RCPT from unkown</description>
-    <group>spam,pci_dss_10.6.1,pci_dss_11.4,</group>
+    <group>spam,pci_dss_10.6.1,pci_dss_11.4,gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="3333" level="7">
     <if_sid>3320</if_sid>
     <match>^terminating on signal</match>
     <description>Postfix stopped.</description>
-    <group>service_availability,pci_dss_10.6.1,</group>
+    <group>service_availability,pci_dss_10.6.1,gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="3351" level="6" frequency="$POSTFIX_FREQ" timeframe="90">
     <if_matched_sid>3301</if_matched_sid>
     <same_source_ip />
     <description>Postfix: Multiple relaying attempts of spam.</description>
-    <group>multiple_spam,pci_dss_10.6.1,pci_dss_11.4,</group>
+    <group>multiple_spam,pci_dss_10.6.1,pci_dss_11.4,gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="3352" level="6" frequency="$POSTFIX_FREQ" timeframe="120">
@@ -129,7 +130,7 @@
     <same_source_ip />
     <description>Postfix: Multiple attempts to send e-mail from </description>
     <description>invalid/unknown sender domain.</description>
-    <group>multiple_spam,pci_dss_10.6.1,pci_dss_11.4,</group>
+    <group>multiple_spam,pci_dss_10.6.1,pci_dss_11.4,gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="3354" level="12" frequency="$POSTFIX_FREQ" timeframe="120">
@@ -137,7 +138,7 @@
     <same_source_ip />
     <description>Postfix: Multiple misuse of SMTP service </description>
     <description>(bad sequence of commands).</description>
-    <group>multiple_spam,pci_dss_10.6.1,pci_dss_11.4,</group>
+    <group>multiple_spam,pci_dss_10.6.1,pci_dss_11.4,gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="3355" level="10" frequency="$POSTFIX_FREQ" timeframe="120">
@@ -145,7 +146,7 @@
     <same_source_ip />
     <description>Postfix: Multiple attempts to send e-mail to </description>
     <description>invalid recipient or from unknown sender domain.</description>
-    <group>multiple_spam,pci_dss_10.6.1,pci_dss_11.4,</group>
+    <group>multiple_spam,pci_dss_10.6.1,pci_dss_11.4,gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="3356" level="10" frequency="$POSTFIX_FREQ" timeframe="120" ignore="30">
@@ -153,14 +154,14 @@
     <same_source_ip />
     <description>Postfix: Multiple attempts to send e-mail from </description>
     <description>black-listed IP address (blocked).</description>
-    <group>multiple_spam,pci_dss_10.6.1,pci_dss_11.4,</group>
+    <group>multiple_spam,pci_dss_10.6.1,pci_dss_11.4,gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="3357" level="10" frequency="6" timeframe="120" ignore="60">
     <if_matched_sid>3332</if_matched_sid>
     <same_source_ip />
     <description>Postfix: Multiple SASL authentication failures.</description>
-    <group>authentication_failures,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,</group>
+    <group>authentication_failures,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
   </rule>
 
   <rule id="3390" level="0">
@@ -177,21 +178,21 @@
     <if_sid>3395</if_sid>
     <match>verification</match>
     <description>Postfix: hostname verification failed</description>
-    <group>spam,pci_dss_10.6.1,pci_dss_11.4,</group>
+    <group>spam,pci_dss_10.6.1,pci_dss_11.4,gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="3397" level="6">
     <if_sid>3395</if_sid>
     <match>RBL</match>
     <description>Postfix: RBL lookup error: Host or domain name not found</description>
-    <group>spam,pci_dss_10.6.1,pci_dss_11.4,</group>
+    <group>spam,pci_dss_10.6.1,pci_dss_11.4,gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="3398" level="6">
     <if_sid>3395</if_sid>
     <match>MAIL|does not resolve to address</match>
     <description>Postfix: Illegal address from unknown sender</description>
-    <group>spam,pci_dss_10.6.1,pci_dss_11.4,</group>
+    <group>spam,pci_dss_10.6.1,pci_dss_11.4,gdpr_IV_35.7.d,</group>
   </rule>
 
   <!--

--- a/rules/0040-imapd_rules.xml
+++ b/rules/0040-imapd_rules.xml
@@ -18,28 +18,28 @@
     <if_sid>3600</if_sid>
     <match>Login failed user=|AUTHENTICATE LOGIN failure</match>
     <description>Imapd user login failed.</description>
-    <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,</group>
+    <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
   </rule>
 
   <rule id="3602" level="3">
     <if_sid>3600</if_sid>
     <match>Authenticated user=</match>
     <description>Imapd user login.</description>
-    <group>authentication_success,pci_dss_10.2.5,gpg13_7.1,</group>
+    <group>authentication_success,pci_dss_10.2.5,gpg13_7.1,gdpr_IV_32.2,</group>
   </rule>
 
   <rule id="3603" level="0">
     <if_sid>3600</if_sid>
     <match>Logout user=</match>
     <description>Imapd user logout.</description>
-    <group>pci_dss_10.2.5,gpg13_7.1,</group>
+    <group>pci_dss_10.2.5,gpg13_7.1,gdpr_IV_32.2,</group>
   </rule>
 
   <rule id="3651" level="10" frequency="$IMAPD_FREQ" timeframe="120">
     <if_matched_sid>3601</if_matched_sid>
     <same_source_ip />
     <description>Imapd Multiple failed logins from same source ip.</description>
-    <group>authentication_failures,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gpg13_7.1,</group>
+    <group>authentication_failures,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
   </rule>
 
 </group>

--- a/rules/0045-mailscanner_rules.xml
+++ b/rules/0045-mailscanner_rules.xml
@@ -29,7 +29,7 @@
     <if_matched_sid>3702</if_matched_sid>
     <same_source_ip />
     <description>mailscanner: Multiple attempts of spam.</description>
-    <group>multiple_spam,pci_dss_10.6.1,gpg13_4.12,</group>
+    <group>multiple_spam,pci_dss_10.6.1,gpg13_4.12,gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="3752" level="0">

--- a/rules/0050-ms-exchange_rules.xml
+++ b/rules/0050-ms-exchange_rules.xml
@@ -31,14 +31,14 @@
     <if_matched_sid>3801</if_matched_sid>
     <same_source_ip />
     <description>ms-exchange: Multiple e-mail attempts to an invalid account.</description>
-    <group>multiple_spam,pci_dss_10.6.1,gpg13_4.12,</group>
+    <group>multiple_spam,pci_dss_10.6.1,gpg13_4.12,gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="3852" level="9" frequency="12" timeframe="120" ignore="240">
     <if_matched_sid>3802</if_matched_sid>
     <same_source_ip />
     <description>ms-exchange: Multiple e-mail 500 error code (spam).</description>
-    <group>multiple_spam,pci_dss_10.6.1,gpg13_4.12,</group>
+    <group>multiple_spam,pci_dss_10.6.1,gpg13_4.12,gdpr_IV_35.7.d,</group>
   </rule>
 
 </group>

--- a/rules/0055-courier_rules.xml
+++ b/rules/0055-courier_rules.xml
@@ -16,14 +16,14 @@
     <if_sid>3900</if_sid>
     <match>^Connection, </match>
     <description>New courier (imap/pop3) connection.</description>
-    <group>connection_attempt,pci_dss_10.6.1,</group>
+    <group>connection_attempt,pci_dss_10.6.1,gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="3902" level="5">
     <if_sid>3900</if_sid>
     <match>^LOGIN FAILED,| FAILED:</match>
     <description>Courier (imap/pop3) authentication failed.</description>
-    <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,</group>
+    <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
   </rule>
 
   <rule id="3903" level="0">
@@ -37,13 +37,13 @@
     <if_sid>3900</if_sid>
     <match>^LOGIN,</match>
     <description>Courier (imap/pop3) authentication success.</description>
-    <group>authentication_success,pci_dss_10.2.5,gpg13_7.1,gpg13_7.2,</group>
+    <group>authentication_success,pci_dss_10.2.5,gpg13_7.1,gpg13_7.2,gdpr_IV_32.2,</group>
   </rule>
 
   <rule id="3910" level="10" frequency="10" timeframe="30">
     <if_matched_sid>3902</if_matched_sid>
     <description>Courier brute force (multiple failed logins).</description>
-    <group>authentication_failures,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gpg13_7.1,</group>
+    <group>authentication_failures,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
     <same_source_ip />
   </rule>
 
@@ -51,6 +51,6 @@
     <if_matched_sid>3901</if_matched_sid>
     <same_source_ip />
     <description>Courier: Multiple connection attempts from same source.</description>
-    <group>recon,pci_dss_10.6.1,pci_dss_11.4,</group>
+    <group>recon,pci_dss_10.6.1,pci_dss_11.4,gdpr_IV_35.7.d,</group>
   </rule>
 </group>

--- a/rules/0060-firewall_rules.xml
+++ b/rules/0060-firewall_rules.xml
@@ -20,13 +20,13 @@
     <action>DROP</action>
     <options>no_log</options>
     <description>Firewall drop event.</description>
-    <group>firewall_drop,pci_dss_1.4,gpg13_4.12,</group>
+    <group>firewall_drop,pci_dss_1.4,gpg13_4.12,gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="4151" level="10" frequency="16" timeframe="45" ignore="240">
     <if_matched_sid>4101</if_matched_sid>
     <same_source_ip />
     <description>Multiple Firewall drop events from same source.</description>
-    <group>multiple_drops,pci_dss_1.4,pci_dss_10.6.1,gpg13_4.12,</group>
+    <group>multiple_drops,pci_dss_1.4,pci_dss_10.6.1,gpg13_4.12,gdpr_IV_35.7.d,</group>
   </rule>
 </group>

--- a/rules/0065-pix_rules.xml
+++ b/rules/0065-pix_rules.xml
@@ -52,21 +52,21 @@
     <if_sid>4314</if_sid>
     <id>^6-605004</id>
     <description>PIX: Failed login attempt.</description>
-    <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.8,</group>
+    <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.8,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
   </rule>
 
   <rule id="4322" level="3">
     <if_sid>4314</if_sid>
     <id>^5-502103</id>
     <description>PIX: Privilege changed.</description>
-    <group>pci_dss_10.2.7,pci_dss_10.6.1,gpg13_7.9,</group>
+    <group>pci_dss_10.2.7,pci_dss_10.6.1,gpg13_7.9,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
   </rule>
 
   <rule id="4323" level="3">
     <if_sid>4314</if_sid>
     <id>^6-605005</id>
     <description>PIX: Successful login.</description>
-    <group>authentication_success,pci_dss_10.2.5,gpg13_7.8,</group>
+    <group>authentication_success,pci_dss_10.2.5,gpg13_7.8,gdpr_IV_32.2,</group>
   </rule>
 
   <rule id="4324" level="9">
@@ -74,46 +74,49 @@
     <id>^6-308001</id>
     <description>PIX: Password mismatch while running 'enable' </description>
     <description>on the PIX.</description>
-    <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.8,</group>
+    <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.8,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
   </rule>
 
   <rule id="4325" level="8">
     <if_sid>4313</if_sid>
     <id>^4-405001</id>
     <description>PIX: ARP collision detected.</description>
-    <group>pci_dss_10.6.1,gpg13_4.12,</group>
+    <group>pci_dss_10.6.1,gpg13_4.12,gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="4326" level="8">
     <if_sid>4313</if_sid>
     <id>^4-401004</id>
     <description>PIX: Attempt to connect from a blocked (shunned) IP.</description>
-    <group>access_denied,pci_dss_10.2.4,pci_dss_11.4,gpg13_4.12,</group>
+    <group>access_denied,pci_dss_10.2.4,pci_dss_11.4,gpg13_4.12,gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="4327" level="8">
     <if_sid>4313</if_sid>
     <id>^4-710004</id>
     <description>PIX: Connection limit exceeded.</description>
-    <group>pci_dss_10.6.1,gpg13_4.12,</group>
+    <group>pci_dss_10.6.1,gpg13_4.12,gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="4330" level="8">
     <if_sid>4310</if_sid>
     <id>^1-106021|^1-106022</id>
     <description>PIX: Attack in progress detected.</description>
+    <group>gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="4331" level="8">
     <if_sid>4311</if_sid>
     <id>^2-106012|^2-106017|^2-106020</id>
     <description>PIX: Attack in progress detected.</description>
+    <group>gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="4332" level="8">
     <if_sid>4313</if_sid>
     <id>^4-4000</id>
     <description>PIX: Attack in progress detected.</description>
+    <group>gdpr_IV_35.7.d,</group>
   </rule>
 
   <!-- Grouping of attack in progress messages. The three above
@@ -122,35 +125,35 @@
   <rule id="4333" level="8">
     <if_sid>4330, 4331, 4332</if_sid>
     <description>PIX: Attack in progress detected</description>
-    <group>ids,pci_dss_11.4,gpg13_4.12,</group>
+    <group>ids,pci_dss_11.4,gpg13_4.12,gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="4334" level="5">
     <if_sid>4314</if_sid>
     <id>^6-113005</id>
     <description>PIX: AAA (VPN) authentication failed.</description>
-    <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,</group>
+    <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
   </rule>
 
   <rule id="4335" level="3">
     <if_sid>4314</if_sid>
     <id>^6-113004</id>
     <description>PIX: AAA (VPN) authentication successful.</description>
-    <group>authentication_success,pci_dss_10.2.5,gpg13_7.1,gpg13_7.2,</group>
+    <group>authentication_success,pci_dss_10.2.5,gpg13_7.1,gpg13_7.2,gdpr_IV_32.2,</group>
   </rule>
 
   <rule id="4336" level="8">
     <if_sid>4314</if_sid>
     <id>^6-113006</id>
     <description>PIX: AAA (VPN) user locked out.</description>
-    <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,gpg13_7.5,</group>
+    <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,gpg13_7.5,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
   </rule>
 
   <rule id="4337" level="8">
     <if_sid>4312</if_sid>
     <id>^3-201008</id>
     <description>PIX: The PIX is disallowing new connections.</description>
-    <group>service_availability,pci_dss_10.6.1,gpg13_4.12,</group>
+    <group>service_availability,pci_dss_10.6.1,gpg13_4.12,gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="4338" level="8">
@@ -158,21 +161,21 @@
     <id>^1-105005|^1-105009|^1-105043</id>
     <match>Failed|Lost Failover</match>
     <description>PIX: Firewall failover pair communication problem.</description>
-    <group>service_availability,pci_dss_10.6.1,gpg13_4.12,</group>
+    <group>service_availability,pci_dss_10.6.1,gpg13_4.12,gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="4339" level="8">
     <if_sid>4314</if_sid>
     <id>^5-111003</id>
     <description>PIX: Firewall configuration deleted.</description>
-    <group>config_changed,pci_dss_1.1.1,pci_dss_10.4,gpg13_4.13,</group>
+    <group>config_changed,pci_dss_1.1.1,pci_dss_10.4,gpg13_4.13,gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="4340" level="8">
     <if_sid>4314</if_sid>
     <id>^5-111005|^5-111004|^5-111002|^5-111007</id>
     <description>PIX: Firewall configuration changed.</description>
-    <group>config_changed,pci_dss_1.1.1,pci_dss_10.4,gpg13_4.13,</group>
+    <group>config_changed,pci_dss_1.1.1,pci_dss_10.4,gpg13_4.13,gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="4341" level="3">
@@ -185,43 +188,43 @@
     <if_sid>4314</if_sid>
     <id>^5-502101|^5-502102</id>
     <description>PIX: User created or modified on the Firewall.</description>
-    <group>adduser,account_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_4.13,</group>
+    <group>adduser,account_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_4.13,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
   </rule>
 
   <rule id="4380" level="10" frequency="6" timeframe="360">
     <if_matched_sid>4310</if_matched_sid>
     <description>Multiple PIX alert messages.</description>
-    <group>pci_dss_10.6.1,pci_dss_11.4,gpg13_4.12,</group>
+    <group>pci_dss_10.6.1,pci_dss_11.4,gpg13_4.12,gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="4381" level="10" frequency="6" timeframe="360">
     <if_matched_sid>4311</if_matched_sid>
     <description>PIX: Multiple critical messages.</description>
-    <group>pci_dss_10.6.1,pci_dss_11.4,gpg13_4.1,</group>
+    <group>pci_dss_10.6.1,pci_dss_11.4,gpg13_4.1,ggdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="4382" level="10" frequency="8" timeframe="120">
     <if_matched_sid>4312</if_matched_sid>
     <description>PIX: Multiple error messages.</description>
-    <group>system_error,pci_dss_10.6.1,pci_dss_11.4,gpg13_4.3,</group>
+    <group>system_error,pci_dss_10.6.1,pci_dss_11.4,gpg13_4.3,gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="4383" level="10" frequency="8" timeframe="120">
     <if_matched_sid>4313</if_matched_sid>
     <description>PIX: Multiple warning messages.</description>
-    <group>pci_dss_10.6.1,gpg13_4.12,</group>
+    <group>pci_dss_10.6.1,gpg13_4.12,gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="4385" level="10" frequency="8" timeframe="240" ignore="90">
     <if_matched_sid>4333</if_matched_sid>
     <same_source_ip />
     <description>PIX: Multiple attack in progress messages.</description>
-    <group>pci_dss_10.6.1,pci_dss_11.4,gpg13_4.12,</group>
+    <group>pci_dss_10.6.1,pci_dss_11.4,gpg13_4.12,gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="4386" level="10" frequency="8" timeframe="240">
     <if_matched_sid>4334</if_matched_sid>
     <description>PIX: Multiple AAA (VPN) authentication failures.</description>
-    <group>authentication_failures,pci_dss_11.4,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,</group>
+    <group>authentication_failures,pci_dss_11.4,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
   </rule>
 </group>

--- a/rules/0065-pix_rules.xml
+++ b/rules/0065-pix_rules.xml
@@ -102,21 +102,21 @@
     <if_sid>4310</if_sid>
     <id>^1-106021|^1-106022</id>
     <description>PIX: Attack in progress detected.</description>
-    <group>gdpr_IV_35.7.d,</group>
+    <group>pci_dss_11.4,gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="4331" level="8">
     <if_sid>4311</if_sid>
     <id>^2-106012|^2-106017|^2-106020</id>
     <description>PIX: Attack in progress detected.</description>
-    <group>gdpr_IV_35.7.d,</group>
+    <group>pci_dss_11.4,gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="4332" level="8">
     <if_sid>4313</if_sid>
     <id>^4-4000</id>
     <description>PIX: Attack in progress detected.</description>
-    <group>gdpr_IV_35.7.d,</group>
+    <group>pci_dss_11.4,gdpr_IV_35.7.d,</group>
   </rule>
 
   <!-- Grouping of attack in progress messages. The three above

--- a/rules/0070-netscreenfw_rules.xml
+++ b/rules/0070-netscreenfw_rules.xml
@@ -48,35 +48,35 @@
     <if_sid>4503</if_sid>
     <id>^00027</id>
     <description>Netscreen Erase sequence started.</description>
-    <group>service_availability,pci_dss_1.4,pci_dss_10.6.1,</group>
+    <group>service_availability,pci_dss_1.4,pci_dss_10.6.1,gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="4506" level="8">
     <if_sid>4501</if_sid>
     <id>^00002</id>
     <description>Netscreen firewall: Successfull admin login</description>
-    <group>authentication_success,pci_dss_10.2.5,pci_dss_10.2.2,gpg13_7.8,</group>
+    <group>authentication_success,pci_dss_10.2.5,pci_dss_10.2.2,gpg13_7.8,gdpr_IV_32.2,</group>
   </rule>
 
   <rule id="4507" level="8">
     <if_sid>4502</if_sid>
     <id>^00515</id>
     <description>Netscreen firewall: Successfull admin login</description>
-    <group>authentication_success,pci_dss_10.2.5,pci_dss_10.2.2,gpg13_7.8,</group>
+    <group>authentication_success,pci_dss_10.2.5,pci_dss_10.2.2,gpg13_7.8,gdpr_IV_32.2,</group>
   </rule>
 
   <rule id="4508" level="8">
     <if_sid>4501</if_sid>
     <id>^00018</id>
     <description>Netscreen firewall: policy changed.</description>
-    <group>config_changed,pci_dss_1.1.1,gpg13_4.12,</group>
+    <group>config_changed,pci_dss_1.1.1,gpg13_4.12,gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="4509" level="8">
     <if_sid>4504</if_sid>
     <id>^00767</id>
     <description>Netscreen firewall: configuration changed.</description>
-    <group>config_changed,pci_dss_1.1.1,gpg13_4.12,</group>
+    <group>config_changed,pci_dss_1.1.1,gpg13_4.12,gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="4550" level="10" frequency="4" timeframe="180" ignore="60">
@@ -84,7 +84,7 @@
     <same_source_ip />
     <description>Netscreen firewall: Multiple critical messages from </description>
     <description>same source IP.</description>
-    <group>pci_dss_1.4,pci_dss_10.6.1,pci_dss_11.4,gpg13_4.1,</group>
+    <group>pci_dss_1.4,pci_dss_10.6.1,pci_dss_11.4,gpg13_4.1,gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="4551" level="10" frequency="6" timeframe="180" ignore="60">
@@ -97,7 +97,7 @@
     <same_source_ip />
     <description>Netscreen firewall: Multiple alert messages from </description>
     <description>same source IP.</description>
-    <group>pci_dss_1.4,pci_dss_10.6.1,pci_dss_11.4,gpg13_4.12,</group>
+    <group>pci_dss_1.4,pci_dss_10.6.1,pci_dss_11.4,gpg13_4.12,gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="4553" level="10" frequency="8" timeframe="100" ignore="60">

--- a/rules/0075-cisco-ios_rules.xml
+++ b/rules/0075-cisco-ios_rules.xml
@@ -16,7 +16,7 @@
     <if_sid>4700</if_sid>
     <id>-0-</id>
     <description>Cisco IOS emergency message.</description>
-    <group>gpg13_3.2,</group>
+    <group>gpg13_3.2,gdpr_IV_35.7.d,</group>
   </rule>
 
 
@@ -69,21 +69,21 @@
     <if_sid>4715</if_sid>
     <id>^%SYS-5-CONFIG</id>
     <description>Cisco IOS router configuration changed.</description>
-    <group>config_changed,pci_dss_10.2.7,gpg13_3.7,</group>
+    <group>config_changed,pci_dss_10.2.7,gpg13_3.7,gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="4722" level="3">
     <if_sid>4715</if_sid>
     <id>^%SEC_LOGIN-5-LOGIN_SUCCESS</id>
     <description>Cisco IOS: Successful login to the router.</description>
-    <group>authentication_success,pci_dss_10.2.5,gpg13_3.6,</group>
+    <group>authentication_success,pci_dss_10.2.5,gpg13_3.6,gdpr_IV_32.2,</group>
   </rule>
 
   <rule id="4724" level="9">
     <if_sid>4714</if_sid>
     <id>^%SEC_LOGIN-4-LOGIN_FAILED</id>
     <description>Cisco IOS: Failed login to the router.</description>
-    <group>authentication_failed,pci_dss_10.2.5,pci_dss_10.2.4,gpg13_3.6,</group>
+    <group>authentication_failed,pci_dss_10.2.5,pci_dss_10.2.4,gpg13_3.6,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
   </rule>
 
 </group>

--- a/rules/0080-sonicwall_rules.xml
+++ b/rules/0080-sonicwall_rules.xml
@@ -16,14 +16,14 @@
     <if_sid>4800</if_sid>
     <status>^1</status>
     <description>SonicWall critical message.</description>
-    <group>gpg13_3.2,</group>
+    <group>gpg13_3.2,gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="4802" level="8">
     <if_sid>4800</if_sid>
     <status>^2</status>
     <description>SonicWall critical message.</description>
-    <group>gpg13_3.2,</group>
+    <group>gpg13_3.2,gdpr_IV_35.7.d,</group>
   </rule>
 
  <rule id="4803" level="4">
@@ -61,25 +61,25 @@
     <if_sid>4806</if_sid>
     <id>^236$</id>
     <description>SonicWall: Firewall administrator login.</description>
-    <group>authentication_success,pci_dss_10.2.5,gpg13_3.6,</group>
+    <group>authentication_success,pci_dss_10.2.5,gpg13_3.6,gdpr_IV_32.2,</group>
   </rule>
 
   <rule id="4811" level="9">
     <if_sid>4801</if_sid>
     <id>^30$|^32$</id>
     <description>SonicWall: Firewall authentication failure.</description>
-    <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_3.6,</group>
+    <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_3.6,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
   </rule>
 
   <rule id="4850" level="10" frequency="6" timeframe="120" ignore="60">
     <if_matched_sid>4804</if_matched_sid>
     <description>SonicWall: Multiple firewall warning messages.</description>
-    <group>service_availability,pci_dss_10.6.1,</group>
+    <group>service_availability,pci_dss_10.6.1,gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="4851" level="10" frequency="6" timeframe="120" ignore="60">
     <if_matched_sid>4803</if_matched_sid>
     <description>SonicWall: Multiple firewall error messages.</description>
-    <group>service_availability,pci_dss_10.6.1,gpg13_3.5,</group>
+    <group>service_availability,pci_dss_10.6.1,gpg13_3.5,gdpr_IV_35.7.d,</group>
   </rule>
 </group>

--- a/rules/0085-pam_rules.xml
+++ b/rules/0085-pam_rules.xml
@@ -16,28 +16,28 @@
     <if_sid>5500</if_sid>
     <match>session opened for user </match>
     <description>PAM: Login session opened.</description>
-    <group>authentication_success,pci_dss_10.2.5,gpg13_7.8,gpg13_7.9</group>
+    <group>authentication_success,pci_dss_10.2.5,gpg13_7.8,gpg13_7.9,gdpr_IV_32.2,</group>
   </rule>
 
   <rule id="5502" level="3">
     <if_sid>5500</if_sid>
     <match>session closed for user </match>
     <description>PAM: Login session closed.</description>
-    <group>pci_dss_10.2.5,gpg13_7.8,gpg13_7.9,</group>
+    <group>pci_dss_10.2.5,gpg13_7.8,gpg13_7.9,gdpr_IV_32.2,</group>
   </rule>
 
   <rule id="5503" level="5">
     <if_sid>5500</if_sid>
     <match>authentication failure; logname=</match>
     <description>PAM: User login failed.</description>
-    <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.8,</group>
+    <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.8,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
   </rule>
 
   <rule id="5504" level="5">
     <if_sid>5500</if_sid>
     <match>check pass; user unknown</match>
     <description>PAM: Attempt to login with an invalid user.</description>
-    <group>invalid_login,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.8,</group>
+    <group>invalid_login,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.8,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
   </rule>
 
   <!-- Ignoring Annoying Ubuntu/debian cron login events. -->
@@ -65,7 +65,7 @@
     <if_matched_sid>5503</if_matched_sid>
     <same_source_ip />
     <description>PAM: Multiple failed logins in a small period of time.</description>
-    <group>authentication_failures,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gpg13_7.8,</group>
+    <group>authentication_failures,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gpg13_7.8,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
   </rule>
 
   <rule id="5552" level="0">
@@ -78,20 +78,20 @@
     <program_name>login</program_name>
     <match>cannot open shared object file: No such file or directory</match>
     <description>PAM misconfiguration.</description>
-    <group>pci_dss_10.6.1,gpg13_4.3,</group>
+    <group>pci_dss_10.6.1,gpg13_4.3,gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="5554" level="4">
     <program_name>login</program_name>
     <match>illegal module type: </match>
     <description>PAM misconfiguration.</description>
-    <group>pci_dss_10.6.1,gpg13_4.3,</group>
+    <group>pci_dss_10.6.1,gpg13_4.3,gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="5555" level="3">
     <match>: password changed for</match>
     <description>PAM: User changed password.</description>
-    <group>pci_dss_8.1.2,pci_dss_10.2.5,gpg13_4.13,gpg13_7.10,</group>
+    <group>pci_dss_8.1.2,pci_dss_10.2.5,gpg13_4.13,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
   </rule>
 
   <rule id="5556" level="0">
@@ -103,7 +103,7 @@
     <if_sid>5556</if_sid>
     <match>password check failed </match>
     <description>unix_chkpwd: Password check failed.</description>
-    <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_4.3,</group>
+    <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_4.3,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
   </rule>
 
 </group>

--- a/rules/0090-telnetd_rules.xml
+++ b/rules/0090-telnetd_rules.xml
@@ -17,23 +17,27 @@
     <if_sid>5600</if_sid>
     <match>refused connect from </match>
     <description>telnetd: Connection refused by TCP Wrappers.</description>
+    <group>gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="5602" level="3">
     <if_sid>5600</if_sid>
     <match>: connect from </match>
     <description>telnetd: Remote host established a telnet connection.</description>
+    <group>gdpr_IV_32.2,</group>
   </rule>
 
   <rule id="5603" level="5" timeframe="1">
     <match>ttloop:  peer died:|ttloop:  read:</match>
     <if_matched_sid>5602</if_matched_sid>
     <description>telnetd: Remote host invalid connection.</description>
+    <group>gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
   </rule>
 
   <rule id="5604" level="5">
     <match>warning: can't verify hostname:</match>
     <description>telnetd: Reverse lookup error (bad hostname config).</description>
+    <group>gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="5631" level="10" frequency="6" timeframe="120">
@@ -41,6 +45,7 @@
     <same_source_ip />
     <description>telnetd: Multiple connection attempts from same source </description>
     <description>(possible scan).</description>
+    <group>gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
   </rule>
 
 </group>

--- a/rules/0090-telnetd_rules.xml
+++ b/rules/0090-telnetd_rules.xml
@@ -24,14 +24,14 @@
     <if_sid>5600</if_sid>
     <match>: connect from </match>
     <description>telnetd: Remote host established a telnet connection.</description>
-    <group>gdpr_IV_32.2,</group>
+    <group>pci_dss_10.2.5,gdpr_IV_32.2,</group>
   </rule>
 
   <rule id="5603" level="5" timeframe="1">
     <match>ttloop:  peer died:|ttloop:  read:</match>
     <if_matched_sid>5602</if_matched_sid>
     <description>telnetd: Remote host invalid connection.</description>
-    <group>gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
+    <group>pci_dss_10.2.4,pci_dss_10.2.5,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
   </rule>
 
   <rule id="5604" level="5">
@@ -45,7 +45,7 @@
     <same_source_ip />
     <description>telnetd: Multiple connection attempts from same source </description>
     <description>(possible scan).</description>
-    <group>gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
+    <group>pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
   </rule>
 
 </group>

--- a/rules/0095-sshd_rules.xml
+++ b/rules/0095-sshd_rules.xml
@@ -17,7 +17,7 @@
     <match>Bad protocol version identification</match>
     <description>sshd: Possible attack on the ssh server </description>
     <description>(or version gathering).</description>
-    <group>pci_dss_11.4,gpg13_4.12,</group>
+    <group>pci_dss_11.4,gpg13_4.12,gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="5702" level="5">
@@ -25,14 +25,14 @@
     <match>^reverse mapping</match>
     <regex>failed - POSSIBLE BREAK</regex>
     <description>sshd: Reverse lookup error (bad ISP or attack).</description>
-    <group>pci_dss_11.4,gpg13_4.12,</group>
+    <group>pci_dss_11.4,gpg13_4.12,gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="5703" level="10" frequency="4" timeframe="360">
     <if_matched_sid>5702</if_matched_sid>
     <description>sshd: Possible breakin attempt </description>
     <description>(high number of reverse lookup errors).</description>
-    <group>pci_dss_11.4,gpg13_4.12,</group>
+    <group>pci_dss_11.4,gpg13_4.12,gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="5704" level="4">
@@ -45,21 +45,21 @@
     <if_matched_sid>5704</if_matched_sid>
     <description>sshd: Possible scan or breakin attempt </description>
     <description>(high number of login timeouts).</description>
-    <group>pci_dss_11.4,gpg13_4.12,</group>
+    <group>pci_dss_11.4,gpg13_4.12,gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="5706" level="6">
     <if_sid>5700</if_sid>
     <match>Did not receive identification string from</match>
     <description>sshd: insecure connection attempt (scan).</description>
-    <group>recon,pci_dss_11.4,gpg13_4.12,</group>
+    <group>recon,pci_dss_11.4,gpg13_4.12,gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="5707" level="14">
     <if_sid>5700</if_sid>
     <match>fatal: buffer_get_string: bad string</match>
     <description>sshd: OpenSSH challenge-response exploit.</description>
-    <group>exploit_attempt,pci_dss_11.4,pci_dss_6.2,gpg13_4.12,</group>
+    <group>exploit_attempt,pci_dss_11.4,pci_dss_6.2,gpg13_4.12,gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="5709" level="0">
@@ -74,7 +74,7 @@
     <if_sid>5700</if_sid>
     <match>illegal user|invalid user</match>
     <description>sshd: Attempt to login using a non-existent user</description>
-    <group>invalid_login,authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_10.6.1,gpg13_7.1,</group>
+    <group>invalid_login,authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_10.6.1,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
   </rule>
 
   <rule id="5711" level="0">
@@ -91,7 +91,7 @@
     <description>sshd: brute force trying to get access to </description>
     <description>the system.</description>
     <same_source_ip />
-    <group>authentication_failures,pci_dss_11.4,pci_dss_10.2.4,pci_dss_10.2.5,</group>
+    <group>authentication_failures,pci_dss_11.4,pci_dss_10.2.4,pci_dss_10.2.5,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
   </rule>
 
   <rule id="5713" level="6">
@@ -106,21 +106,21 @@
     <description>sshd: SSH CRC-32 Compensation attack</description>
     <info type="cve">2001-0144</info>
     <info type="link">http://www.securityfocus.com/bid/2347/info/</info>
-    <group>exploit_attempt,pci_dss_11.4,pci_dss_6.2,gpg13_4.12,</group>
+    <group>exploit_attempt,pci_dss_11.4,pci_dss_6.2,gpg13_4.12,gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="5715" level="3">
     <if_sid>5700</if_sid>
     <match>^Accepted|authenticated.$</match>
     <description>sshd: authentication success.</description>
-    <group>authentication_success,pci_dss_10.2.5,gpg13_7.1,gpg13_7.2,</group>
+    <group>authentication_success,pci_dss_10.2.5,gpg13_7.1,gpg13_7.2,gdpr_IV_32.2,</group>
   </rule>
 
   <rule id="5716" level="5">
     <if_sid>5700</if_sid>
     <match>^Failed|^error: PAM: Authentication</match>
     <description>sshd: authentication failed.</description>
-    <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,</group>
+    <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
   </rule>
 
   <rule id="5717" level="4">
@@ -133,20 +133,20 @@
     <if_sid>5700</if_sid>
     <match>not allowed because</match>
     <description>sshd: Attempt to login using a denied user.</description>
-    <group>invalid_login,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,</group>
+    <group>invalid_login,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
   </rule>
 
   <rule id="5719" level="10" frequency="6" timeframe="120" ignore="60">
     <if_matched_sid>5718</if_matched_sid>
     <description>sshd: Multiple access attempts using a denied user.</description>
-    <group>invalid_login,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gpg13_7.1,</group>
+    <group>invalid_login,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
   </rule>
 
   <rule id="5720" level="10" frequency="6">
     <if_matched_sid>5716</if_matched_sid>
     <same_source_ip />
     <description>sshd: Multiple authentication failures.</description>
-    <group>authentication_failures,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gpg13_7.1,</group>
+    <group>authentication_failures,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
   </rule>
 
   <rule id="5721" level="0">
@@ -159,7 +159,7 @@
     <if_sid>5700</if_sid>
     <match>Connection closed</match>
     <description>sshd: ssh connection closed.</description>
-    <group>pci_dss_10.2.5,</group>
+    <group>pci_dss_10.2.5,gdpr_IV_32.2,</group>
   </rule>
 
   <rule id="5723" level="0">
@@ -167,7 +167,7 @@
     <match>error: buffer_get_bignum2_ret: negative numbers not supported</match>
     <info>This maybe a bad key in authorized_keys.</info>
     <description>sshd: key error.</description>
-    <group>pci_dss_4.1,pci_dss_10.6.1,gpg13_4.3</group>
+    <group>pci_dss_4.1,pci_dss_10.6.1,gpg13_4.3,gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="5724" level="0">
@@ -175,7 +175,7 @@
     <match>fatal: buffer_get_bignum2: buffer error</match>
     <info>This error may relate to ssh key handling.</info>
     <description>sshd: key error.</description>
-    <group>pci_dss_4.1,pci_dss_10.6.1,gpg13_4.3,</group>
+    <group>pci_dss_4.1,pci_dss_10.6.1,gpg13_4.3,gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="5725" level="0">
@@ -194,7 +194,7 @@
     <if_sid>5700</if_sid>
     <match>failed: Address already in use.</match>
     <description>sshd: Attempt to start sshd when something already bound to the port.</description>
-    <group>pci_dss_10.6.1,pci_dss_2.2.3,gpg13_4.3,</group>
+    <group>pci_dss_10.6.1,pci_dss_2.2.3,gpg13_4.3,gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="5728" level="4">
@@ -202,7 +202,7 @@
     <match>Authentication service cannot retrieve user credentials</match>
     <info>May be related to PAM module errors.</info>
     <description>sshd: Authentication services were not able to retrieve user credentials.</description>
-    <group>authentication_failed,pci_dss_10.2.5,gpg13_7.1,</group>
+    <group>authentication_failed,pci_dss_10.2.5,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
   </rule>
 
   <rule id="5729" level="0">
@@ -215,14 +215,14 @@
     <if_sid>5700</if_sid>
     <regex>error: connect to \S+ port \d+ failed: Connection refused</regex>
     <description>sshd: SSHD is not accepting connections.</description>
-    <group>pci_dss_10.6.1,gpg13_4.3,</group>
+    <group>pci_dss_10.6.1,gpg13_4.3,gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="5731" level="6">
     <if_sid>5700</if_sid>
     <match>AKASSH_Version_Mapper1.</match>
     <description>sshd: SSH Scanning.</description>
-    <group>recon,pci_dss_11.4,</group>
+    <group>recon,pci_dss_11.4,gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="5732" level="0">
@@ -235,7 +235,7 @@
     <if_sid>5700</if_sid>
     <match>Invalid credentials</match>
     <description>sshd: User entered incorrect password.</description>
-    <group>authentication_failures,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,</group>
+    <group>authentication_failures,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
   </rule>
 
   <rule id="5734" level="0">
@@ -262,14 +262,14 @@
     <if_sid>5700</if_sid>
     <match>^fatal: Cannot bind any address.$</match>
     <description>sshd: cannot bind to configured address.</description>
-    <group>pci_dss_10.6.1,gpg13_4.3,</group>
+    <group>pci_dss_10.6.1,gpg13_4.3,gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="5738" level="5">
     <if_sid>5700</if_sid>
     <match>set_loginuid failed opening loginuid$</match>
     <description>sshd: pam_loginuid could not open loginuid.</description>
-    <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,</group>
+    <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
   </rule>
 
   <rule id="5739" level="4">
@@ -294,7 +294,7 @@
     <if_sid>5700</if_sid>
     <match>Connection timed out$</match>
     <description>sshd: connection timed out</description>
-    <group>pci_dss_8.1.5,</group>
+    <group>pci_dss_8.1.5,gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="5743" level="4">
@@ -337,7 +337,7 @@
     <if_sid>5700</if_sid>
     <match>Corrupted MAC on input.</match>
     <description>sshd: corrupted MAC on input</description>
-    <group>pci_dss_10.6.1,gpg13_4.3,</group>
+    <group>pci_dss_10.6.1,gpg13_4.3,gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="5749" level="4">

--- a/rules/0100-solaris_bsm_rules.xml
+++ b/rules/0100-solaris_bsm_rules.xml
@@ -28,27 +28,27 @@
     <if_sid>6102</if_sid>
     <match>^login</match>
     <description>Solaris: Login session succeeded.</description>
-    <group>authentication_success,pci_dss_10.2.5,gpg13_7.8,gpg13_7.9,</group>
+    <group>authentication_success,pci_dss_10.2.5,gpg13_7.8,gpg13_7.9,gdpr_IV_32.2,</group>
   </rule>
 
   <rule id="6104" level="5">
     <if_sid>6101</if_sid>
     <match>^login</match>
     <description>Solaris: Login session failed.</description>
-    <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.8,</group>
+    <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.8,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
   </rule>
 
   <rule id="6105" level="3">
     <if_sid>6102</if_sid>
     <match>^su </match>
     <description>Solaris: User successfully changed UID.</description>
-    <group>authentication_success,pci_dss_10.2.5,gpg13_7.8,gpg13_7.9,</group>
+    <group>authentication_success,pci_dss_10.2.5,gpg13_7.8,gpg13_7.9,gdpr_IV_32.2,</group>
   </rule>
 
   <rule id="6106" level="5">
     <if_sid>6103</if_sid>
     <match>^su </match>
     <description>Solaris: User failed to change UID (user id).</description>
-    <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.8,</group>
+    <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.8,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
   </rule>
 </group>

--- a/rules/0105-asterisk_rules.xml
+++ b/rules/0105-asterisk_rules.xml
@@ -37,42 +37,42 @@
     <if_sid>6201</if_sid>
     <match>Wrong password</match>
     <description>Asterisk: Login session failed.</description>
-    <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,</group>
+    <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
   </rule>
 
   <rule id="6211" level="5">
     <if_sid>6201</if_sid>
     <match>Username/auth name mismatch</match>
     <description>Asterisk: Login session failed (invalid user).</description>
-    <group>invalid_login,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,</group>
+    <group>invalid_login,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
   </rule>
 
   <rule id="6212" level="5">
     <if_sid>6201</if_sid>
     <match>No matching peer found</match>
     <description>Asterisk: Login session failed (invalid extension).</description>
-    <group>invalid_login,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,</group>
+    <group>invalid_login,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
   </rule>
 
   <rule id="6250" level="10" frequency="6" timeframe="300">
     <if_matched_sid>6211</if_matched_sid>
     <same_source_ip />
     <description>Asterisk: Multiple failed logins (user enumeration in process).</description>
-    <group>pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gpg13_7.1,</group>
+    <group>pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
   </rule>
 
   <rule id="6251" level="10" frequency="6" timeframe="300">
     <if_matched_sid>6210</if_matched_sid>
     <same_source_ip />
     <description>Asterisk: Multiple failed logins.</description>
-    <group>pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gpg13_7.1,</group>
+    <group>pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
   </rule>
 
   <rule id="6252" level="10" frequency="6" timeframe="300">
     <if_matched_sid>6212</if_matched_sid>
     <same_source_ip />
     <description>Asterisk: Extension enumeration.</description>
-    <group>pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gpg13_7.1,</group>
+    <group>pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
   </rule>
 
   <!--From Javi Benito jabi.benito@gmail.com-->
@@ -81,7 +81,7 @@
     <if_sid>6201</if_sid>
     <match>No registration for peer</match>
     <description>Asterisk: Login session failed (invalid iax user).</description>
-    <group>invalid_login,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,</group>
+    <group>invalid_login,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
   </rule>
 
   <!--From Javi Benito jabi.benito@gmail.com-->
@@ -89,7 +89,7 @@
     <if_matched_sid>6253</if_matched_sid>
     <same_source_ip />
     <description>Asterisk: Extension IAX Enumeration.</description>
-    <group>pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gpg13_7.1,</group>
+    <group>pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
   </rule>
 
   <!--From Javi Benito jabi.benito@gmail.com-->
@@ -97,7 +97,7 @@
     <if_sid>6202</if_sid>
     <match>Don't know how to respond via</match>
     <description>Asterisk: Possible Registration Hijacking.</description>
-    <group>invalid_login,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gpg13_7.1,</group>
+    <group>invalid_login,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
   </rule>
 
   <!--From Javi Benito jabi.benito@gmail.com-->
@@ -105,7 +105,7 @@
     <if_sid>6201</if_sid>
     <match>failed MD5 authentication</match>
     <description>Asterisk: IAX peer Wrong Password.</description>
-    <group>invalid_login,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,</group>
+    <group>invalid_login,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
   </rule>
 
   <!--From Javi Benito jabi.benito@gmail.com-->
@@ -113,7 +113,7 @@
     <if_matched_sid>6256</if_matched_sid>
     <same_source_ip />
     <description>Asterisk: Multiple failed logins.</description>
-    <group>pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,</group>
+    <group>pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
   </rule>
 
 </group>

--- a/rules/0110-ms_dhcp_rules.xml
+++ b/rules/0110-ms_dhcp_rules.xml
@@ -100,21 +100,21 @@ ID,Date,Time,Description,IP Address,Host Name,MAC Address
 	<if_sid>6300</if_sid>
 	<id>^13</id>
     <description>MS-DHCP: An IP address was found to be in use on the network.</description>
-    <group>dhcp_lease_action,pci_dss_10.6.1,gpg13_4.12,</group>
+    <group>dhcp_lease_action,pci_dss_10.6.1,gpg13_4.12,gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="6308" level="12">
 	<if_sid>6300</if_sid>
 	<id>^14</id>
     <description>MS-DHCP: A lease request could not be satisfied because the scope's address pool was exhausted.</description>
-    <group>service_availability,dhcp_lease_action,pci_dss_10.6.1,gpg13_4.12,</group>
+    <group>service_availability,dhcp_lease_action,pci_dss_10.6.1,gpg13_4.12,gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="6309" level="7">
 	<if_sid>6300</if_sid>
 	<id>^15</id>
     <description>MS-DHCP: A lease was denied.</description>
-    <group>dhcp_lease_action,pci_dss_10.6.1,gpg13_4.12,</group>
+    <group>dhcp_lease_action,pci_dss_10.6.1,gpg13_4.12,gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="6310" level="0">
@@ -157,7 +157,7 @@ ID,Date,Time,Description,IP Address,Host Name,MAC Address
 	<if_sid>6300</if_sid>
 	<id>^22</id>
     <description>MS-DHCP: A BOOTP request could not be satisfied because the scope's  address pool for BOOTP was exhausted.</description>
-    <group>dhcp_lease_action,pci_dss_10.6.1,gpg13_4.12,</group>
+    <group>dhcp_lease_action,pci_dss_10.6.1,gpg13_4.12,gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="6315" level="0">
@@ -192,21 +192,21 @@ ID,Date,Time,Description,IP Address,Host Name,MAC Address
 	<if_sid>6300</if_sid>
 	<id>^31</id>
     <description>MS-DHCP: DNS update failed.</description>
-    <group>dhcp_dns_maintenance,pci_dss_10.6.1,gpg13_4.3,</group>
+    <group>dhcp_dns_maintenance,pci_dss_10.6.1,gpg13_4.3,gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="6320" level="0">
 	<if_sid>6300</if_sid>
 	<id>^32</id>
     <description>MS-DHCP: DNS update successful.</description>
-    <group>dhcp_dns_maintenance,pci_dss_10.6.1,gpg13_4.12,</group>
+    <group>dhcp_dns_maintenance,pci_dss_10.6.1,gpg13_4.12,gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="6323" level="12">
 	<if_sid>6300</if_sid>
 	<id>^33</id>
     <description>MS-DHCP: Packet dropped due to NAP policy.</description>
-    <group>dhcp_lease_action,</group>
+    <group>dhcp_lease_action,gdpr_IV_35.7.d,</group>
 
   </rule>
 
@@ -300,7 +300,7 @@ Server 2008 IPv6 Event ID  Meaning
 	<if_sid>6350</if_sid>
 	<id>^11006</id>
     <description>MS-DHCP: DHCP Decline.</description>
-    <group>dhcp_ipv6,</group>
+    <group>dhcp_ipv6,gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="6358" level="0">
@@ -321,7 +321,7 @@ Server 2008 IPv6 Event ID  Meaning
 	<if_sid>6350</if_sid>
 	<id>^11009</id>
     <description>MS-DHCP: Scope Full.</description>
-    <group>dhcp_ipv6,</group>
+    <group>dhcp_ipv6,gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="6361" level="3">
@@ -335,14 +335,14 @@ Server 2008 IPv6 Event ID  Meaning
 	<if_sid>6350</if_sid>
 	<id>^11011</id>
     <description>MS-DHCP: Stopped.</description>
-    <group>service_availability,</group>
+    <group>service_availability,gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="6363" level="10">
 	<if_sid>6350</if_sid>
 	<id>^11012</id>
     <description>MS-DHCP: Audit log paused.</description>
-    <group>service_availability,pci_dss_10.1,pci_dss_10.2.6,gpg13_10.1,</group>
+    <group>service_availability,pci_dss_10.1,pci_dss_10.2.6,gpg13_10.1,gdpr_IV_30.1.g,</group>
   </rule>
 
 
@@ -350,14 +350,14 @@ Server 2008 IPv6 Event ID  Meaning
 	<if_sid>6350</if_sid>
 	<id>^11013</id>
     <description>MS-DHCP: DHCP Log File.</description>
-    <group>system_error,</group>
+    <group>system_error,gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="6365" level="7">
 	<if_sid>6350</if_sid>
 	<id>^11014</id>
     <description>MS-DHCP: Bad Address.</description>
-    <group>dhcp_ipv6,</group>
+    <group>dhcp_ipv6,gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="6366" level="4">
@@ -414,7 +414,7 @@ Server 2008 IPv6 Event ID  Meaning
 	<if_sid>6350</if_sid>
 	<id>^11023</id>
     <description>MS-DHCP: Service not authorized in AD.</description>
-    <group>dhcp_ipv6,pci_dss_10.6.1,gpg13_4.3,</group>
+    <group>dhcp_ipv6,pci_dss_10.6.1,gpg13_4.3,gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="6374" level="3">
@@ -428,6 +428,6 @@ Server 2008 IPv6 Event ID  Meaning
 	<if_sid>6350</if_sid>
 	<id>^11025</id>
     <description>MS-DHCP: Service has not determined if it is authorized in AD.</description>
-    <group>dhcp_ipv6,pci_dss_10.6.1,gpg13_4.3,</group>
+    <group>dhcp_ipv6,pci_dss_10.6.1,gpg13_4.3,gdpr_IV_35.7.d,</group>
   </rule>
 </group>

--- a/rules/0115-arpwatch_rules.xml
+++ b/rules/0115-arpwatch_rules.xml
@@ -17,28 +17,28 @@
     <options>alert_by_email</options>
     <if_fts />
     <description>Arpwatch new host detected.</description>
-    <group>new_host,pci_dss_10.6.1,</group>
+    <group>new_host,pci_dss_10.6.1,gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="7202" level="9">
     <if_sid>7200</if_sid>
     <match>flip flop </match>
     <description>Arpwatch: "flip flop" message. IP address/MAC relation changing too often.</description>
-    <group>ip_spoof,pci_dss_1.3.4,pci_dss_11.4,</group>
+    <group>ip_spoof,pci_dss_1.3.4,pci_dss_11.4,gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="7203" level="3">
     <if_sid>7200</if_sid>
     <match>reaper: pid </match>
     <description>Arpwatch: exiting.</description>
-    <group>service_availability,pci_dss_10.6.1,gpg13_4.14,</group>
+    <group>service_availability,pci_dss_10.6.1,gpg13_4.14,gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="7204" level="9">
     <if_sid>7200</if_sid>
     <match>changed ethernet address </match>
     <description>Arpwatch: Changed network interface for ip address.</description>
-    <group>ip_spoof,pci_dss_1.3.4,pci_dss_11.4,</group>
+    <group>ip_spoof,pci_dss_1.3.4,pci_dss_11.4,gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="7205" level="0">
@@ -57,21 +57,21 @@
     <if_sid>7200</if_sid>
     <match>/dev/bpf0: Permission denied</match>
     <description>arpwatch probably run with wrong permissions</description>
-    <group>pci_dss_10.6.1,</group>
+    <group>pci_dss_10.6.1,gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="7208" level="1">
     <if_sid>7200</if_sid>
     <match>reused old ethernet address</match>
     <description>Arpwatch: An IP has reverted to an old ethernet address.</description>
-    <group>pci_dss_10.6.1,</group>
+    <group>pci_dss_10.6.1,gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="7209" level="7">
     <if_sid>7200</if_sid>
     <match>ethernet mismatch</match>
     <description>Arpwatch: Possible arpspoofing attempt.</description>
-    <group>ip_spoof,pci_dss_1.3.4,pci_dss_11.4,</group>
+    <group>ip_spoof,pci_dss_1.3.4,pci_dss_11.4,gdpr_IV_35.7.d,</group>
   </rule>
 
 </group>

--- a/rules/0120-symantec-av_rules.xml
+++ b/rules/0120-symantec-av_rules.xml
@@ -21,7 +21,7 @@
   <rule id="7310" level="9">
     <if_sid>7300, 7301</if_sid>
     <id>^5$|^17$</id>
-    <group>virus,pci_dss_5.1,pci_dss_5.2,pci_dss_11.4,gpg13_4.2,</group>
+    <group>virus,pci_dss_5.1,pci_dss_5.2,pci_dss_11.4,gpg13_4.2,gdpr_IV_35.7.d,</group>
     <description>Symantec-AV: Virus detected.</description>
   </rule>
 
@@ -29,7 +29,7 @@
     <if_sid>7300, 7301</if_sid>
     <id>^2$|^3$|^4$|^13$</id>
     <description>Symantec-AV: Virus scan updated,started or stopped.</description>
-    <group>pci_dss_5.1,pci_dss_10.6.1,</group>
+    <group>pci_dss_5.1,pci_dss_10.6.1,gdpr_IV_35.7.d,</group>
   </rule>
 
 </group>

--- a/rules/0125-symantec-ws_rules.xml
+++ b/rules/0125-symantec-ws_rules.xml
@@ -16,21 +16,21 @@
     <if_sid>7400</if_sid>
     <id>^3=2,2=1</id>
     <description>Symantec-WS: Login failed accessing the web proxy.</description>
-    <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_71,</group>
+    <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_71,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
   </rule>
 
   <rule id="7415" level="3">
     <if_sid>7400</if_sid>
     <id>^3=1,2=1</id>
     <description>Symantec-WS: Login success accessing the web proxy.</description>
-    <group>authentication_success,pci_dss_10.2.5,gpg13_7.1,gpg13_7.2,</group>
+    <group>authentication_success,pci_dss_10.2.5,gpg13_7.1,gpg13_7.2,gdpr_IV_32.2,</group>
   </rule>
 
   <rule id="7420" level="3">
     <if_sid>7415</if_sid>
     <user>virtadmin</user>
     <description>Symantec-WS: Admin Login success to the web proxy.</description>
-    <group>authentication_success,pci_dss_10.2.5,gpg13_7.1,gpg13_7.2,</group>
+    <group>authentication_success,pci_dss_10.2.5,gpg13_7.1,gpg13_7.2,gdpr_IV_32.2,</group>
   </rule>
 
   <!-- Example alerting using the url (event id 2=27 is for web access

--- a/rules/0130-trend-osce_rules.xml
+++ b/rules/0130-trend-osce_rules.xml
@@ -15,14 +15,14 @@
   <rule id="7610" level="5">
     <if_sid>7600</if_sid>
     <id>^0|$|^1$|^2$|^33|^10$|^11$|^12$</id>
-    <group>virus,pci_dss_5.1,pci_dss_5.2,pci_dss_11.4,gpg13_4.2,</group>
+    <group>virus,pci_dss_5.1,pci_dss_5.2,pci_dss_11.4,gpg13_4.2,gdpr_IV_35.7.d,</group>
     <description>Trend: Virus detected and cleaned/quarantined/removed</description>
   </rule>
 
   <rule id="7611" level="9">
     <if_sid>7600</if_sid>
     <id>^5$|^6$|^7$|^8$|^14$|^15$|^16$</id>
-    <group>virus,pci_dss_5.1,pci_dss_5.2,pci_dss_11.4,gpg13_4.2,</group>
+    <group>virus,pci_dss_5.1,pci_dss_5.2,pci_dss_11.4,gpg13_4.2,gdpr_IV_35.7.d,</group>
     <description>Trend: Virus detected and unable to clean up.</description>
   </rule>
 
@@ -30,13 +30,13 @@
     <if_sid>7600</if_sid>
     <id>^4$|^13$</id>
     <description>Trend: Virus scan completed with no errors detected.</description>
-    <group>pci_dss_5.1,</group>
+    <group>pci_dss_5.1,gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="7613" level="5">
     <if_sid>7600</if_sid>
     <id>^25$</id>
     <description>Trend: Virus scan passed by found potential security risk.</description>
-    <group>pci_dss_5.1,pci_dss_5.2,pci_dss_11.4,</group>
+    <group>pci_dss_5.1,pci_dss_5.2,pci_dss_11.4,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
   </rule>
 </group>

--- a/rules/0135-hordeimp_rules.xml
+++ b/rules/0135-hordeimp_rules.xml
@@ -28,40 +28,41 @@
     <if_sid>9300</if_sid>
     <match>^[error]</match>
     <description>Horde IMP error message.</description>
+    <group>gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="9304" level="9" ignore="60">
     <if_sid>9300</if_sid>
     <match>^[emergency]</match>
     <description>Horde IMP emergency message.</description>
-    <group>service_availability,</group>
+    <group>service_availability,gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="9305" level="3">
     <if_sid>9302</if_sid>
     <match>Login success for </match>
     <description>Horde IMP successful login.</description>
-    <group>authentication_success,pci_dss_10.2.5,gpg13_7.1,gpg13_7.2,</group>
+    <group>authentication_success,pci_dss_10.2.5,gpg13_7.1,gpg13_7.2,gdpr_IV_32.2,</group>
   </rule>
 
   <rule id="9306" level="5">
     <if_sid>9303</if_sid>
     <match>FAILED LOGIN </match>
     <description>Horde IMP Failed login.</description>
-    <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,</group>
+    <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
   </rule>
 
   <rule id="9351" level="10" frequency="6" timeframe="120">
     <if_matched_sid>9306</if_matched_sid>
     <same_source_ip />
     <description>Horde brute force (multiple failed logins).</description>
-    <group>authentication_failures,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gpg13_7.1,</group>
+    <group>authentication_failures,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
   </rule>
 
   <rule id="9352" level="10" frequency="4" timeframe="320">
     <if_matched_sid>9304</if_matched_sid>
     <description>Multiple Horde emergency messages.</description>
-    <group>service_availability,pci_dss_10.6.1,gpg13_4.1,</group>
+    <group>service_availability,pci_dss_10.6.1,gpg13_4.1,gdpr_IV_35.7.d,</group>
   </rule>
 
 </group>

--- a/rules/0140-roundcube_rules.xml
+++ b/rules/0140-roundcube_rules.xml
@@ -17,20 +17,20 @@
     <if_sid>9400</if_sid>
     <match>failed (LOGIN)| Login failed | Authentication failed| Failed login </match>
     <description>Roundcube authentication failed.</description>
-    <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,</group>
+    <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
   </rule>
 
   <rule id="9402" level="3">
     <if_sid>9400</if_sid>
     <match>Successful login</match>
     <description>Roundcube authentication succeeded.</description>
-    <group>authentication_success,pci_dss_10.2.5,gpg13_7.1,gpg13_7.2,</group>
+    <group>authentication_success,pci_dss_10.2.5,gpg13_7.1,gpg13_7.2,gdpr_IV_32.2,</group>
   </rule>
 
   <rule id="9403" level="10" frequency="6" timeframe="120">
     <if_matched_sid>9401</if_matched_sid>
     <same_source_ip />
     <description>Roundcube brute force (multiple failed logins).</description>
-    <group>authentication_failures,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gpg13_7.1,</group>
+    <group>authentication_failures,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
   </rule>
 </group>

--- a/rules/0145-wordpress_rules.xml
+++ b/rules/0145-wordpress_rules.xml
@@ -16,14 +16,14 @@
     <if_sid>9500</if_sid>
     <match>User authentication failed</match>
     <description>Wordpress authentication failed.</description>
-    <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,</group>
+    <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
   </rule>
 
   <rule id="9502" level="3">
     <if_sid>9500</if_sid>
     <match>User logged in</match>
     <description>Wordpress authentication succeeded.</description>
-    <group>authentication_success,pci_dss_10.2.5,gpg13_7.1,gpg13_7.2,</group>
+    <group>authentication_success,pci_dss_10.2.5,gpg13_7.1,gpg13_7.2,gdpr_IV_32.2,</group>
   </rule>
 
   <rule id="9503" level="3">
@@ -48,14 +48,14 @@
     <if_sid>9500</if_sid>
     <match>Warning: IDS:</match>
     <description>Attack against Wordpress detected.</description>
-    <group>pci_dss_11.4,</group>
+    <group>pci_dss_11.4,gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="9551" level="10">
     <if_matched_sid>9501</if_matched_sid>
     <same_source_ip />
     <description>Multiple wordpress authentication failures.</description>
-    <group>authentication_failures,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gpg13_7.1,</group>
+    <group>authentication_failures,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
   </rule>
 
 </group>

--- a/rules/0150-cimserver_rules.xml
+++ b/rules/0150-cimserver_rules.xml
@@ -17,13 +17,13 @@
     <if_sid>9600</if_sid>
     <match>Authentication failed</match>
     <description>cimserver: Compaq Insight Manager authentication failure.</description>
-    <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.8,</group>
+    <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.8,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
   </rule>
 
   <rule id="9611" level="12">
     <if_sid>9600</if_sid>
     <match>Server stopped</match>
     <description>cimserver: Compaq Insight Manager stopped.</description>
-    <group>service_availability,pci_dss_10.6.1,gpg13_4.14,</group>
+    <group>service_availability,pci_dss_10.6.1,gpg13_4.14,gdpr_IV_35.7.d,</group>
   </rule>
 </group>

--- a/rules/0155-dovecot_rules.xml
+++ b/rules/0155-dovecot_rules.xml
@@ -16,21 +16,21 @@
   <if_sid>9700</if_sid>
   <match>login: Login: </match>
   <description>Dovecot Authentication Success.</description>
-  <group>authentication_success,pci_dss_10.2.5,gpg13_7.1,gpg13_7.2,</group>
+  <group>authentication_success,pci_dss_10.2.5,gpg13_7.1,gpg13_7.2,gdpr_IV_32.2,</group>
 </rule>
 
 <rule id="9702" level="5">
   <if_sid>9700</if_sid>
   <match>Password mismatch$</match>
   <description>Dovecot Authentication Failed.</description>
-  <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,</group>
+  <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
 </rule>
 
 <rule id="9703" level="3">
   <if_sid>9700</if_sid>
   <match>starting up</match>
   <description>Dovecot is Starting Up.</description>
-  <group>pci_dss_10.6.1,gpg13_4.14,</group>
+  <group>pci_dss_10.6.1,gpg13_4.14,gdpr_IV_35.7.d,</group>
 </rule>
 
 <rule id="9704" level="2">
@@ -43,21 +43,21 @@
   <if_sid>9700</if_sid>
   <match>user not found|User not known|unknown user|auth failed</match>
   <description>Dovecot Invalid User Login Attempt.</description>
-  <group>invalid_login,authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,</group>
+  <group>invalid_login,authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
 </rule>
 
 <rule id="9706" level="3">
   <if_sid>9700</if_sid>
   <match>: Disconnected: </match>
   <description>Dovecot Session Disconnected.</description>
-  <group>pci_dss_10.2.5,pci_dss_8.1.5,pci_dss_8.1.8,gpg13_7.1,</group>
+  <group>pci_dss_10.2.5,pci_dss_8.1.5,pci_dss_8.1.8,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
 </rule>
 
 <rule id="9707" level="5">
   <if_sid>9700</if_sid>
   <match>: Aborted login</match>
   <description>Dovecot Aborted Login.</description>
-  <group>invalid_login,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,</group>
+  <group>invalid_login,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
 </rule>
 
 
@@ -66,14 +66,14 @@
   <if_matched_sid>9702</if_matched_sid>
   <same_source_ip />
   <description>Dovecot Multiple Authentication Failures.</description>
-  <group>authentication_failures,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gpg13_7.1,</group>
+  <group>authentication_failures,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
 </rule>
 
 <rule id="9751" level="10" frequency="6" timeframe="240">
   <if_matched_sid>9705</if_matched_sid>
   <same_source_ip />
   <description>Dovecot brute force attack (multiple auth failures).</description>
-  <group>authentication_failures,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gpg13_7.1,</group>
+  <group>authentication_failures,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
 </rule>
 
 <rule id="9770" level="0">
@@ -85,7 +85,7 @@
   <if_sid>9770</if_sid>
   <match>user not found|User not known|unknown user|auth failed</match>
   <description>Dovecot Invalid User Login Attempt.</description>
-  <group>invalid_login,authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,</group>
+  <group>invalid_login,authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
 </rule>
 
 </group>

--- a/rules/0160-vmpop3d_rules.xml
+++ b/rules/0160-vmpop3d_rules.xml
@@ -15,7 +15,7 @@
   <rule id="9801" level="5">
     <if_sid>9800</if_sid>
     <match>failed auth</match>
-    <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,</group>
+    <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
     <description>vm-pop3d: Login failed accessing the pop3 server.</description>
   </rule>
 
@@ -23,7 +23,7 @@
     <if_matched_sid>9801</if_matched_sid>
     <same_source_ip />
     <description>vm-pop3d: POP3 brute force (multiple failed logins).</description>
-    <group>authentication_failures,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,</group>
+    <group>authentication_failures,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
   </rule>
 
 </group>

--- a/rules/0165-vpopmail_rules.xml
+++ b/rules/0165-vpopmail_rules.xml
@@ -16,28 +16,28 @@
   <rule id="9901" level="5">
     <if_sid>9900</if_sid>
     <match> password fail </match>
-    <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,</group>
+    <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
     <description>vpopmail: Login failed.</description>
   </rule>
 
   <rule id="9902" level="5">
     <if_sid>9900</if_sid>
     <match> vpopmail user not found </match>
-    <group>invalid_login,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,</group>
+    <group>invalid_login,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
     <description>vpopmail: Attempt to login to vpopmail with invalid username.</description>
   </rule>
 
   <rule id="9903" level="5">
     <if_sid>9900</if_sid>
     <match> null password given </match>
-    <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,</group>
+    <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
     <description>vpopmail: Attempt to login to vpopmail with empty password.</description>
   </rule>
 
   <rule id="9904" level="3">
     <if_sid>9900</if_sid>
     <match> login success </match>
-    <group>authentication_success,pci_dss_10.2.5,gpg13_7.1,gpg13_7.2,</group>
+    <group>authentication_success,pci_dss_10.2.5,gpg13_7.1,gpg13_7.2,gdpr_IV_32.2,</group>
     <description>vpopmail: successful login.</description>
   </rule>
 
@@ -45,21 +45,21 @@
     <if_matched_sid>9901</if_matched_sid>
     <same_source_ip />
     <description>vpopmail: brute force (multiple failed logins).</description>
-    <group>authentication_failures,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gpg13_7.1,</group>
+    <group>authentication_failures,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
   </rule>
 
   <rule id="9952" level="10" frequency="8" timeframe="240">
     <if_matched_sid>9902</if_matched_sid>
     <same_source_ip />
     <description>vpopmail: brute force (email harvesting).</description>
-    <group>authentication_failures,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gpg13_7.1,</group>
+    <group>authentication_failures,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
   </rule>
 
   <rule id="9953" level="10" frequency="8" timeframe="240">
     <if_matched_sid>9903</if_matched_sid>
     <same_source_ip />
     <description>vpopmail: brute force (empty password).</description>
-    <group>authentication_failures,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gpg13_7.1,</group>
+    <group>authentication_failures,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
   </rule>
 
 </group>

--- a/rules/0170-ftpd_rules.xml
+++ b/rules/0170-ftpd_rules.xml
@@ -17,7 +17,7 @@
     <if_sid>11100</if_sid>
     <match>FTP LOGIN REFUSED</match>
     <description>FTPD: connection refused.</description>
-    <group>authentication_failed,access_denied,pci_dss_10.2.4,pci_dss_10.2.5,</group>
+    <group>authentication_failed,access_denied,pci_dss_10.2.4,pci_dss_10.2.5,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
   </rule>
 
   <rule id="11102" level="0">
@@ -47,14 +47,14 @@
   <rule id="11106" level="3">
     <if_sid>11100</if_sid>
     <match>FTP LOGIN FROM|connection from|connect from</match>
-    <group>connection_attempt,pci_dss_10.2.1,</group>
+    <group>connection_attempt,pci_dss_10.2.1,gdpr_IV_35.7.d,</group>
     <description>FTPD: Remote host connected to FTP server.,</description>
   </rule>
 
   <rule id="11107" level="5">
     <if_sid>11100</if_sid>
     <match>refused connect from</match>
-    <group>access_denied,pci_dss_10.2.4,</group>
+    <group>access_denied,pci_dss_10.2.4,gdpr_IV_35.7.d,</group>
     <description>FTPD: Connection blocked by Tcp Wrappers.</description>
   </rule>
 
@@ -69,34 +69,34 @@
     <if_sid>11100</if_sid>
     <match>repeated login failures</match>
     <description>FTPD: Multiple FTP failed login attempts.</description>
-    <group>authentication_failures,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gpg13_7.1,</group>
+    <group>authentication_failures,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
   </rule>
 
   <rule id="11110" level="3">
     <if_sid>11100</if_sid>
     <match>timed out after</match>
     <description>FTPD: User disconnected due to time out.</description>
-    <group>pci_dss_8.1.5,</group>
+    <group>pci_dss_8.1.5,gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="11111" level="9">
     <if_sid>11100</if_sid>
     <match>PAM_ERROR_MSG: Account is disabled</match>
     <description>FTPD: Attempt to login with disabled account.</description>
-    <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_8.1.4,gpg13_7.1,</group>
+    <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_8.1.4,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
   </rule>
 
   <rule id="11112" level="5">
     <if_sid>11100</if_sid>
     <match>^Failed authentication from</match>
     <description>FTPD: authentication failure.</description>
-    <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,</group>
+    <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
   </rule>
 
   <rule id="11113" level="5">
     <if_sid>11100</if_sid>
     <regex>^login \S+ from \S+ failed</regex>
     <description>FTPD: authentication failure.</description>
-    <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,</group>
+    <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
   </rule>
 </group>

--- a/rules/0175-proftpd_rules.xml
+++ b/rules/0175-proftpd_rules.xml
@@ -16,7 +16,7 @@
     <if_sid>11200</if_sid>
     <match>FTP session opened.$</match>
     <description>proftpd: FTP session opened.</description>
-    <group>connection_attempt,pci_dss_10.2.5,</group>
+    <group>connection_attempt,pci_dss_10.2.5,gdpr_IV_32.2,</group>
   </rule>
 
   <rule id="11202" level="0">
@@ -29,35 +29,35 @@
     <if_sid>11200</if_sid>
     <match> no such user </match>
     <description>proftpd: Attempt to login using a non-existent user.</description>
-    <group>invalid_login,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,</group>
+    <group>invalid_login,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
   </rule>
 
   <rule id="11204" level="5">
     <if_sid>11200</if_sid>
     <match>Incorrect password.$|Login failed</match>
     <description>proftpd: Login failed accessing the FTP server</description>
-    <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,</group>
+    <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
   </rule>
 
   <rule id="11205" level="3">
     <if_sid>11200</if_sid>
     <match>Login successful</match>
     <description>proftpd: FTP Authentication success.</description>
-    <group>authentication_success,pci_dss_10.2.5,gpg13_7.1,gpg13_7.2,</group>
+    <group>authentication_success,pci_dss_10.2.5,gpg13_7.1,gpg13_7.2,gdpr_IV_32.2,</group>
   </rule>
 
   <rule id="11206" level="5">
     <if_sid>11200</if_sid>
     <regex>Connection from \S+ [\S+] denied</regex>
     <description>proftpd: Connection denied by ProFTPD configuration.</description>
-    <group>access_denied,pci_dss_10.2.4,pci_dss_10.2.5,</group>
+    <group>access_denied,pci_dss_10.2.4,pci_dss_10.2.5,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
   </rule>
 
   <rule id="11207" level="5">
     <if_sid>11200</if_sid>
     <match>refused connect from</match>
     <description>proftpd: Connection refused by TCP Wrappers.</description>
-    <group>access_denied,pci_dss_10.2.4,pci_dss_10.2.5,</group>
+    <group>access_denied,pci_dss_10.2.4,pci_dss_10.2.5,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
   </rule>
 
   <rule id="11208" level="4">
@@ -74,14 +74,14 @@
     <description> keep state of FTP traffic.</description>
     <info type="link">http://www.kb.cert.org/vuls/id/328867</info>
     <info type="text">US-Cert Note VU#328867: Multiple vendors' firewalls do not adequately keep state of FTP traffic</info>
-    <group>pci_dss_10.6.1,pci_dss_11.4,</group>
+    <group>pci_dss_10.6.1,pci_dss_11.4,gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="11210" level="10">
     <if_sid>11200</if_sid>
     <match>Maximum login attempts </match>
     <description>proftpd: Multiple failed login attempts.</description>
-    <group>authentication_failures,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gpg13_7.1,</group>
+    <group>authentication_failures,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
   </rule>
 
   <rule id="11211" level="4">
@@ -100,28 +100,28 @@
     <if_sid>11200</if_sid>
     <match>connect from </match>
     <description>proftpd: Remote host connected to FTP server.</description>
-    <group>connection_attempt,pci_dss_10.6.1,</group>
+    <group>connection_attempt,pci_dss_10.6.1,gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="11214" level="3">
     <if_sid>11200</if_sid>
     <match>FTP no transfer timeout, disconnected</match>
     <description>proftpd: Remote host disconnected due to inactivity.</description>
-    <group>pci_dss_8.1.5,</group>
+    <group>pci_dss_8.1.5,gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="11215" level="3">
     <if_sid>11200</if_sid>
     <match>FTP login timed out, disconnected</match>
     <description>proftpd: Remote host disconnected due to login time out.</description>
-    <group>pci_dss_8.1.5,</group>
+    <group>pci_dss_8.1.5,gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="11216" level="3">
     <if_sid>11200</if_sid>
     <match>FTP session idle timeout, disconnected</match>
     <description>proftpd: Remote host disconnected due to time out.</description>
-    <group>pci_dss_8.1.5,</group>
+    <group>pci_dss_8.1.5,gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="11217" level="3">
@@ -134,14 +134,14 @@
     <if_sid>11200</if_sid>
     <match>ProFTPD terminating (signal 11)</match>
     <description>proftpd: FTP process crashed.</description>
-    <group>service_availability,pci_dss_10.6.1,</group>
+    <group>service_availability,pci_dss_10.6.1,gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="11219" level="12">
     <if_sid>11200</if_sid>
     <match>Reallocating sreaddir buffer</match>
     <description>proftpd: FTP server Buffer overflow attempt.</description>
-    <group>pci_dss_6.5.2,pci_dss_11.4,pci_dss_6.2,</group>
+    <group>pci_dss_6.5.2,pci_dss_11.4,pci_dss_6.2,gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="11220" level="4">
@@ -169,21 +169,21 @@
     <if_matched_sid>11204</if_matched_sid>
     <same_source_ip />
     <description>proftpd: FTP brute force (multiple failed logins).</description>
-    <group>authentication_failures,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,</group>
+    <group>authentication_failures,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
   </rule>
 
   <rule id="11252" level="10" frequency="10" timeframe="60">
     <if_matched_sid>11201</if_matched_sid>
     <same_source_ip />
     <description>proftpd: Multiple connection attempts from same source.</description>
-    <group>recon,pci_dss_11.4,</group>
+    <group>recon,pci_dss_11.4,gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="11253" level="10" frequency="10" timeframe="120">
     <if_matched_sid>11215</if_matched_sid>
     <same_source_ip />
     <description>proftpd: Multiple timed out logins from same source.</description>
-    <group>pci_dss_10.6.1,</group>
+    <group>pci_dss_10.6.1,gdpr_IV_35.7.d,</group>
   </rule>
 
 </group>

--- a/rules/0180-pure-ftpd_rules.xml
+++ b/rules/0180-pure-ftpd_rules.xml
@@ -17,21 +17,21 @@
     <if_sid>11300</if_sid>
     <match>[INFO] New connection from</match>
     <description>pure-ftpd: New FTP connection.</description>
-    <group>connection_attempt,pci_dss_10.6.1,</group>
+    <group>connection_attempt,pci_dss_10.6.1,gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="11302" level="5">
     <if_sid>11300</if_sid>
     <match>[WARNING] Authentication failed for user</match>
     <description>pure-ftpd: FTP Authentication failed.</description>
-    <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,</group>
+    <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
   </rule>
 
   <rule id="11303" level="0">
     <if_sid>11300</if_sid>
     <match> [INFO] Logout| [INFO] Timeout</match>
     <description>pure-ftpd: FTP user logout/timeout</description>
-    <group>pci_dss_8.1.5,gpg13_7.1,gpg13_7.2,</group>
+    <group>pci_dss_8.1.5,gpg13_7.1,gpg13_7.2,gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="11304" level="0">
@@ -44,27 +44,27 @@
     <if_sid>11300</if_sid>
     <match>[INFO] Can't change directory to</match>
     <description>pure-ftpd: Attempt to access invalid directory</description>
-    <group>pci_dss_10.2.4,</group>
+    <group>pci_dss_10.2.4,gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="11306" level="10" frequency="6" timeframe="120">
     <if_matched_sid>11302</if_matched_sid>
     <description>pure-ftpd: FTP brute force (multiple failed logins).</description>
-    <group>authentication_failures,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gpg13_7.1,</group>
+    <group>authentication_failures,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
   </rule>
 
   <rule id="11307" level="10" frequency="6" timeframe="60">
     <if_matched_sid>11301</if_matched_sid>
     <same_source_ip />
     <description>pure-ftpd: Multiple connection attempts from same source.</description>
-    <group>recon,pci_dss_11.4,</group>
+    <group>recon,pci_dss_11.4,gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="11309" level="3">
     <if_sid>11300</if_sid>
     <match>[INFO] \S+ is now logged in| is now logged in</match>
     <description>pure-ftpd: FTP Authentication success.</description>
-    <group>authentication_success,pci_dss_10.2.5,gpg13_7.1,gpg13_7.2,</group>
+    <group>authentication_success,pci_dss_10.2.5,gpg13_7.1,gpg13_7.2,gdpr_IV_32.2,</group>
   </rule>
 
   <rule id="11310" level="0">

--- a/rules/0185-vsftpd_rules.xml
+++ b/rules/0185-vsftpd_rules.xml
@@ -25,14 +25,14 @@
     <if_sid>11400</if_sid>
     <match>OK LOGIN: </match>
     <description>vsftpd: FTP Authentication success.</description>
-    <group>authentication_success,pci_dss_10.2.5,gpg13_7.1,gpg13_7.2,</group>
+    <group>authentication_success,pci_dss_10.2.5,gpg13_7.1,gpg13_7.2,gdpr_IV_32.2,</group>
   </rule>
 
   <rule id="11403" level="5">
     <if_sid>11400</if_sid>
     <match>FAIL LOGIN: </match>
     <description>vsftpd: Login failed accessing the FTP server.</description>
-    <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,</group>
+    <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
   </rule>
 
   <rule id="11404" level="0">
@@ -45,7 +45,7 @@
     <if_matched_sid>11403</if_matched_sid>
     <same_source_ip />
     <description>vsftpd: FTP brute force (multiple failed logins).</description>
-    <group>authentication_failures,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gpg13_7.1,</group>
+    <group>authentication_failures,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
   </rule>
 
   <rule id="11452" level="10" frequency="10" timeframe="60">
@@ -53,7 +53,7 @@
     <same_source_ip />
     <description>vsftpd: Multiple FTP connection attempts from </description>
     <description>same source IP.</description>
-    <group>recon,pci_dss_11.4,</group>
+    <group>recon,pci_dss_11.4,gdpr_IV_35.7.d,</group>
   </rule>
 
 </group>

--- a/rules/0190-ms_ftpd_rules.xml
+++ b/rules/0190-ms_ftpd_rules.xml
@@ -24,7 +24,7 @@
     <action>PASS</action>
     <id>530</id>
     <description>MS-FTP: FTP Authentication failed.</description>
-    <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,</group>
+    <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
   </rule>
 
   <rule id="11503" level="3">
@@ -32,7 +32,7 @@
     <action>PASS</action>
     <id>230</id>
     <description>MS-FTP: FTP Authentication success.</description>
-    <group>authentication_success,pci_dss_10.2.5,gpg13_7.1,gpg13_7.2,</group>
+    <group>authentication_success,pci_dss_10.2.5,gpg13_7.1,gpg13_7.2,gdpr_IV_32.2,</group>
   </rule>
 
   <rule id="11504" level="4">
@@ -44,20 +44,20 @@
   <rule id="11510" level="10" frequency="6" timeframe="120">
     <if_matched_sid>11502</if_matched_sid>
     <description>MS-FTP: FTP brute force (multiple failed logins).</description>
-    <group>authentication_failures,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gpg13_7.1,</group>
+    <group>authentication_failures,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
   </rule>
 
   <rule id="11511" level="10" frequency="8" timeframe="30">
     <if_matched_sid>11501</if_matched_sid>
     <same_source_ip />
     <description>MS-FTP: Multiple connection attempts from same source.</description>
-    <group>recon,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,</group>
+    <group>recon,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
   </rule>
 
   <rule id="11512" level="10" frequency="6" timeframe="120">
     <if_matched_sid>11504</if_matched_sid>
     <same_source_ip />
     <description>MS-FTP: Multiple FTP errors from same source.</description>
-    <group>pci_dss_10.6.1,</group>
+    <group>pci_dss_10.6.1,gdpr_IV_35.7.d,</group>
   </rule>
 </group>

--- a/rules/0195-named_rules.xml
+++ b/rules/0195-named_rules.xml
@@ -16,14 +16,14 @@
     <if_sid>12100</if_sid>
     <match>dropping source port zero packet from</match>
     <description>Invalid DNS packet. Possibility of attack.</description>
-    <group>invalid_access,pci_dss_10.2.4,pci_dss_11.4,</group>
+    <group>invalid_access,pci_dss_10.2.4,pci_dss_11.4,gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="12102" level="9">
     <if_sid>12100</if_sid>
     <match>denied AXFR from</match>
     <description>Failed attempt to perform a zone transfer.</description>
-    <group>access_denied,pci_dss_10.2.4,pci_dss_11.4,</group>
+    <group>access_denied,pci_dss_10.2.4,pci_dss_11.4,gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="12103" level="4">
@@ -32,7 +32,7 @@
     <description>DNS update denied. </description>
     <description>Generally mis-configuration.</description>
     <info type="link">http://seclists.org/incidents/2000/May/217</info>
-    <group>client_misconfig,pci_dss_10.2.4,</group>
+    <group>client_misconfig,pci_dss_10.2.4,gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="12104" level="4">
@@ -52,14 +52,14 @@
     <if_sid>12100</if_sid>
     <match>refused notify from non-master</match>
     <description>DNS configuration error.</description>
-	<group>system_error,pci_dss_10.6.1,gpg13_4.3,</group>
+	<group>system_error,pci_dss_10.6.1,gpg13_4.3,gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="12107" level="0">
     <if_sid>12100</if_sid>
     <regex>update \S+ denied</regex>
     <description>DNS update using RFC2136 Dynamic protocol.</description>
-    <group>pci_dss_10.2.4,pci_dss_10.6.1,</group>
+    <group>pci_dss_10.2.4,pci_dss_10.6.1,gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="12108" level="5">
@@ -67,14 +67,14 @@
     <match>query (cache) denied|: query (cache)</match>
     <description>Query cache denied (probably config error).</description>
     <info type="link">http://www.reedmedia.net/misc/dns/errors.html</info>
-	<group>system_error,pci_dss_10.2.4,pci_dss_10.6.1,gpg13_4.3,connection_attempt,</group>
+	<group>system_error,pci_dss_10.2.4,pci_dss_10.6.1,gpg13_4.3,connection_attempt,gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="12109" level="12">
     <if_sid>12100</if_sid>
     <match>exiting (due to fatal error)</match>
     <description>Named fatal error. DNS service going down.</description>
-    <group>service_availability,pci_dss_10.6.1,gpg13_4.1,</group>
+    <group>service_availability,pci_dss_10.6.1,gpg13_4.1,gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="12110" level="8">
@@ -88,20 +88,20 @@
   <rule id="12111" level="8">
     <regex>^transfer of \S+ from \S+ failed while receiving \S+ REFUSED</regex>
     <description>Unable to perform zone transfer.</description>
-    <group>system_error,pci_dss_10.6.1,gpg13_4.3,</group>
+    <group>system_error,pci_dss_10.6.1,gpg13_4.3,gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="12112" level="4">
     <regex>^zone \S+: expired</regex>
     <description>Zone transfer error.</description>
-    <group>pci_dss_10.6.1,gpg13_4.3,</group>
+    <group>pci_dss_10.6.1,gpg13_4.3,gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="12113" level="0">
     <if_sid>12100</if_sid>
     <match>zone transfer deferred due to quota</match>
     <description>Zone transfer deferred.</description>
-    <group>pci_dss_10.6.1,</group>
+    <group>pci_dss_10.6.1,gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="12114" level="1">
@@ -121,7 +121,7 @@
     <match>syntax error near|</match>
     <match>reloading configuration failed: unexpected token</match>
     <description>Syntax error in a named configuration file.</description>
-	<group>pci_dss_10.6.1,gpg13_4.3,</group>
+	<group>pci_dss_10.6.1,gpg13_4.3,gdpr_IV_35.7.d,</group>
   </rule>
 
 
@@ -129,7 +129,7 @@
     <if_sid>12100</if_sid>
     <regex>refresh: retry limit for master \S+ exceeded</regex>
     <description>Zone transfer rety limit exceeded</description>
-    <group>pci_dss_10.6.1,</group>
+    <group>pci_dss_10.6.1,gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="12118" level="1">
@@ -166,21 +166,21 @@
     <if_sid>12100</if_sid>
     <match>already exists previous definition</match>
     <description>Zone has been duplicated</description>
-	<group>pci_dss_10.6.1,</group>
+	<group>pci_dss_10.6.1,gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="12125" level="3">
     <if_sid>12100</if_sid>
     <match>reloading configuration failed: unexpected end of input</match>
     <description>BIND Configuration error.</description>
-	<group>pci_dss_10.6.1,gpg13_4.3,</group>
+	<group>pci_dss_10.6.1,gpg13_4.3,gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="12126" level="0">
     <if_sid>12100</if_sid>
     <regex>zone \S+: \(master\) removed</regex>
     <description>Zone has been removed from a master server</description>
-	<group>pci_dss_10.6.1,</group>
+	<group>pci_dss_10.6.1,gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="12127" level="1">
@@ -200,21 +200,21 @@
     <if_sid>12128</if_sid>
     <match>failed to connect: connection refused</match>
     <description>Zone transfer failed, unable to connect to master.</description>
-    <group>pci_dss_10.6.1,</group>
+    <group>pci_dss_10.6.1,gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="12130" level="2">
     <if_sid>12100</if_sid>
     <match>IPv6 interfaces failed</match>
     <description>Could not listen on IPv6 interface.</description>
-	<group>pci_dss_10.6.1,</group>
+	<group>pci_dss_10.6.1,gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="12131" level="2">
     <if_sid>12100</if_sid>
     <match>failed; interface ignored</match>
     <description>Could not bind to an interface.</description>
-	<group>pci_dss_10.6.1,</group>
+	<group>pci_dss_10.6.1,gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="12132" level="0">
@@ -227,14 +227,14 @@
     <if_sid>12100</if_sid>
     <regex>open: \S+: permission denied$</regex>
     <description>Could not open configuration file, permission denied.</description>
-	<group>pci_dss_10.2.4,</group>
+	<group>pci_dss_10.2.4,gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="12134" level="4">
     <if_sid>12100</if_sid>
     <match>loading configuration: permission denied</match>
     <description>Could not open configuration file, permission denied.</description>
-	<group>pci_dss_10.2.4,</group>
+	<group>pci_dss_10.2.4,gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="12135" level="0">
@@ -247,7 +247,7 @@
     <if_sid>12128</if_sid>
     <match>failed to connect: host unreachable</match>
     <description>Master appears to be down.</description>
-    <group>pci_dss_10.6.1,</group>
+    <group>pci_dss_10.6.1,gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="12137" level="0">
@@ -296,14 +296,14 @@
     <if_sid>12100</if_sid>
     <match>reloading configuration failed: out of memory</match>
     <description>Server does not have enough memory to reload the configuration.</description>
-    <group>pci_dss_10.6.1,gpg13_4.1,</group>
+    <group>pci_dss_10.6.1,gpg13_4.1,gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="12145" level="1">
     <if_sid>12100</if_sid>
     <regex>zone transfer \S+ denied</regex>
     <description>zone transfer denied</description>
-    <group>pci_dss_10.6.1,pci_dss_10.2.4,</group>
+    <group>pci_dss_10.6.1,pci_dss_10.2.4,gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="12146" level="0">

--- a/rules/0200-smbd_rules.xml
+++ b/rules/0200-smbd_rules.xml
@@ -22,7 +22,7 @@
     <if_sid>13100</if_sid>
     <match>Denied connection from|Connection denied from</match>
     <description>Samba connection denied.</description>
-    <group>access_denied,pci_dss_10.2.4,</group>
+    <group>access_denied,pci_dss_10.2.4,gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="13103" level="0">
@@ -35,7 +35,7 @@
     <if_sid>13100</if_sid>
     <match>Permission denied--</match>
     <description>Samba: User action denied by configuration.</description>
-    <group>access_denied,pci_dss_10.2.4,pci_dss_10.2.5,</group>
+    <group>access_denied,pci_dss_10.2.4,pci_dss_10.2.5,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
   </rule>
 
   <rule id="13105" level="3">
@@ -53,21 +53,21 @@
     <if_sid>13100</if_sid>
     <match>smbd is already running</match>
     <description>Samba: An attempt has been made to start smbd but the process is already running.</description>
-    <group>pci_dss_10.6.1,</group>
+    <group>pci_dss_10.6.1,gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="13109" level="1">
     <if_sid>13106</if_sid>
     <match>nmbd is already running</match>
     <description>Samba: An attempt has been made to start nmbd but the process is already running.</description>
-    <group>pci_dss_10.6.1,</group>
+    <group>pci_dss_10.6.1,gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="13110" level="3">
     <if_sid>13100</if_sid>
     <match>Connection denied from</match>
     <description>Samba: Connection was denied.</description>
-    <group>pci_dss_10.2.4,</group>
+    <group>pci_dss_10.2.4,gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="13111" level="3">
@@ -81,7 +81,7 @@
     <match>gvfsd-smb</match>
     <regex>segfault at \S+ ip \S+ sp \S+ error \d+ in</regex>
     <description>Samba: Segfault in gvfs-smb.</description>
-    <group>pci_dss_6.5.2,pci_dss_11.4,pci_dss_6.2,</group>
+    <group>pci_dss_6.5.2,pci_dss_11.4,pci_dss_6.2,gdpr_IV_35.7.d,</group>
   </rule>
 
 </group>

--- a/rules/0205-racoon_rules.xml
+++ b/rules/0205-racoon_rules.xml
@@ -15,7 +15,7 @@
   <rule id="14101" level="5">
     <decoded_as>racoon-failed</decoded_as>
     <description>racoon: VPN authentication failed.</description>
-    <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,</group>
+    <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
   </rule>
 
   <rule id="14110" level="0">
@@ -39,7 +39,7 @@
   <rule id="14120" level="3">
     <if_sid>14110</if_sid>
     <match>ISAKMP-SA established </match>
-    <group>authentication_success,pci_dss_10.2.5,</group>
+    <group>authentication_success,pci_dss_10.2.5,gdpr_IV_32.2,</group>
     <description>racoon: VPN established.</description>
   </rule>
 
@@ -65,6 +65,6 @@
     <if_matched_sid>14101</if_matched_sid>
     <same_source_ip />
     <description>racoon: Multiple failed VPN logins.</description>
-    <group>pci_dss_11.4,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,</group>
+    <group>pci_dss_11.4,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
   </rule>
 </group>

--- a/rules/0210-vpn_concentrator_rules.xml
+++ b/rules/0210-vpn_concentrator_rules.xml
@@ -16,14 +16,14 @@
     <if_sid>14200</if_sid>
     <id>^IKE/52$</id>
     <description>CiscoVPN: VPN authentication successful.</description>
-    <group>authentication_success,pci_dss_10.2.5,gpg13_7.1,gpg13_7.2,</group>
+    <group>authentication_success,pci_dss_10.2.5,gpg13_7.1,gpg13_7.2,gdpr_IV_32.2,</group>
   </rule>
 
   <rule id="14202" level="5">
     <if_sid>14200</if_sid>
     <id>^AUTH/5$|^AUTH/9$|^IKE/167$|^PPP/9$|^SSH/33$|^PSH/23$</id>
     <description>CiscoVPN: VPN authentication failed.</description>
-    <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,</group>
+    <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
   </rule>
 
   <rule id="14203" level="4">
@@ -31,13 +31,13 @@
     <id>^HTTP/47$|^SSH/16$</id>
     <options>alert_by_email</options>
     <description>CiscoVPN: VPN Admin authentication successful.</description>
-    <group>authentication_success,pci_dss_10.2.5,gpg13_7.1,gpg13_7.2,</group>
+    <group>authentication_success,pci_dss_10.2.5,gpg13_7.1,gpg13_7.2,gdpr_IV_32.2,</group>
   </rule>
 
   <rule id="14251" level="10" frequency="8" timeframe="240">
     <if_matched_sid>14202</if_matched_sid>
     <same_source_ip />
     <description>CiscoVPN: Multiple VPN authentication failures.</description>
-    <group>authentication_failures,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,</group>
+    <group>authentication_failures,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
   </rule>
 </group>

--- a/rules/0215-policy_rules.xml
+++ b/rules/0215-policy_rules.xml
@@ -11,13 +11,13 @@
     <if_group>authentication_success</if_group>
     <time>6 pm - 8:30 am</time>
     <description>Successful login during non-business hours.</description>
-    <group>login_time,pci_dss_10.2.5,pci_dss_10.6.1,gpg13_7.1,gpg13_7.2,</group>
+    <group>login_time,pci_dss_10.2.5,pci_dss_10.6.1,gpg13_7.1,gpg13_7.2,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
   </rule>
 
   <rule id="17102" level="9">
     <if_group>authentication_success</if_group>
     <weekday>weekends</weekday>
     <description>Successful login during weekend.</description>
-    <group>login_day,pci_dss_10.2.5,pci_dss_10.6.1,gpg13_7.1,gpg13_7.2,</group>
+    <group>login_day,pci_dss_10.2.5,pci_dss_10.6.1,gpg13_7.1,gpg13_7.2,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
   </rule>
 </group>

--- a/rules/0220-msauth_rules.xml
+++ b/rules/0220-msauth_rules.xml
@@ -31,7 +31,7 @@
     <if_sid>18100</if_sid>
     <status>^ERROR</status>
     <description>Windows error event.</description>
-    <group>system_error,gpg13_4.3,</group>
+    <group>system_error,gpg13_4.3,gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="18104" level="0">
@@ -44,35 +44,35 @@
     <if_sid>18100</if_sid>
     <status>^AUDIT_FAILURE|^failure</status>
     <description>Windows audit failure event.</description>
-    <group>pci_dss_10.6.1,</group>
+    <group>pci_dss_10.6.1,gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="18106" level="5">
     <if_sid>18105</if_sid>
     <id>^529$|^530$|^531$|^532$|^533$|^534$|^535$|^536$|^537$|^539$|^4625$</id>
     <description>Windows Logon Failure.</description>
-    <group>win_authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,</group>
+    <group>win_authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
   </rule>
 
   <rule id="18107" level="3">
     <if_sid>18104</if_sid>
     <id>^528$|^540$|^673$|^4624$|^4769$</id>
     <description>Windows Logon Success.</description>
-    <group>authentication_success,pci_dss_10.2.5,gpg13_7.1,gpg13_7.2,</group>
+    <group>authentication_success,pci_dss_10.2.5,gpg13_7.1,gpg13_7.2,gdpr_IV_32.2,</group>
   </rule>
 
   <rule id="18108" level="4">
     <if_sid>18105</if_sid>
     <id>^577$|^4673$</id>
     <description>Windows: Failed attempt to perform a privileged operation.</description>
-    <group>authentication_success,pci_dss_10.2.2,</group>
+    <group>authentication_success,pci_dss_10.2.2,gdpr_IV_32.2,</group>
   </rule>
 
   <rule id="18109" level="3">
     <if_sid>18104</if_sid>
     <id>^682$|^683$|^4778$|^4779$</id>
     <description>Windows: Session reconnected/disconnected to winstation.</description>
-    <group>authentication_success,pci_dss_8.1.5,</group>
+    <group>authentication_success,pci_dss_8.1.5,gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="18110" level="8">
@@ -80,7 +80,7 @@
     <id>^624$|^626$|^4720$|^4722$</id>
     <description>Windows: User account enabled or created.</description>
     <group>adduser,account_changed,</group>
-    <group>pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,</group>
+    <group>pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
   </rule>
 
   <rule id="18111" level="8">
@@ -88,21 +88,21 @@
     <id>^628$|^642$|^685$|^4738$|^4781$</id>
     <description>Windows: User account changed.</description>
     <group>account_changed,</group>
-    <group>pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,</group>
+    <group>pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
   </rule>
 
   <rule id="18112" level="8">
     <if_sid>18104</if_sid>
     <id>^630$|^629$|^4725$|^4726$</id>
     <description>Windows: User account disabled or deleted.</description>
-    <group>adduser,account_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,</group>
+    <group>adduser,account_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
   </rule>
 
   <rule id="18113" level="8">
     <if_sid>18104</if_sid>
     <id>^612$|^643$|^4719$|^4907$|^4912$|^4719$</id>
     <description>Windows Audit Policy changed.</description>
-    <group>policy_changed,pci_dss_10.6.1,gpg13_10.1,</group>
+    <group>policy_changed,pci_dss_10.6.1,gpg13_10.1,gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="18114" level="5">
@@ -113,7 +113,7 @@
     <id>^656$|^4752$|^659$|^4755$|^660$|^4756$|^661$|^4757$|^664$|^4760$|</id>
     <id>^665$|^4761$|^666$|^4762$</id>
     <description>Windows: Group Account Changed</description>
-    <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,</group>
+    <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
   </rule>
 
   <rule id="18115" level="8">
@@ -121,14 +121,14 @@
     <id>^640$</id>
     <description>Windows: General account database changed.</description>
     <info type="link">http://www.ultimatewindowssecurity.com/events/com259.html</info>
-    <group>adduser,account_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,</group>
+    <group>adduser,account_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
   </rule>
 
   <rule id="18116" level="9">
     <if_sid>18104</if_sid>
     <id>^644$|^4740$</id>
     <description>Windows: User account locked out (multiple login errors).</description>
-    <group>authentication_failures,pci_dss_8.1.6,pci_dss_11.4,gpg13_7.5,</group>
+    <group>authentication_failures,pci_dss_8.1.6,pci_dss_11.4,gpg13_7.5,gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="18117" level="7">
@@ -142,7 +142,7 @@
     <if_sid>18104</if_sid>
     <id>^517$|^1102$</id>
     <description>Windows audit log was cleared.</description>
-    <group>logs_cleared,pci_dss_10.6.1,gpg13_10.1,</group>
+    <group>logs_cleared,pci_dss_10.6.1,gpg13_10.1,gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="18119" level="3">
@@ -150,7 +150,7 @@
     <options>alert_by_email</options>
     <if_fts />
     <description>Windows: First time this user logged in this system.</description>
-    <group>authentication_success,pci_dss_10.2.5,gpg13_7.1,gpg13_7.2,</group>
+    <group>authentication_success,pci_dss_10.2.5,gpg13_7.1,gpg13_7.2,gdpr_IV_32.2,</group>
   </rule>
 
   <rule id="18120" level="0">
@@ -163,21 +163,21 @@
     <if_sid>18102, 18103</if_sid>
     <id>^20187$|^20014$|^20078$|^20050$|^20049$|^20189$</id>
     <description>Windows: Remote access login failure.</description>
-    <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_8.1.5,gpg13_7.1,</group>
+    <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_8.1.5,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
   </rule>
 
   <rule id="18126" level="3">
     <if_sid>18101</if_sid>
     <id>^20158$</id>
     <description>Windows: Remote access login success.</description>
-    <group>authentication_success,pci_dss_10.2.5,pci_dss_8.1.5,gpg13_7.1,gpg13_7.2,</group>
+    <group>authentication_success,pci_dss_10.2.5,pci_dss_8.1.5,gpg13_7.1,gpg13_7.2,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
   </rule>
 
   <rule id="18127" level="5">
     <if_sid>18104</if_sid>
     <id>^646$|^645$|^647$|^4741$|^4742$|^4743$</id>
     <description>Windows: Computer account added/changed/deleted.</description>
-    <group>account_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,</group>
+    <group>account_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
   </rule>
 
   <rule id="18128" level="8">
@@ -185,14 +185,14 @@
     <id>^65xxx</id>
     <description>Windows: Group account added/changed/deleted.</description>
     <info>This rule has been deprecated</info>
-    <group>account_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,</group>
+    <group>account_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
   </rule>
 
   <rule id="18129" level="8">
     <if_sid>18103</if_sid>
     <id>^13570$</id>
     <description>Windows file system full.</description>
-    <group>low_diskspace,pci_dss_10.6.1,gpg13_4.1,</group>
+    <group>low_diskspace,pci_dss_10.6.1,gpg13_4.1,gdpr_IV_35.7.d,</group>
   </rule>
 
 
@@ -202,7 +202,7 @@
     <id>^529$|^4625$</id>
     <description>Windows: Logon Failure - Unknown user or bad password.</description>
     <info type="link">http://www.ultimatewindowssecurity.com/events/com190.html</info>
-    <group>win_authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,</group>
+    <group>win_authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
   </rule>
 
   <rule id="18131" level="5">
@@ -210,7 +210,7 @@
     <id>^530$</id>
     <description>Windows: Logon Failure - Account logon time restriction violation.</description>
     <info type="link">http://www.ultimatewindowssecurity.com/events/com191.html</info>
-    <group>win_authentication_failed,login_denied,pci_dss_10.2.5,pci_dss_8.1.5,gpg13_7.1,</group>
+    <group>win_authentication_failed,login_denied,pci_dss_10.2.5,pci_dss_8.1.5,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
   </rule>
 
   <rule id="18132" level="5">
@@ -218,7 +218,7 @@
     <id>^531$</id>
     <description>Windows: Logon Failure - Account currently disabled.</description>
     <info type="link">http://www.ultimatewindowssecurity.com/events/com192.html</info>
-    <group>win_authentication_failed,login_denied,pci_dss_10.2.5,pci_dss_8.1.4,gpg13_7.5,</group>
+    <group>win_authentication_failed,login_denied,pci_dss_10.2.5,pci_dss_8.1.4,gpg13_7.5,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
   </rule>
 
   <rule id="18133" level="5">
@@ -226,7 +226,7 @@
     <id>^532$</id>
     <description>Windows: Logon Failure - Specified account expired.</description>
     <info type="link">http://www.ultimatewindowssecurity.com/events/com193.html</info>
-    <group>win_authentication_failed,login_denied,pci_dss_10.2.5,pci_dss_8.1.5,gpg13_7.5,</group>
+    <group>win_authentication_failed,login_denied,pci_dss_10.2.5,pci_dss_8.1.5,gpg13_7.5,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
   </rule>
 
   <rule id="18134" level="7">
@@ -234,7 +234,7 @@
     <id>^533$</id>
     <description>Windows: Logon Failure - User not allowed to login at this computer.</description>
     <info type="link">http://www.ultimatewindowssecurity.com/events/com194.html</info>
-    <group>win_authentication_failed,login_denied,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.5,</group>
+    <group>win_authentication_failed,login_denied,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.5,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
   </rule>
 
   <rule id="18135" level="5">
@@ -242,7 +242,7 @@
     <id>^534$</id>
     <description>Windows: Logon Failure - User not granted logon type.</description>
     <info type="link">http://www.ultimatewindowssecurity.com/events/com195.html</info>
-    <group>win_authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.5,</group>
+    <group>win_authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.5,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
   </rule>
 
   <rule id="18136" level="5">
@@ -250,42 +250,42 @@
     <id>^535$</id>
     <description>Windows: Logon Failure - Account's password expired.</description>
     <info type="link">http://www.ultimatewindowssecurity.com/events/com196.html</info>
-    <group>win_authentication_failed,pci_dss_10.2.5,pci_dss_8.2.4,gpg13_7.5,</group>
+    <group>win_authentication_failed,pci_dss_10.2.5,pci_dss_8.2.4,gpg13_7.5,gdpr_IV_32.2,</group>
   </rule>
 
   <rule id="18137" level="5">
     <if_sid>18106</if_sid>
     <id>^536$|^537$</id>
     <description>Windows: Logon Failure - Internal error.</description>
-    <group>win_authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,</group>
+    <group>win_authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
   </rule>
 
   <rule id="18138" level="7">
     <if_sid>18106</if_sid>
     <id>^539$</id>
     <description>Windows: Logon Failure - Account locked out.</description>
-    <group>win_authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_8.1.6,gpg13_7.5,gpg13_7.1,</group>
+    <group>win_authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_8.1.6,gpg13_7.5,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
   </rule>
 
   <rule id="18139" level="5">
     <if_sid>18105</if_sid>
     <id>^673$|^675$|^681$|^4769$</id>
     <description>Windows DC Logon Failure.</description>
-    <group>win_authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,</group>
+    <group>win_authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
   </rule>
 
   <rule id="18140" level="5">
     <if_sid>18104</if_sid>
     <id>^520$|^4616$</id>
     <description>Windows: System time changed.</description>
-    <group>time_changed,pci_dss_10.6.1,gpg13_1.3,gpg13_4.13,</group>
+    <group>time_changed,pci_dss_10.6.1,gpg13_1.3,gpg13_4.13,gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="18141" level="7">
     <if_sid>18102</if_sid>
     <id>^1076$</id>
     <match>unexpected shutdown</match>
-    <group>system_error, system_shutdown,pci_dss_10.6.1,</group>
+    <group>system_error, system_shutdown,pci_dss_10.6.1,gdpr_IV_35.7.d,</group>
     <description>Unexpected Windows shutdown.</description>
   </rule>
 
@@ -294,28 +294,28 @@
     <id>^671$|^4767$</id>
     <description>Windows: User account unlocked.</description>
     <info type="link">http://www.ultimatewindowssecurity.com/events/com291.html</info>
-    <group>account_changed,pci_dss_10.2.5,pci_dss_8.1.6,gpg13_7.10,</group>
+    <group>account_changed,pci_dss_10.2.5,pci_dss_8.1.6,gpg13_7.10,gdpr_IV_32.2,</group>
   </rule>
 
   <rule id="18143" level="8">
     <if_sid>18114</if_sid>
     <id>^631$|^635$|^658$</id>
     <description>Windows: Security enabled group created.</description>
-    <group>adduser,account_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,</group>
+    <group>adduser,account_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
   </rule>
 
   <rule id="18144" level="8">
     <if_sid>18114</if_sid>
     <id>^634$|^638$|^662$</id>
     <description>Windows: Security enabled group deleted.</description>
-    <group>adduser,account_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,</group>
+    <group>adduser,account_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
   </rule>
 
   <!-- Some services change their startup type automatically -->
   <rule id="18145" level="3">
     <if_sid>18101</if_sid>
     <id>^7040$</id>
-    <group>policy_changed,pci_dss_10.6,</group>
+    <group>policy_changed,pci_dss_10.6,gdpr_IV_35.7.d,</group>
     <description>Windows: Service startup type was changed.</description>
     <info type="text">This does not appear to be logged on Windows 2000.</info>
   </rule>
@@ -338,13 +338,14 @@
     <if_sid>18104</if_sid>
     <id>^4608$</id>
     <description>Windows is starting up.</description>
+    <group></group>
   </rule>
 
   <rule id="18149" level="3">
     <if_sid>18104</if_sid>
     <id>^538$|^551$|^4634$|^4647$</id>
     <description>Windows User Logoff.</description>
-    <group>pci_dss_10.2.5,</group>
+    <group>pci_dss_10.2.5,gdpr_IV_32.2,</group>
   </rule>
 
 <!-- Granular group rules -->
@@ -354,7 +355,7 @@
     <id>^631$|^4727$|^635$|^4731$|^658$|^4754$|^648$|^4744$|^653$|^4749$|</id>
     <id>^663$|^4759$</id>
     <description>Windows: Group Account Created</description>
-    <group>group_created,win_group_created,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,</group>
+    <group>group_created,win_group_created,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
   </rule>
 
   <rule id="18201" level="5">
@@ -362,14 +363,14 @@
     <id>^634$|^4730$|^638$|^4734$|^662$|^4758$|^652$|^4748$|^657$|^4753$|</id>
     <id>^667$|^4763$</id>
     <description>Windows: Group Account Deleted</description>
-    <group>group_deleted,win_group_deleted,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,</group>
+    <group>group_deleted,win_group_deleted,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
   </rule>
 
   <rule id="18202" level="5">
     <if_sid>18200</if_sid>
     <id>^631$|^4727$</id>
     <description>Windows: Security Enabled Global Group Created</description>
-    <group>group_created,win_group_created,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,</group>
+    <group>group_created,win_group_created,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
     <info>http://www.ultimatewindowssecurity.com/securitylog/encyclopedia/event.aspx?eventid=631</info>
   </rule>
 
@@ -377,7 +378,7 @@
     <if_sid>18114</if_sid>
     <id>^632$|^4728$</id>
     <description>Windows: Security Enabled Global Group Member Added</description>
-    <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,</group>
+    <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
     <info>http://www.ultimatewindowssecurity.com/securitylog/encyclopedia/event.aspx?eventid=632</info>
   </rule>
 
@@ -385,7 +386,7 @@
     <if_sid>18114</if_sid>
     <id>^633$|^4729$</id>
     <description>Windows: Security Enabled Global Group Member Removed</description>
-    <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,</group>
+    <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
     <info>http://www.ultimatewindowssecurity.com/securitylog/encyclopedia/event.aspx?eventid=633</info>
   </rule>
 
@@ -393,7 +394,7 @@
     <if_sid>18201</if_sid>
     <id>^634$|^4730$</id>
     <description>Windows: Security Enabled Global Group Deleted</description>
-    <group>group_deleted,win_group_deleted,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,</group>
+    <group>group_deleted,win_group_deleted,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
     <info>http://www.ultimatewindowssecurity.com/securitylog/encyclopedia/event.aspx?eventid=634</info>
   </rule>
 
@@ -401,7 +402,7 @@
     <if_sid>18200</if_sid>
     <id>^635$|^4731$</id>
     <description>Windows: Security Enabled Local Group Created</description>
-    <group>group_created,win_group_created,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,</group>
+    <group>group_created,win_group_created,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
     <info>http://www.ultimatewindowssecurity.com/securitylog/encyclopedia/event.aspx?eventid=635</info>
   </rule>
 
@@ -409,7 +410,7 @@
     <if_sid>18114</if_sid>
     <id>^636$|^4732$</id>
     <description>Windows: Security Enabled Local Group Member Added</description>
-   <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,</group>
+   <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
     <info>http://www.ultimatewindowssecurity.com/securitylog/encyclopedia/event.aspx?eventid=636</info>
   </rule>
 
@@ -417,7 +418,7 @@
     <if_sid>18114</if_sid>
     <id>^637$|^4733$</id>
     <description>Windows: Security Enabled Local Group Member Removed</description>
-    <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,</group>
+    <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
     <info>http://www.ultimatewindowssecurity.com/securitylog/encyclopedia/event.aspx?eventid=637</info>
   </rule>
 
@@ -425,7 +426,7 @@
     <if_sid>18201</if_sid>
     <id>^638$|^4734$</id>
     <description>Windows: Security Enabled Local Group Deleted</description>
-    <group>group_deleted,win_group_deleted,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,</group>
+    <group>group_deleted,win_group_deleted,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
     <info>http://www.ultimatewindowssecurity.com/securitylog/encyclopedia/event.aspx?eventid=638</info>
   </rule>
 
@@ -433,7 +434,7 @@
     <if_sid>18114</if_sid>
     <id>^639$|^4735$</id>
     <description>Windows: Security Enabled Local Group Changed</description>
-    <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,</group>
+    <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
     <info>http://www.ultimatewindowssecurity.com/securitylog/encyclopedia/event.aspx?eventid=639</info>
   </rule>
 
@@ -441,7 +442,7 @@
     <if_sid>18114</if_sid>
     <id>^641$|^4737$</id>
     <description>Windows: Security Enabled Global Group Changed</description>
-    <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,</group>
+    <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
     <info>http://www.ultimatewindowssecurity.com/securitylog/encyclopedia/event.aspx?eventid=641</info>
   </rule>
 
@@ -449,7 +450,7 @@
     <if_sid>18200</if_sid>
     <id>^658$|^4754$</id>
     <description>Windows: Security Enabled Universal Group Created</description>
-    <group>group_created,win_group_created,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,</group>
+    <group>group_created,win_group_created,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
     <info>http://www.ultimatewindowssecurity.com/securitylog/encyclopedia/event.aspx?eventid=658</info>
   </rule>
 
@@ -457,7 +458,7 @@
     <if_sid>18114</if_sid>
     <id>^659$|^4755$</id>
     <description>Windows: Security Enabled Universal Group Changed</description>
-    <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,</group>
+    <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
     <info>http://www.ultimatewindowssecurity.com/securitylog/encyclopedia/event.aspx?eventid=659</info>
   </rule>
 
@@ -465,7 +466,7 @@
     <if_sid>18114</if_sid>
     <id>^660$|^4756$</id>
     <description>Windows: Security Enabled Universal Group Member Added</description>
-    <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,</group>
+    <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
     <info>http://www.ultimatewindowssecurity.com/securitylog/encyclopedia/event.aspx?eventid=660</info>
   </rule>
 
@@ -473,7 +474,7 @@
     <if_sid>18114</if_sid>
     <id>^661$|^4757$</id>
     <description>Windows: Security Enabled Universal Group Member Removed</description>
-    <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,</group>
+    <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
     <info>http://www.ultimatewindowssecurity.com/securitylog/encyclopedia/event.aspx?eventid=661</info>
   </rule>
 
@@ -481,7 +482,7 @@
     <if_sid>18201</if_sid>
     <id>^662$|^4758$</id>
     <description>Windows: Security Enabled Universal Group Deleted</description>
-    <group>group_deleted,win_group_deleted,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,</group>
+    <group>group_deleted,win_group_deleted,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
     <info>http://www.ultimatewindowssecurity.com/securitylog/encyclopedia/event.aspx?eventid=662</info>
   </rule>
 
@@ -489,7 +490,7 @@
     <if_sid>18207,18208</if_sid>
     <regex> ID:\s+\p*S-1-5-32-544</regex>
     <description>Windows: Administrators Group Changed</description>
-    <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,</group>
+    <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
     <info>http://support.microsoft.com/kb/243330</info>
   </rule>
 
@@ -497,7 +498,7 @@
     <if_sid>18207,18208</if_sid>
     <regex> ID:\s+%{S-1-1-0}</regex>
     <description>Windows: Everyone Group Changed</description>
-    <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,</group>
+    <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
     <info>http://support.microsoft.com/kb/243330</info>
   </rule>
 
@@ -505,7 +506,7 @@
     <if_sid>18207,18208</if_sid>
     <regex> ID:\s+%{S-1-5-9}</regex>
     <description>Windows: Enterprise Domain Controllers Group Changed</description>
-    <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,</group>
+    <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
     <info>http://support.microsoft.com/kb/243330</info>
   </rule>
 
@@ -513,7 +514,7 @@
     <if_sid>18207,18208</if_sid>
     <regex> ID:\s+%{S-1-5-11}</regex>
     <description>Windows: Authenticated Users Group Changed</description>
-    <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,</group>
+    <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
     <info>http://support.microsoft.com/kb/243330</info>
   </rule>
 
@@ -521,7 +522,7 @@
     <if_sid>18207,18208</if_sid>
     <regex> ID:\s+%{S-1-5-13}</regex>
     <description>Windows: Terminal Server Users Group Changed</description>
-    <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,</group>
+    <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
     <info>http://support.microsoft.com/kb/243330</info>
   </rule>
 
@@ -529,7 +530,7 @@
     <if_sid>18203,18204</if_sid>
     <regex> ID:\s+%{S-1-5-21\S+-512}</regex>
     <description>Windows: Domain Admins Group Changed</description>
-    <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,</group>
+    <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
     <info>http://support.microsoft.com/kb/243330</info>
   </rule>
 
@@ -537,7 +538,7 @@
     <if_sid>18203,18204</if_sid>
     <regex> ID:\s+%{S-1-5-21\S+-513}</regex>
     <description>Windows: Domain Users Group Changed</description>
-    <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,</group>
+    <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
     <info>http://support.microsoft.com/kb/243330</info>
   </rule>
 
@@ -552,7 +553,7 @@
     <if_sid>18203,18204</if_sid>
     <regex> ID:\s+%{S-1-5-21\S+-514}</regex>
     <description>Windows: Domain Guests Group Changed</description>
-    <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,</group>
+    <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
     <info>http://support.microsoft.com/kb/243330</info>
   </rule>
 
@@ -560,7 +561,7 @@
     <if_sid>18203,18204</if_sid>
     <regex> ID:\s+%{S-1-5-21\S+-515}</regex>
     <description>Windows: Domain Computers Group Changed</description>
-    <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,</group>
+    <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
     <info>http://support.microsoft.com/kb/243330</info>
   </rule>
 
@@ -568,7 +569,7 @@
     <if_sid>18203,18204</if_sid>
     <regex> ID:\s+%{S-1-5-21\S+-516}</regex>
     <description>Windows: Domain Controllers Group Changed</description>
-    <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,</group>
+    <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
     <info>http://support.microsoft.com/kb/243330</info>
   </rule>
 
@@ -576,7 +577,7 @@
     <if_sid>18207,18208</if_sid>
     <regex> ID:\s+%{S-1-5-21\S+-517}</regex>
     <description>Windows: Cert Publishers Group Changed</description>
-    <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,</group>
+    <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
     <info>http://support.microsoft.com/kb/243330</info>
   </rule>
 
@@ -584,7 +585,7 @@
     <if_sid>18203,18204</if_sid>
     <regex> ID:\s+%{S-1-5-21\.+-518}</regex>
     <description>Windows: Schema Admins Group Changed</description>
-    <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,</group>
+    <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
     <info>http://support.microsoft.com/kb/243330</info>
   </rule>
 
@@ -592,7 +593,7 @@
     <if_sid>18203,18204</if_sid>
     <regex> ID:\s+%{S-1-5-21\S+-519}</regex>
     <description>Windows: Enterprise Admins Group Changed</description>
-    <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,</group>
+    <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
     <info>http://support.microsoft.com/kb/243330</info>
   </rule>
 
@@ -600,7 +601,7 @@
     <if_sid>18203,18204</if_sid>
     <regex> ID:\s+%{S-1-5-21\S+-520}</regex>
     <description>Windows: Group Policy Creator Owners Group Changed</description>
-    <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,</group>
+    <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
     <info>http://support.microsoft.com/kb/243330</info>
   </rule>
 
@@ -608,7 +609,7 @@
     <if_sid>18207,18208</if_sid>
     <regex>\w* ID:\s+%{S-1-5-21\S+-553}</regex>
     <description>Windows: RAS and IAS Servers Group Changed</description>
-    <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,</group>
+    <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
     <info>http://support.microsoft.com/kb/243330</info>
   </rule>
 
@@ -616,7 +617,7 @@
     <if_sid>18207,18208</if_sid>
     <regex> ID:\s+%{S-1-5-32-545}</regex>
     <description>Windows: Users Group Changed</description>
-    <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,</group>
+    <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
     <info>http://support.microsoft.com/kb/243330</info>
   </rule>
 
@@ -624,7 +625,7 @@
     <if_sid>18207,18208</if_sid>
     <regex> ID:\s+%{S-1-5-32-546}</regex>
     <description>Windows: Guests Group Changed</description>
-    <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,</group>
+    <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
     <info>http://support.microsoft.com/kb/243330</info>
   </rule>
 
@@ -632,7 +633,7 @@
     <if_sid>18207,18208</if_sid>
     <regex> ID:\s+%{S-1-5-32-547}</regex>
     <description>Windows: Power Users Group Changed</description>
-    <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,</group>
+    <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
     <info>http://support.microsoft.com/kb/243330</info>
   </rule>
 
@@ -640,7 +641,7 @@
     <if_sid>18207,18208</if_sid>
     <regex> ID:\s+%{S-1-5-32-548}</regex>
     <description>Windows: Account Operators Group Changed</description>
-    <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,</group>
+    <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
     <info>http://support.microsoft.com/kb/243330</info>
   </rule>
 
@@ -648,7 +649,7 @@
     <if_sid>18207,18208</if_sid>
     <regex> ID:\s+%{S-1-5-32-549}</regex>
     <description>Windows: Server Operators Group Changed</description>
-    <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,</group>
+    <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
     <info>http://support.microsoft.com/kb/243330</info>
   </rule>
 
@@ -656,7 +657,7 @@
     <if_sid>18207,18208</if_sid>
     <regex>\w* ID:\s+%{S-1-5-32-550}</regex>
     <description>Windows: Print Operators Group Changed</description>
-    <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,</group>
+    <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
     <info>http://support.microsoft.com/kb/243330</info>
   </rule>
 
@@ -664,7 +665,7 @@
     <if_sid>18207,18208</if_sid>
     <regex> ID:\s+%{S-1-5-32-551}</regex>
     <description>Windows: Backup Operators Group Changed</description>
-    <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,</group>
+    <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
     <info>http://support.microsoft.com/kb/243330</info>
   </rule>
 
@@ -672,7 +673,7 @@
     <if_sid>18207,18208</if_sid>
     <regex> ID:\s+%{S-1-5-32-552}</regex>
     <description>Windows: Replicators Group Changed</description>
-    <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,</group>
+    <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
     <info>http://support.microsoft.com/kb/243330</info>
   </rule>
 
@@ -680,7 +681,7 @@
     <if_sid>18207,18208</if_sid>
     <regex> ID:\s+%{S-1-5-32-554}</regex>
     <description>Pre-Windows 2000 Compatible Access Group Changed</description>
-    <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,</group>
+    <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
     <info>http://support.microsoft.com/kb/243330</info>
   </rule>
 
@@ -688,7 +689,7 @@
     <if_sid>18207,18208</if_sid>
     <regex> ID:\s+%{S-1-5-32-555}</regex>
     <description>Windows: Remote Desktop Users Group Changed</description>
-    <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,</group>
+    <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
     <info>http://support.microsoft.com/kb/243330</info>
   </rule>
 
@@ -696,7 +697,7 @@
     <if_sid>18207,18208</if_sid>
     <regex> ID:\s+%{S-1-5-32-556}</regex>
     <description>Windows: Network Configuration Operators Group Changed</description>
-    <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,</group>
+    <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
     <info>http://support.microsoft.com/kb/243330</info>
   </rule>
 
@@ -704,7 +705,7 @@
     <if_sid>18207,18208</if_sid>
     <regex> ID:\s+%{S-1-5-32-557}</regex>
     <description>Windows: Incoming Forest Trust Builders Group Changed</description>
-    <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,</group>
+    <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
     <info>http://support.microsoft.com/kb/243330</info>
   </rule>
 
@@ -712,7 +713,7 @@
     <if_sid>18207,18208</if_sid>
     <regex> ID:\s+%{S-1-5-32-558}</regex>
     <description>Windows: Performance Monitor Users Group Changed</description>
-    <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,</group>
+    <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
     <info>http://support.microsoft.com/kb/243330</info>
   </rule>
 
@@ -720,7 +721,7 @@
     <if_sid>18207,18208</if_sid>
     <regex> ID:\s+%{S-1-5-32-559}</regex>
     <description>Windows: Performance Log Users Group Changed</description>
-    <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,</group>
+    <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
     <info>http://support.microsoft.com/kb/243330</info>
   </rule>
 
@@ -728,7 +729,7 @@
     <if_sid>18207,18208</if_sid>
     <regex> ID:\s+%{S-1-5-32-560}</regex>
     <description>Windows Authorization Access Group Changed</description>
-    <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,</group>
+    <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
     <info>http://support.microsoft.com/kb/243330</info>
   </rule>
 
@@ -736,7 +737,7 @@
     <if_sid>18207,18208</if_sid>
     <regex> ID:\s+%{S-1-5-32-561}</regex>
     <description>Windows: Terminal Server License Servers Group Changed</description>
-    <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,</group>
+    <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
     <info>http://support.microsoft.com/kb/243330</info>
   </rule>
 
@@ -744,7 +745,7 @@
     <if_sid>18207,18208</if_sid>
     <regex> ID:\s+%{S-1-5-32-562}</regex>
     <description>Windows: Distributed COM Users Group Changed</description>
-    <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,</group>
+    <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
     <info>http://support.microsoft.com/kb/243330</info>
   </rule>
 
@@ -752,7 +753,7 @@
     <if_sid>18207,18208</if_sid>
     <regex> ID:\s+%{S-1-5-\s*21\.+\s*-498}</regex>
     <description>Windows: Enterprise Read-only Domain Controllers Group Changed</description>
-    <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,</group>
+    <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
     <info>http://support.microsoft.com/kb/243330</info>
   </rule>
 
@@ -760,7 +761,7 @@
     <if_sid>18207,18208</if_sid>
     <regex> ID:\s+%{S-1-5-\s*21\.+\s*-529}</regex>
     <description>Windows: Read-only Domain Controllers Group Changed</description>
-    <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,</group>
+    <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
     <info>http://support.microsoft.com/kb/243330</info>
   </rule>
 
@@ -768,7 +769,7 @@
     <if_sid>18207,18208</if_sid>
     <regex> ID:\s+%{S-1-5-32-569}</regex>
     <description>Windows: Cryptographic Operators Group Changed</description>
-    <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,</group>
+    <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
     <info>http://support.microsoft.com/kb/243330</info>
   </rule>
 
@@ -776,7 +777,7 @@
     <if_sid>18207,18208</if_sid>
     <regex> ID:\s+%{S-1-5-\s*21\.+\s*-571}</regex>
     <description>Windows: Allowed RODC Password Replication Group Changed</description>
-    <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,</group>
+    <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
     <info>http://support.microsoft.com/kb/243330</info>
   </rule>
 
@@ -784,7 +785,7 @@
     <if_sid>18207,18208</if_sid>
     <regex> ID:\s+%{S-1-5-\s*21\.+\s*-572}</regex>
     <description>Windows: Denied RODC Password Replication Group Changed</description>
-    <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,</group>
+    <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
     <info>http://support.microsoft.com/kb/243330</info>
   </rule>
 
@@ -792,7 +793,7 @@
     <if_sid>18207,18208</if_sid>
     <regex> ID:\s+%{S-1-5-32-573}</regex>
     <description>Windows: Event Log Readers Group Changed</description>
-    <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,</group>
+    <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
     <info>http://support.microsoft.com/kb/243330</info>
   </rule>
 
@@ -800,7 +801,7 @@
     <if_sid>18207,18208</if_sid>
     <regex> ID:\s+%{S-1-5-32-574}</regex>
     <description>Windows: Certificate Service DCOM Access Group Changed</description>
-    <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,</group>
+    <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
     <info>http://support.microsoft.com/kb/243330</info>
   </rule>
 
@@ -809,7 +810,7 @@
     <if_sid>18101</if_sid>
     <id>^200$|^300$|^302$</id>
     <description>Windows: TS Gateway login success.</description>
-    <group>authentication_success,pci_dss_10.2.5,gpg13_7.1,gpg13_7.2,</group>
+    <group>authentication_success,pci_dss_10.2.5,gpg13_7.1,gpg13_7.2,gdpr_IV_32.2,</group>
     <info>https://technet.microsoft.com/en-us/library/cc775181(v=ws.10).aspx</info>
   </rule>
 
@@ -826,7 +827,7 @@
     <if_sid>18102, 18103</if_sid>
     <id>^201$|^203$|^204$|^301$|^304$|^305$|^306$|^1001$</id>
     <description>Windows: TS Gateway login failure.</description>
-    <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,</group>
+    <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
     <info>https://technet.microsoft.com/en-us/library/cc775181(v=ws.10).aspx</info>
   </rule>
 
@@ -847,7 +848,7 @@
     <id>^528$|^538$|^540$|^4624$</id>
     <user>^LOCAL SERVICE|^NETWORK SERVICE|^ANONYMOUS LOGON</user>
     <description>Windows Logon Success (ignored).</description>
-    <group>pci_dss_10.2.5,gpg13_7.1,gpg13_7.2,</group>
+    <group>pci_dss_10.2.5,gpg13_7.1,gpg13_7.2,gdpr_IV_32.2,</group>
   </rule>
 
 
@@ -858,7 +859,7 @@
     <description>Windows DC integrity check on decrypted </description>
     <description>field failed.</description>
     <info type="link">http://www.ultimatewindowssecurity.com/kerberrors.html</info>
-    <group>win_authentication_failed,attacks,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,</group>
+    <group>win_authentication_failed,attacks,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
   </rule>
 
   <rule id="18171" level="10">
@@ -866,7 +867,7 @@
     <match>Failure Code: 0x22</match>
     <description>Windows DC - Possible replay attack.</description>
     <info type="link">http://www.ultimatewindowssecurity.com/kerberrors.html</info>
-    <group>win_authentication_failed,attacks,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,</group>
+    <group>win_authentication_failed,attacks,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
   </rule>
 
   <rule id="18172" level="7">
@@ -874,7 +875,7 @@
     <match>Failure Code: 0x25</match>
     <description>Windows DC - Clock skew too great.</description>
     <info type="link">http://www.ultimatewindowssecurity.com/kerberrors.html</info>
-    <group>win_authentication_failed,attacks,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,</group>
+    <group>win_authentication_failed,attacks,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
   </rule>
 
 
@@ -882,7 +883,7 @@
   <rule id="18180" level="5">
     <if_sid>18105</if_sid>
     <id>^18456$</id>
-    <group>win_authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,</group>
+    <group>win_authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
     <description>MS SQL Server Logon Failure.</description>
   </rule>
 
@@ -890,7 +891,7 @@
     <if_sid>18104</if_sid>
     <id>^18454$|^18453$</id>
     <description>MS SQL Server Logon Success.</description>
-    <group>authentication_success,pci_dss_10.2.5,gpg13_7.1,gpg13_7.2,</group>
+    <group>authentication_success,pci_dss_10.2.5,gpg13_7.1,gpg13_7.2,gdpr_IV_32.2,</group>
   </rule>
 
 <!-- Detail logon rules -->
@@ -899,7 +900,7 @@
     <id>^4624$</id>
     <match>Logon Type:   8</match>
     <description>MS Exchange Logon Success.</description>
-    <group>pci_dss_10.2.5,gpg13_7.1,gpg13_7.2,</group>
+    <group>pci_dss_10.2.5,gpg13_7.1,gpg13_7.2,gdpr_IV_32.2,</group>
   </rule>
 
   <rule id="18261" level="0">
@@ -907,7 +908,7 @@
     <id>^4634$</id>
     <match>Logon Type:   8</match>
     <description>MS Exchange User Logoff.</description>
-    <group>pci_dss_10.2.5,gpg13_7.1,gpg13_7.2,</group>
+    <group>pci_dss_10.2.5,gpg13_7.1,gpg13_7.2,gdpr_IV_32.2,</group>
   </rule>
 
 
@@ -916,19 +917,19 @@
     <if_matched_sid>18108</if_matched_sid>
     <same_user />
     <description>Windows: Multiple failed attempts to perform a privileged operation by the same user.</description>
-    <group>pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,</group>
+    <group>pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
   </rule>
 
   <rule id="18152" level="10" frequency="$MS_FREQ" timeframe="240">
     <if_matched_group>win_authentication_failed</if_matched_group>
     <description>Multiple Windows Logon Failures.</description>
-    <group>authentication_failures,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,</group>
+    <group>authentication_failures,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
   </rule>
 
   <rule id="18153" level="10" frequency="$MS_FREQ" timeframe="240">
     <if_matched_sid>18105</if_matched_sid>
     <description>Multiple Windows audit failure events.</description>
-    <group>pci_dss_10.6.1,</group>
+    <group>pci_dss_10.6.1,gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="18154" level="10" frequency="$MS_FREQ" timeframe="240">
@@ -944,13 +945,13 @@
   <rule id="18156" level="10" frequency="$MS_FREQ" timeframe="240">
     <if_matched_sid>18125</if_matched_sid>
     <description>Windows: Multiple remote access login failures.</description>
-    <group>authentication_failures,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,pci_dss_8.1.5,</group>
+    <group>authentication_failures,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,pci_dss_8.1.5,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
   </rule>
 
   <rule id="18157" level="10" frequency="$MS_FREQ" timeframe="240">
       <if_matched_sid>18258</if_matched_sid>
       <description>Windows: Multiple TS Gateway login failures.</description>
-      <group>authentication_failures,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,</group>
+      <group>authentication_failures,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
   </rule>
 
   <!--
@@ -963,6 +964,7 @@
       <match>chromoting</match>
       <regex>: chromoting: \.* Access denied for client: </regex>
       <description>Chrome Remote Desktop attempt - access denied</description>
+      <group>gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
   </rule>
 
   <rule id="18159" level="5">
@@ -970,6 +972,7 @@
       <match>chromoting</match>
       <regex>: chromoting: \.* Client connected:</regex>
       <description>Chrome Remote Desktop attempt - connected</description>
+      <group>gdpr_IV_32.2,</group>
   </rule>
 
   <rule id="18160" level="5">
@@ -977,6 +980,7 @@
       <match>chromoting</match>
       <regex>: chromoting: \.* Client disconnected:</regex>
       <description>Chrome Remote Desktop attempt - disconnected</description>
+      <group>gdpr_IV_32.2,</group>
   </rule>
 
 </group>

--- a/rules/0220-msauth_rules.xml
+++ b/rules/0220-msauth_rules.xml
@@ -964,7 +964,7 @@
       <match>chromoting</match>
       <regex>: chromoting: \.* Access denied for client: </regex>
       <description>Chrome Remote Desktop attempt - access denied</description>
-      <group>gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
+      <group>pci_dss_10.2.4,pci_dss_10.2.5,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
   </rule>
 
   <rule id="18159" level="5">
@@ -972,7 +972,7 @@
       <match>chromoting</match>
       <regex>: chromoting: \.* Client connected:</regex>
       <description>Chrome Remote Desktop attempt - connected</description>
-      <group>gdpr_IV_32.2,</group>
+      <group>pci_dss_10.2.5,gdpr_IV_32.2,</group>
   </rule>
 
   <rule id="18160" level="5">
@@ -980,7 +980,7 @@
       <match>chromoting</match>
       <regex>: chromoting: \.* Client disconnected:</regex>
       <description>Chrome Remote Desktop attempt - disconnected</description>
-      <group>gdpr_IV_32.2,</group>
+      <group>pci_dss_10.2.5,gdpr_IV_32.2,</group>
   </rule>
 
 </group>

--- a/rules/0225-mcafee_av_rules.xml
+++ b/rules/0225-mcafee_av_rules.xml
@@ -44,21 +44,21 @@
   <rule id="7504" level="12">
     <if_sid>7500</if_sid>
     <regex>$MCAFEE_VIRUS</regex>
-    <group>virus,pci_dss_5.1,pci_dss_5.2,pci_dss_10.6.1,pci_dss_11.4,gpg13_4.2,</group>
+    <group>virus,pci_dss_5.1,pci_dss_5.2,pci_dss_10.6.1,pci_dss_11.4,gpg13_4.2,gdpr_IV_35.7.d,</group>
     <description>McAfee Windows AV - Virus detected and not removed.</description>
   </rule>
 
   <rule id="7505" level="7">
     <if_sid>7504</if_sid>
     <match>$MCAFEE_VIRUS_OK</match>
-    <group>virus,pci_dss_5.1,pci_dss_5.2,pci_dss_10.6.1,pci_dss_11.4,gpg13_4.2,</group>
+    <group>virus,pci_dss_5.1,pci_dss_5.2,pci_dss_10.6.1,pci_dss_11.4,gpg13_4.2,gdpr_IV_35.7.d,</group>
     <description>McAfee Windows AV - Virus detected and properly removed.</description>
   </rule>
 
   <rule id="7506" level="7">
     <if_sid>7504</if_sid>
     <match>Will be deleted</match>
-    <group>virus,pci_dss_5.1,pci_dss_5.2,pci_dss_10.6.1,pci_dss_11.4,gpg13_4.2,</group>
+    <group>virus,pci_dss_5.1,pci_dss_5.2,pci_dss_10.6.1,pci_dss_11.4,gpg13_4.2,gdpr_IV_35.7.d,</group>
     <description>McAfee Windows AV - Virus detected and file will be deleted.</description>
   </rule>
 
@@ -66,7 +66,7 @@
     <if_sid>7500</if_sid>
     <match>scan started|scan stopped</match>
     <description>McAfee Windows AV - Scan started or stopped.</description>
-    <group>pci_dss_5.1,pci_dss_10.2.6,pci_dss_10.6.1,gpg13_4.14,gpg13_10.1</group>
+    <group>pci_dss_5.1,pci_dss_10.2.6,pci_dss_10.6.1,gpg13_4.14,gpg13_10.1,gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="7508" level="3">
@@ -74,42 +74,42 @@
     <id>^257</id>
     <match>completed.  No detections</match>
     <description>McAfee Windows AV - Scan completed with no viruses found.</description>
-    <group>pci_dss_5.1,pci_dss_10.2.6,pci_dss_10.6.1,gpg13_4.14,gpg13_10.1</group>
+    <group>pci_dss_5.1,pci_dss_10.2.6,pci_dss_10.6.1,gpg13_4.14,gpg13_10.1,gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="7509" level="5">
     <if_sid>7500</if_sid>
     <match>scan was cancelled |has taken too long</match>
     <description>McAfee Windows AV - Virus scan cancelled.</description>
-    <group>pci_dss_5.1,pci_dss_10.2.6,pci_dss_10.6.1,gpg13_4.14,gpg13_10.1,</group>
+    <group>pci_dss_5.1,pci_dss_10.2.6,pci_dss_10.6.1,gpg13_4.14,gpg13_10.1,gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="7510" level="5">
     <if_sid>7500</if_sid>
     <match>scan was canceled because</match>
     <description>McAfee Windows AV - Virus scan cancelled due to shutdown.</description>
-    <group>pci_dss_5.1,pci_dss_10.2.6,pci_dss_10.6.1,gpg13_4.14,gpg13_10.1,</group>
+    <group>pci_dss_5.1,pci_dss_10.2.6,pci_dss_10.6.1,gpg13_4.14,gpg13_10.1,gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="7511" level="3">
     <if_sid>7500</if_sid>
     <match>update was successful</match>
     <description>McAfee Windows AV - Virus program or DAT update succeeded.</description>
-    <group>pci_dss_5.1,pci_dss_10.6.1,pci_dss_5.2,gpg13_4.4,gpg13_4.14,</group>
+    <group>pci_dss_5.1,pci_dss_10.6.1,pci_dss_5.2,gpg13_4.4,gpg13_4.14,gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="07512" level="7">
     <if_sid>7500</if_sid>
     <match>update failed</match>
     <description>McAfee Windows AV - Virus program or DAT update failed.</description>
-    <group>pci_dss_5.1,pci_dss_10.6.1,pci_dss_5.2,gpg13_4.14,</group>
+    <group>pci_dss_5.1,pci_dss_10.6.1,pci_dss_5.2,gpg13_4.14,gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="7513" level="7">
     <if_sid>7500</if_sid>
     <match>update was cancelled</match>
     <description>McAfee Windows AV - Virus program or DAT update cancelled.</description>
-    <group>pci_dss_5.1,pci_dss_10.6.1,pci_dss_5.2,gpg13_4.14,</group>
+    <group>pci_dss_5.1,pci_dss_10.6.1,pci_dss_5.2,gpg13_4.14,gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="7514" level="5">
@@ -124,7 +124,7 @@
   <rule id="7550" level="10" frequency="$MCAFEE_FREQ" timeframe="240">
     <if_matched_sid>7502</if_matched_sid>
     <description>Multiple McAfee AV warning events.</description>
-    <group>pci_dss_5.1,pci_dss_10.6.1,</group>
+    <group>pci_dss_5.1,pci_dss_10.6.1,gdpr_IV_35.7.d,</group>
   </rule>
 
 </group>

--- a/rules/0230-ms-se_rules.xml
+++ b/rules/0230-ms-se_rules.xml
@@ -17,28 +17,28 @@
   <rule id="7710" level="12">
     <if_sid>7701</if_sid>
     <id>^1118$|^1119$</id>
-    <group>virus,pci_dss_5.1,pci_dss_5.2,pci_dss_10.6.1,pci_dss_11.4,gpg13_4.2,</group>
+    <group>virus,pci_dss_5.1,pci_dss_5.2,pci_dss_10.6.1,pci_dss_11.4,gpg13_4.2,gdpr_IV_35.7.d,</group>
     <description>Microsoft Security Essentials - Virus detected, but unable to remove.</description>
   </rule>
 
   <rule id="7711" level="7">
     <if_sid>7701</if_sid>
     <id>^1107$</id>
-    <group>virus,pci_dss_5.1,pci_dss_5.2,pci_dss_10.6.1,pci_dss_11.4,gpg13_4.2,</group>
+    <group>virus,pci_dss_5.1,pci_dss_5.2,pci_dss_10.6.1,pci_dss_11.4,gpg13_4.2,gdpr_IV_35.7.d,</group>
     <description>Microsoft Security Essentials - Virus detected and properly removed.</description>
   </rule>
 
   <rule id="7712" level="7">
     <if_sid>7701</if_sid>
     <id>^1119$|^1118$|^1117$|^1116$</id>
-    <group>virus,pci_dss_5.1,pci_dss_5.2,pci_dss_10.6.1,pci_dss_11.4,gpg13_4.2,</group>
+    <group>virus,pci_dss_5.1,pci_dss_5.2,pci_dss_10.6.1,pci_dss_11.4,gpg13_4.2,gdpr_IV_35.7.d,</group>
     <description>Microsoft Security Essentials - Virus detected.</description>
   </rule>
 
    <rule id="7713" level="7">
     <if_sid>7701</if_sid>
     <id>^1015$</id>
-    <group>virus,pci_dss_5.1,pci_dss_5.2,pci_dss_10.6.1,pci_dss_11.4,gpg13_4.2,</group>
+    <group>virus,pci_dss_5.1,pci_dss_5.2,pci_dss_10.6.1,pci_dss_11.4,gpg13_4.2,gdpr_IV_35.7.d,</group>
     <description>Microsoft Security Essentials - Suspicious activity detected.</description>
   </rule>
 
@@ -46,20 +46,20 @@
     <if_sid>7701</if_sid>
     <id>^5007$</id>
     <description>Microsoft Security Essentials - Configuration changed.</description>
-    <group>policy_changed,pci_dss_10.2.7,pci_dss_10.6.1,gpg13_4.4,</group>
+    <group>policy_changed,pci_dss_10.2.7,pci_dss_10.6.1,gpg13_4.4,gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="7721" level="9">
     <if_sid>7701</if_sid>
     <id>^5008$</id>
-    <group>pci_dss_10.6.1,gpg13_4.14,</group>
+    <group>pci_dss_10.6.1,gpg13_4.14,gdpr_IV_35.7.d,</group>
     <description>Microsoft Security Essentials - Service failed.</description>
   </rule>
 
   <rule id="7722" level="9">
     <if_sid>7701</if_sid>
     <id>^3002$</id>
-    <group>pci_dss_10.6.1,gpg13_4.14,</group>
+    <group>pci_dss_10.6.1,gpg13_4.14,gdpr_IV_35.7.d,</group>
     <description>Microsoft Security Essentials - Real time protection failed.</description>
   </rule>
 
@@ -72,35 +72,35 @@
   <rule id="7724" level="8">
     <if_sid>7701</if_sid>
     <id>^2004$</id>
-    <group>pci_dss_10.6.1,gpg13_4.14,gpg13_4.4,gpg13_,</group>
+    <group>pci_dss_10.6.1,gpg13_4.14,gpg13_4.4,gpg13_,gdpr_IV_35.7.d,</group>
     <description>Microsoft Security Essentials - Loading definitions failed. Using last good set.</description>
   </rule>
 
   <rule id="7725" level="8">
     <if_sid>7701</if_sid>
     <id>^2003$</id>
-    <group>pci_dss_10.6.1,gpg13_4.14,</group>
+    <group>pci_dss_10.6.1,gpg13_4.14,gdpr_IV_35.7.d,</group>
     <description>Microsoft Security Essentials - Engine update failed.</description>
   </rule>
 
   <rule id="7726" level="8">
     <if_sid>7701</if_sid>
     <id>^2001$</id>
-    <group>pci_dss_10.6.1,gpg13_4.14,</group>
+    <group>pci_dss_10.6.1,gpg13_4.14,gdpr_IV_35.7.d,</group>
     <description>Microsoft Security Essentials - Definitions update failed.</description>
   </rule>
 
   <rule id="7727" level="7">
     <if_sid>7701</if_sid>
     <id>^1005$</id>
-    <group>pci_dss_10.6.1,gpg13_4.4,</group>
+    <group>pci_dss_10.6.1,gpg13_4.4,gdpr_IV_35.7.d,</group>
     <description>Microsoft Security Essentials - Scan error. Scan has stopped.</description>
   </rule>
 
   <rule id="7728" level="5">
     <if_sid>7701</if_sid>
     <id>^1002$</id>
-    <group>pci_dss_10.6.1,gpg13_4.14,</group>
+    <group>pci_dss_10.6.1,gpg13_4.14,gdpr_IV_35.7.d,</group>
     <description>Microsoft Security Essentials - Scan stopped before completion.</description>
   </rule>
 
@@ -114,11 +114,13 @@
 
   <rule id="7750" level="10" frequency="6" timeframe="240">
     <if_matched_sid>7711</if_matched_sid>
+    <group>gdpr_IV_35.7.d,</group>
     <description>Multiple Microsoft Security Essentials AV warnings detected.</description>
   </rule>
 
   <rule id="7751" level="10" frequency="6" timeframe="240">
     <if_matched_sid>7712</if_matched_sid>
+    <group>gdpr_IV_35.7.d,</group>
     <description>Multiple Microsoft Security Essentials AV warnings detected.</description>
   </rule>
 </group>

--- a/rules/0230-ms-se_rules.xml
+++ b/rules/0230-ms-se_rules.xml
@@ -114,13 +114,13 @@
 
   <rule id="7750" level="10" frequency="6" timeframe="240">
     <if_matched_sid>7711</if_matched_sid>
-    <group>gdpr_IV_35.7.d,</group>
+    <group>pci_dss_5.1,pci_dss_5.2,pci_dss_10.6.1,pci_dss_11.4,gdpr_IV_35.7.d,</group>
     <description>Multiple Microsoft Security Essentials AV warnings detected.</description>
   </rule>
 
   <rule id="7751" level="10" frequency="6" timeframe="240">
     <if_matched_sid>7712</if_matched_sid>
-    <group>gdpr_IV_35.7.d,</group>
+    <group>pci_dss_5.1,pci_dss_5.2,pci_dss_10.6.1,pci_dss_11.4,gdpr_IV_35.7.d,</group>
     <description>Multiple Microsoft Security Essentials AV warnings detected.</description>
   </rule>
 </group>

--- a/rules/0235-vmware_rules.xml
+++ b/rules/0235-vmware_rules.xml
@@ -21,7 +21,7 @@
     <if_sid>19100</if_sid>
     <status>^crit|^fatal</status>
     <description>VMware ESX critical message.</description>
-    <group>gpg13_4.1,</group>
+    <group>gpg13_4.1,gdpr_IV_35.7.d,</group>
   </rule>
 
  <rule id="19103" level="4">
@@ -63,14 +63,14 @@
     <if_sid>19106</if_sid>
     <match>logged in$</match>
     <description>VMWare ESX authentication success.</description>
-    <group>authentication_success,pci_dss_10.2.5,gpg13_7.1,gpg13_7.2,</group>
+    <group>authentication_success,pci_dss_10.2.5,gpg13_7.1,gpg13_7.2,gdpr_IV_32.2,</group>
   </rule>
 
   <rule id="19111" level="5">
     <if_sid>19106</if_sid>
     <match>Failed login attempt for</match>
     <description>VMWare ESX authentication failure.</description>
-    <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,</group>
+    <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
   </rule>
 
   <rule id="19112" level="3">
@@ -78,7 +78,7 @@
     <program_name>vmware-hostd|vmware-authd</program_name>
     <match>Accepted password for|login from</match>
     <description>VMWare ESX user login.</description>
-    <group>authentication_success,pci_dss_10.2.5,gpg13_7.1,gpg13_7.2,</group>
+    <group>authentication_success,pci_dss_10.2.5,gpg13_7.1,gpg13_7.2,gdpr_IV_32.2,</group>
   </rule>
 
   <rule id="19113" level="3">
@@ -86,7 +86,7 @@
     <program_name>vmware-hostd|vmware-authd</program_name>
     <match>Rejected password for</match>
     <description>VMWare ESX user authentication failure.</description>
-    <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,</group>
+    <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
   </rule>
 
 
@@ -95,7 +95,7 @@
     <if_sid>19106</if_sid>
     <match>-> VM_STATE_OFF</match>
     <description>Virtual machine state changed to OFF.</description>
-    <group>service_availability,pci_dss_10.6.1,gpg13_4.13,</group>
+    <group>service_availability,pci_dss_10.6.1,gpg13_4.13,gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="19121" level="3">
@@ -117,7 +117,7 @@
     <if_sid>19106</if_sid>
     <match>-> VM_STATE_RECONFIGURING</match>
     <description>Virtual machine being reconfigured.</description>
-    <group>config_changed,pci_dss_10.2.7,gpg13_4.13,</group>
+    <group>config_changed,pci_dss_10.2.7,gpg13_4.13,gdpr_IV_35.7.d,</group>
     <options>alert_by_email</options>
   </rule>
 
@@ -127,25 +127,25 @@
   <rule id="19150" level="10" frequency="6" timeframe="120" ignore="60">
     <if_matched_sid>19104</if_matched_sid>
     <description>Multiple VMWare ESX warning messages.</description>
-    <group>service_availability,pci_dss_10.6.1,gpg13_4.12,</group>
+    <group>service_availability,pci_dss_10.6.1,gpg13_4.12,gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="19151" level="10" frequency="6" timeframe="120" ignore="60">
     <if_matched_sid>19103</if_matched_sid>
     <description>Multiple VMWare ESX error messages.</description>
-    <group>service_availability,pci_dss_10.6.1,gpg13_4.3,</group>
+    <group>service_availability,pci_dss_10.6.1,gpg13_4.3,gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="19152" level="10" frequency="6" timeframe="120">
     <if_matched_sid>19111</if_matched_sid>
     <description>Multiple VMWare ESX authentication failures.</description>
-    <group>authentication_failures,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gpg13_7.1,</group>
+    <group>authentication_failures,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
   </rule>
 
   <rule id="19153" level="10" frequency="6" timeframe="120">
     <if_matched_sid>19113</if_matched_sid>
     <description>Multiple VMWare ESX user authentication failures.</description>
-    <group>authentication_failures,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gpg13_7.1,</group>
+    <group>authentication_failures,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
   </rule>
 
 </group>

--- a/rules/0240-ids_rules.xml
+++ b/rules/0240-ids_rules.xml
@@ -63,7 +63,7 @@
     <same_id />
     <check_if_ignored>id</check_if_ignored>
     <description>Multiple IDS alerts for same id.</description>
-    <group>pci_dss_10.6.1,pci_dss_11.4,</group>
+    <group>pci_dss_10.6.1,pci_dss_11.4,gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="20151" level="10" frequency="$IDS_FREQ" timeframe="120" ignore="90">
@@ -71,7 +71,7 @@
     <same_source_ip />
     <check_if_ignored>srcip, id</check_if_ignored>
     <description>Multiple IDS events from same source ip.</description>
-    <group>pci_dss_10.6.1,pci_dss_11.4,</group>
+    <group>pci_dss_10.6.1,pci_dss_11.4,gdpr_IV_35.7.d,</group>
   </rule>
 
 
@@ -86,6 +86,7 @@
     <ignore>srcip, id</ignore>
     <description>Multiple IDS events from same source ip </description>
     <description>(ignoring now this srcip and id).</description>
+    <group>gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="20162" level="11" frequency="3" timeframe="3800">
@@ -94,5 +95,6 @@
     <ignore>id</ignore>
     <description>Multiple IDS alerts for same id </description>
     <description>(ignoring now this id).</description>
+    <group>gdpr_IV_35.7.d,</group>
   </rule>
 </group>

--- a/rules/0240-ids_rules.xml
+++ b/rules/0240-ids_rules.xml
@@ -86,7 +86,7 @@
     <ignore>srcip, id</ignore>
     <description>Multiple IDS events from same source ip </description>
     <description>(ignoring now this srcip and id).</description>
-    <group>gdpr_IV_35.7.d,</group>
+    <group>pci_dss_10.6.1,pci_dss_11.4,gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="20162" level="11" frequency="3" timeframe="3800">
@@ -95,6 +95,6 @@
     <ignore>id</ignore>
     <description>Multiple IDS alerts for same id </description>
     <description>(ignoring now this id).</description>
-    <group>gdpr_IV_35.7.d,</group>
+    <group>pci_dss_10.6.1,pci_dss_11.4,gdpr_IV_35.7.d,</group>
   </rule>
 </group>

--- a/rules/0245-web_rules.xml
+++ b/rules/0245-web_rules.xml
@@ -23,7 +23,7 @@
     <if_sid>31100</if_sid>
     <id>^4</id>
     <description>Web server 400 error code.</description>
-	<group>attack,pci_dss_6.5,pci_dss_11.4,</group>
+	<group>attack,pci_dss_6.5,pci_dss_11.4,gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="31102" level="0">
@@ -38,7 +38,7 @@
     <url>=select%20|select+|insert%20|%20from%20|%20where%20|union%20|</url>
     <url>union+|where+|null,null|xp_cmdshell</url>
     <description>SQL injection attempt.</description>
-    <group>attack,sql_injection,pci_dss_6.5,pci_dss_11.4,pci_dss_6.5.1,</group>
+    <group>attack,sql_injection,pci_dss_6.5,pci_dss_11.4,pci_dss_6.5.1,gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="31104" level="6">
@@ -51,7 +51,7 @@
     <url>/x90/|default.ida|/sumthin|nsiislog.dll|chmod%|wget%|cd%20|</url>
     <url>exec%20|../..//|%5C../%5C|././././|2e%2e%5c%2e|\x5C\x5C</url>
     <description>Common web attack.</description>
-    <group>attack,pci_dss_6.5,pci_dss_11.4,pci_dss_6.5.1,</group>
+    <group>attack,pci_dss_6.5,pci_dss_11.4,pci_dss_6.5.1,gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="31105" level="6">
@@ -59,21 +59,21 @@
     <url>%3Cscript|%3C%2Fscript|script>|script%3E|SRC=javascript|IMG%20|</url>
     <url>%20ONLOAD=|INPUT%20|iframe%20</url>
     <description>XSS (Cross Site Scripting) attempt.</description>
-    <group>attack,pci_dss_6.5,pci_dss_11.4,pci_dss_6.5.7,</group>
+    <group>attack,pci_dss_6.5,pci_dss_11.4,pci_dss_6.5.7,gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="31106" level="6">
     <if_sid>31103, 31104, 31105</if_sid>
     <id>^200</id>
     <description>A web attack returned code 200 (success).</description>
-    <group>attack,pci_dss_6.5,pci_dss_11.4,</group>
+    <group>attack,pci_dss_6.5,pci_dss_11.4,gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="31110" level="6">
     <if_sid>31100</if_sid>
     <url>?-d|?-s|?-a|?-b|?-w</url>
     <description>PHP CGI-bin vulnerability attempt.</description>
-    <group>attack,pci_dss_6.5,pci_dss_11.4,</group>
+    <group>attack,pci_dss_6.5,pci_dss_11.4,gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="31109" level="6">
@@ -81,7 +81,7 @@
     <url>+as+varchar</url>
     <regex>%2Bchar\(\d+\)%2Bchar\(\d+\)%2Bchar\(\d+\)%2Bchar\(\d+\)%2Bchar\(\d+\)%2Bchar\(\d+\)</regex>
     <description>MSSQL Injection attempt (/ur.php, urchin.js)</description>
-    <group>attack,pci_dss_6.5,pci_dss_11.4,pci_dss_6.5.1,</group>
+    <group>attack,pci_dss_6.5,pci_dss_11.4,pci_dss_6.5.1,gdpr_IV_35.7.d,</group>
   </rule>
 
 
@@ -98,7 +98,7 @@
     <if_sid>31100</if_sid>
     <description>URL too long. Higher than allowed on most </description>
     <description>browsers. Possible attack.</description>
-    <group>invalid_access,pci_dss_6.5,pci_dss_11.4,pci_dss_6.5.8,pci_dss_10.2.4,</group>
+    <group>invalid_access,pci_dss_6.5,pci_dss_11.4,pci_dss_6.5.8,pci_dss_10.2.4,gdpr_IV_35.7.d,</group>
   </rule>
 
 
@@ -153,7 +153,7 @@
     <same_source_ip />
     <description>Multiple web server 400 error codes </description>
     <description>from same source ip.</description>
-    <group>web_scan,recon,pci_dss_6.5,pci_dss_11.4,</group>
+    <group>web_scan,recon,pci_dss_6.5,pci_dss_11.4,gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="31152" level="10" frequency="6" timeframe="120">
@@ -161,14 +161,14 @@
     <same_source_ip />
     <description>Multiple SQL injection attempts from same </description>
     <description>source ip.</description>
-    <group>attack,sql_injection,pci_dss_6.5,pci_dss_11.4,pci_dss_6.5.1,</group>
+    <group>attack,sql_injection,pci_dss_6.5,pci_dss_11.4,pci_dss_6.5.1,gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="31153" level="10" frequency="8" timeframe="120">
     <if_matched_sid>31104</if_matched_sid>
     <same_source_ip />
     <description>Multiple common web attacks from same source ip.</description>
-    <group>attack,pci_dss_6.5,pci_dss_11.4,</group>
+    <group>attack,pci_dss_6.5,pci_dss_11.4,gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="31154" level="10" frequency="8" timeframe="120">
@@ -176,42 +176,42 @@
     <same_source_ip />
     <description>Multiple XSS (Cross Site Scripting) attempts </description>
     <description>from same source ip.</description>
-    <group>attack,pci_dss_6.5,pci_dss_11.4,pci_dss_6.5.7,</group>
+    <group>attack,pci_dss_6.5,pci_dss_11.4,pci_dss_6.5.7,gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="31161" level="10" frequency="12" timeframe="120">
     <if_matched_sid>31121</if_matched_sid>
     <same_source_ip />
     <description>Multiple web server 501 error code (Not Implemented).</description>
-    <group>web_scan,recon,pci_dss_6.5,pci_dss_11.4,</group>
+    <group>web_scan,recon,pci_dss_6.5,pci_dss_11.4,gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="31162" level="10" frequency="12" timeframe="120">
     <if_matched_sid>31122</if_matched_sid>
     <same_source_ip />
     <description>Multiple web server 500 error code (Internal Error).</description>
-    <group>system_error,pci_dss_6.5,pci_dss_10.6.1,</group>
+    <group>system_error,pci_dss_6.5,pci_dss_10.6.1,gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="31163" level="10" frequency="12" timeframe="120">
     <if_matched_sid>31123</if_matched_sid>
     <same_source_ip />
     <description>Multiple web server 503 error code (Service unavailable).</description>
-    <group>web_scan,recon,pci_dss_6.5,pci_dss_11.4,pci_dss_10.6.1,</group>
+    <group>web_scan,recon,pci_dss_6.5,pci_dss_11.4,pci_dss_10.6.1,gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="31164" level="6">
     <if_sid>31100</if_sid>
     <url>=%27|select%2B|insert%2B|%2Bfrom%2B|%2Bwhere%2B|%2Bunion%2B</url>
     <description>SQL injection attempt.</description>
-    <group>attack,sqlinjection,attack,pci_dss_6.5,pci_dss_11.4,pci_dss_6.5.1,</group>
+    <group>attack,sqlinjection,attack,pci_dss_6.5,pci_dss_11.4,pci_dss_6.5.1,gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="31165" level="6">
     <if_sid>31100</if_sid>
     <url>%EF%BC%87|%EF%BC%87|%EF%BC%87|%2531|%u0053%u0045</url>
     <description>SQL injection attempt.</description>
-    <group>attack,sqlinjection,pci_dss_6.5,pci_dss_11.4,pci_dss_6.5.1,</group>
+    <group>attack,sqlinjection,pci_dss_6.5,pci_dss_11.4,pci_dss_6.5.1,gdpr_IV_35.7.d,</group>
   </rule>
 
     <!--
@@ -229,7 +229,7 @@
         <description>Shellshock attack detected</description>
 	<info type="cve">CVE-2014-6271</info>
 	<info type="link">https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2014-6271</info>
-        <group>attack,pci_dss_11.4,</group>
+        <group>attack,pci_dss_11.4,gdpr_IV_35.7.d,</group>
     </rule>
 
 </group>

--- a/rules/0250-apache_rules.xml
+++ b/rules/0250-apache_rules.xml
@@ -37,21 +37,21 @@
     <match>exit signal Segmentation Fault</match>
     <description>Apache: segmentation fault.</description>
     <info type="link">http://www.securityfocus.com/infocus/1633</info>
-    <group>service_availability,pci_dss_6.5.2,pci_dss_6.6,gpg13_4.14,</group>
+    <group>service_availability,pci_dss_6.5.2,pci_dss_6.6,gpg13_4.14,gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="30105" level="5">
     <if_sid>30101</if_sid>
     <match>denied by server configuration</match>
     <description>Apache: Attempt to access forbidden file or directory.</description>
-    <group>access_denied,pci_dss_6.5.8,pci_dss_10.2.4,</group>
+    <group>access_denied,pci_dss_6.5.8,pci_dss_10.2.4,gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="30106" level="5">
     <if_sid>30101</if_sid>
     <match>Directory index forbidden by rule</match>
     <description>Apache: Attempt to access forbidden directory index.</description>
-    <group>access_denied,pci_dss_6.5.8,pci_dss_10.2.4,</group>
+    <group>access_denied,pci_dss_6.5.8,pci_dss_10.2.4,gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="30107" level="6">
@@ -60,28 +60,28 @@
     <description>Apache: Code Red attack.</description>
     <info type="link">http://www.cert.org/advisories/CA-2001-19.html</info>
     <info type="text">CERT: Advisory CA-2001-19 "Code Red" Worm Exploiting Buffer Overflow In IIS Indexing Service DLL</info>
-    <group>automatic_attack,pci_dss_6.2,pci_dss_6.5.2,pci_dss_11.4,</group>
+    <group>automatic_attack,pci_dss_6.2,pci_dss_6.5.2,pci_dss_11.4,gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="30108" level="5">
     <if_sid>30102</if_sid>
     <match>authentication failed</match>
     <description>Apache: User authentication failed.</description>
-    <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,</group>
+    <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
   </rule>
 
   <rule id="30109" level="9">
     <if_sid>30101</if_sid>
     <regex>user \S+ not found|user \S+ in realm \.* not found</regex>
     <description>Apache: Attempt to login using a non-existent user.</description>
-    <group>invalid_login,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,</group>
+    <group>invalid_login,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
   </rule>
 
   <rule id="30110" level="5">
     <if_sid>30101</if_sid>
     <match>authentication failure</match>
     <description>Apache: User authentication failed.</description>
-    <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,</group>
+    <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
   </rule>
 
   <rule id="30112" level="0">
@@ -90,7 +90,7 @@
     <match>failed to open stream: No such file or directory|</match>
     <match>Failed opening </match>
     <description>Apache: Attempt to access an non-existent file (those are reported on the access.log).</description>
-    <group>unknown_resource,pci_dss_10.2.1,pci_dss_10.2.4,</group>
+    <group>unknown_resource,pci_dss_10.2.1,pci_dss_10.2.4,gdpr_IV_35.7.d,</group>
   </rule>
 
   <!-- [Tue Mar 07 12:05:15 2006] [error] [client 200.206.165.91] Invalid URI in request %3Bi%3A3%3Bi%3A0%3B%7D; usercookie[password]=d6ed9e1750d0b2aba6b3311cbec087d8; 45befd35f8a0f47b89ed8831f892b8dc=167c4e46a940cd2570b952eea527b27a; PHPSESSID=616hjdg7kj9bln37efsv7vt7g3
@@ -107,14 +107,14 @@
     <if_matched_sid>30115</if_matched_sid>
     <same_source_ip />
     <description>Apache: Multiple Invalid URI requests from same source.</description>
-    <group>invalid_request,pci_dss_10.2.4,pci_dss_11.4,</group>
+    <group>invalid_request,pci_dss_10.2.4,pci_dss_11.4,gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="30117" level="10">
     <if_sid>30101</if_sid>
     <match>File name too long|request failed: URI too long</match>
     <description>Apache: Invalid URI, file name too long.</description>
-    <group>invalid_request,pci_dss_10.2.4,</group>
+    <group>invalid_request,pci_dss_10.2.4,gdpr_IV_35.7.d,</group>
   </rule>
 
   <!-- Mod security rules by <ossec ( at ) sioban.net -->
@@ -122,21 +122,21 @@
     <if_sid>30101</if_sid>
     <match>mod_security: Access denied|ModSecurity: Access denied</match>
     <description>ModSecurity: Access attempt blocked.</description>
-    <group>modsecurity,access_denied,pci_dss_10.2.4,</group>
+    <group>modsecurity,access_denied,pci_dss_10.2.4,gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="30119" level="12" frequency="6" timeframe="120">
     <if_matched_sid>30118</if_matched_sid>
     <same_source_ip />
     <description>ModSecurity: Multiple attempts blocked.</description>
-    <group>modsecurity,access_denied,pci_dss_10.2.4,pci_dss_11.4,</group>
+    <group>modsecurity,access_denied,pci_dss_10.2.4,pci_dss_11.4,gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="30120" level="12">
     <if_sid>30101</if_sid>
     <match>Resource temporarily unavailable:</match>
     <description>Apache: without resources to run.</description>
-    <group>service_availability,pci_dss_10.6.1,</group>
+    <group>service_availability,pci_dss_10.6.1,gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="30200" level="6" noalert="1">
@@ -149,13 +149,13 @@
     <if_sid>30200</if_sid>
     <match>^mod_security-message: Access denied </match>
     <description>ModSecurity: access denied.</description>
-    <group>modsecurity,access_denied,pci_dss_10.2.4,</group>
+    <group>modsecurity,access_denied,pci_dss_10.2.4,gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="30202" level="10" frequency="8" timeframe="120">
     <if_matched_sid>30201</if_matched_sid>
     <description>ModSecurity: Multiple attempts blocked.</description>
-    <group>modsecurity,access_denied,pci_dss_10.2.4,pci_dss_11.4,</group>
+    <group>modsecurity,access_denied,pci_dss_10.2.4,pci_dss_11.4,gdpr_IV_35.7.d,</group>
   </rule>
 
   <!-- Apache 2.4 Rules -->
@@ -182,21 +182,21 @@
     <match>exit signal Segmentation Fault</match>
     <description>Apache: segmentation fault.</description>
     <info type="link">http://www.securityfocus.com/infocus/1633</info>
-    <group>service_availability,pci_dss_6.5.2,pci_dss_6.6,gpg13_4.14,</group>
+    <group>service_availability,pci_dss_6.5.2,pci_dss_6.6,gpg13_4.14,gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="30305" level="5">
     <if_sid>30301</if_sid>
     <id>AH01630</id>
     <description>Apache: Attempt to access forbidden file or directory.</description>
-    <group>access_denied,pci_dss_6.5.8,pci_dss_10.2.4,</group>
+    <group>access_denied,pci_dss_6.5.8,pci_dss_10.2.4,gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="30306" level="5">
     <if_sid>30301</if_sid>
     <id>AH01276</id>
     <description>Apache: Attempt to access forbidden directory index.</description>
-    <group>access_denied,pci_dss_6.5.8,pci_dss_10.2.4,</group>
+    <group>access_denied,pci_dss_6.5.8,pci_dss_10.2.4,gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="30307" level="6">
@@ -205,28 +205,28 @@
     <description>Apache: Client sent malformed Host header. Possible Code Red attack.</description>
     <info type="link">http://www.cert.org/advisories/CA-2001-19.html</info>
     <info type="text">CERT: Advisory CA-2001-19 "Code Red" Worm Exploiting Buffer Overflow In IIS Indexing Service DLL</info>
-    <group>automatic_attack,pci_dss_6.2,pci_dss_6.5.2,pci_dss_11.4,</group>
+    <group>automatic_attack,pci_dss_6.2,pci_dss_6.5.2,pci_dss_11.4,gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="30308" level="5">
     <if_sid>30302</if_sid>
     <id>AH01617|AH01807|AH01694|AH01695|AH02009|AH02010</id>
     <description>Apache: User authentication failed.</description>
-    <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,</group>
+    <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
   </rule>
 
   <rule id="30309" level="5">
     <if_sid>30301</if_sid>
     <id>AH01618|AH01808|AH01790</id>
     <description>Apache: Attempt to login using a non-existent user.</description>
-    <group>invalid_login,pci_dss_11.4,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,</group>
+    <group>invalid_login,pci_dss_11.4,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
   </rule>
 
   <rule id="30310" level="10" frequency="10" timeframe="160">
     <if_matched_sid>30309</if_matched_sid>
     <same_source_ip/>
     <description>Apache: Multiple authentication failures with invalid user.</description>
-    <group>authentication_failures,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,</group>
+    <group>authentication_failures,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
   </rule>
 
   <rule id="30312" level="0">
@@ -235,28 +235,28 @@
     <match>failed to open stream: No such file or directory|</match>
     <match>Failed opening </match>
     <description>Apache: Attempt to access an non-existent file (those are reported on the access.log).</description>
-    <group>unknown_resource,pci_dss_10.2.4,</group>
+    <group>unknown_resource,pci_dss_10.2.4,gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="30315" level="5">
     <if_sid>30301</if_sid>
     <id>AH00126</id>
     <description>Apache: Invalid URI (bad client request).</description>
-    <group>invalid_request,pci_dss_10.2.4,</group>
+    <group>invalid_request,pci_dss_10.2.4,gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="30316" level="10" frequency="8" timeframe="120">
     <if_matched_sid>30315</if_matched_sid>
     <same_source_ip />
     <description>Apache: Multiple Invalid URI requests from same source.</description>
-    <group>invalid_request,pci_dss_10.2.4,pci_dss_11.4,</group>
+    <group>invalid_request,pci_dss_10.2.4,pci_dss_11.4,gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="30317" level="10">
     <if_sid>30301</if_sid>
     <id>AH00565</id>
     <description>Apache: Invalid URI, file name too long.</description>
-    <group>invalid_request,pci_dss_10.2.4,</group>
+    <group>invalid_request,pci_dss_10.2.4,gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="30318" level="5">
@@ -277,7 +277,7 @@
     <if_sid>30301</if_sid>
     <match>ModSecurity: Access denied</match>
     <description>ModSecurity Access denied messages grouped</description>
-    <group>modsecurity,pci_dss_10.2.4,</group>
+    <group>modsecurity,pci_dss_10.2.4,gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="30403" level="0">
@@ -309,7 +309,7 @@
         <description>Apache: Shellshock attack attempt</description>
 	<info type="cve">CVE-2014-6271</info>
 	<info type="link">https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2014-6271</info>
-        <group>attack,pci_dss_11.4,</group>
+        <group>attack,pci_dss_11.4,gdpr_IV_35.7.d,</group>
     </rule>
 
 </group>

--- a/rules/0255-zeus_rules.xml
+++ b/rules/0255-zeus_rules.xml
@@ -30,21 +30,21 @@
     <if_sid>31200</if_sid>
     <regex>^[\S+ \S+] SERIOUS:</regex>
     <description>Zeus serious log.</description>
-    <group>gpg13_4.3,</group>
+    <group>gpg13_4.3,gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="31204" level="12">
     <if_sid>31200</if_sid>
     <regex>^[\S+ \S+] FATAL:</regex>
     <description>Zeus fatal log.</description>
-    <group>pci_dss_10.6.1,gpg13_4.1,</group>
+    <group>pci_dss_10.6.1,gpg13_4.1,gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="31205" level="8">
     <if_sid>31202</if_sid>
     <match>admin:Authentication failure</match>
     <description>Zeus: Admin authentication failed.</description>
-    <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,</group>
+    <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
   </rule>
 
   <rule id="31206" level="0">
@@ -57,6 +57,6 @@
   <rule id="31251" level="10" frequency="6" timeframe="120">
     <if_matched_sid>31202</if_matched_sid>
     <description>Multiple Zeus warnings.</description>
-    <group>pci_dss_10.6.1,gpg13_4.12,</group>
+    <group>pci_dss_10.6.1,gpg13_4.12,gdpr_IV_35.7.d,</group>
   </rule>
 </group>

--- a/rules/0260-nginx_rules.xml
+++ b/rules/0260-nginx_rules.xml
@@ -40,14 +40,14 @@
     <if_sid>31301</if_sid>
     <match>accept() failed (53: Software caused connection abort)</match>
     <description>Nginx: Incomplete client request.</description>
-    <group>pci_dss_10.6.1,</group>
+    <group>pci_dss_10.6.1,gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="31312" level="0">
     <if_sid>31301</if_sid>
     <match>no user/password was provided for basic authentication</match>
     <description>Nginx: Initial 401 authentication request.</description>
-    <group>pci_dss_10.6.1,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,</group>
+    <group>pci_dss_10.6.1,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
   </rule>
 
   <rule id="31315" level="5">
@@ -55,14 +55,14 @@
     <match> password mismatch, client| was not found in </match>
     <description>Nginx: Web authentication failed.</description>
     <group>authentication_failed,</group>
-    <group>pci_dss_10.6.1,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,</group>
+    <group>pci_dss_10.6.1,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
   </rule>
 
   <rule id="31316" level="10" frequency="6" timeframe="240">
     <if_matched_sid>31315</if_matched_sid>
     <same_source_ip />
     <description>Nginx: Multiple web authentication failures.</description>
-    <group>authentication_failures,pci_dss_10.6.1,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gpg13_7.1,</group>
+    <group>authentication_failures,pci_dss_10.6.1,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
   </rule>
 
   <rule id="31317" level="0">
@@ -75,7 +75,7 @@
     <if_sid>31301</if_sid>
     <match>failed (36: File name too long)</match>
     <description>Nginx: Invalid URI, file name too long.</description>
-    <group>invalid_request,pci_dss_10.2.4,</group>
+    <group>invalid_request,pci_dss_10.2.4,gdpr_IV_35.7.d,</group>
   </rule>
 
   <!-- ModSecurity Rules -->
@@ -90,7 +90,7 @@
     <if_sid>31301</if_sid>
     <match>ModSecurity: Access denied</match>
     <description>ModSecurity Access denied messages grouped</description>
-    <group>modsecurity,pci_dss_10.2.4,</group>
+    <group>modsecurity,pci_dss_10.2.4,gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="31332" level="0">

--- a/rules/0265-php_rules.xml
+++ b/rules/0265-php_rules.xml
@@ -17,14 +17,14 @@
     <if_sid>31301, 30101</if_sid>
     <match>PHP Fatal error: </match>
     <description>PHP Fatal error.</description>
-    <group>pci_dss_6.5,pci_dss_6.5.5,pci_dss_10.6.1,gpg13_4.1,</group>
+    <group>pci_dss_6.5,pci_dss_6.5.5,pci_dss_10.6.1,gpg13_4.1,gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="31403" level="0">
     <if_sid>31301, 30101</if_sid>
     <match>PHP Parse error:</match>
     <description>PHP Parse error.</description>
-    <group>pci_dss_6.5,pci_dss_6.5.5,pci_dss_10.6.1,gpg13_4.3,</group>
+    <group>pci_dss_6.5,pci_dss_6.5.5,pci_dss_10.6.1,gpg13_4.3,gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="31404" level="0">
@@ -35,13 +35,13 @@
   <rule id="31405" level="0">
     <match>^PHP Fatal error: </match>
     <description>PHP Fatal error.</description>
-    <group>pci_dss_6.5,pci_dss_6.5.5,pci_dss_10.6.1,gpg13_4.1,</group>
+    <group>pci_dss_6.5,pci_dss_6.5.5,pci_dss_10.6.1,gpg13_4.1,gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="31406" level="0">
     <match>^PHP Parse error: </match>
     <description>PHP Parse error.</description>
-    <group>pci_dss_6.5,pci_dss_6.5.5,pci_dss_10.6.1,gpg13_4.3,</group>
+    <group>pci_dss_6.5,pci_dss_6.5.5,pci_dss_10.6.1,gpg13_4.3,gdpr_IV_35.7.d,</group>
   </rule>
 
 
@@ -56,7 +56,7 @@
   <rule id="31411" level="6">
     <if_sid>31410</if_sid>
     <match> expects parameter 1 to be string, array given in</match>
-    <group>attack,pci_dss_6.5,pci_dss_11.4,</group>
+    <group>attack,pci_dss_6.5,pci_dss_11.4,gdpr_IV_35.7.d,</group>
     <description>PHP web attack.</description>
   </rule>
 
@@ -65,7 +65,7 @@
     <match>Failed opening|failed to open stream</match>
     <description>PHP internal error (missing file).</description>
     <options>alert_by_email</options>
-    <group>attack,pci_dss_6.5,gpg13_4.3,</group>
+    <group>attack,pci_dss_6.5,gpg13_4.3,gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="31413" level="5" ignore="1200">
@@ -74,7 +74,7 @@
     <description>PHP internal error (server out of space).</description>
     <options>alert_by_email</options>
     <group>low_diskspace,</group>
-    <group>attack,pci_dss_6.5,pci_dss_10.2.7,gpg13_4.3,</group>
+    <group>attack,pci_dss_6.5,pci_dss_10.2.7,gpg13_4.3,gdpr_IV_35.7.d,</group>
   </rule>
 
 
@@ -92,7 +92,7 @@ d 'includes/SkinTemplate.php'
     <match>Failed opening required |Call to undefined function </match>
     <description>PHP internal error (missing file or function).</description>
     <options>alert_by_email</options>
-    <group>pci_dss_6.5,pci_dss_6.5.5,pci_dss_10.6.1,gpg13_4.3,</group>
+    <group>pci_dss_6.5,pci_dss_6.5.5,pci_dss_10.6.1,gpg13_4.3,gdpr_IV_35.7.d,</group>
   </rule>
 
 
@@ -102,7 +102,7 @@ d 'includes/SkinTemplate.php'
     <if_sid>31403, 31406</if_sid>
     <description>PHP Parse error.</description>
     <options>alert_by_email</options>
-    <group>pci_dss_6.5,pci_dss_6.5.5,pci_dss_10.6.1,gpg13_4.3,</group>
+    <group>pci_dss_6.5,pci_dss_6.5.5,pci_dss_10.6.1,gpg13_4.3,gdpr_IV_35.7.d,</group>
   </rule>
 
 </group>

--- a/rules/0270-web_appsec_rules.xml
+++ b/rules/0270-web_appsec_rules.xml
@@ -20,7 +20,7 @@
     <url>/wp-comments-post.php</url>
     <regex>Googlebot|MSNBot|BingBot</regex>
     <description>WordPress Comment Spam (coming from a fake search engine UA).</description>
-    <group>pci_dss_6.5,pci_dss_11.4,</group>
+    <group>pci_dss_6.5,pci_dss_11.4,gdpr_IV_35.7.d,</group>
    </rule>
 
   <!-- Timthumb scans.
@@ -30,7 +30,7 @@
     <url>thumb.php|timthumb.php</url>
     <regex> "GET \S+thumb.php?src=\S+.php</regex>
     <description>TimThumb vulnerability exploit attempt.</description>
-    <group>pci_dss_6.5,pci_dss_11.4,</group>
+    <group>pci_dss_6.5,pci_dss_11.4,gdpr_IV_35.7.d,</group>
    </rule>
 
   <!-- osCommerce login.php bypass
@@ -40,7 +40,7 @@
     <url>login.php</url>
     <regex> "POST /\S+.php/login.php?cPath=</regex>
     <description>osCommerce login.php bypass attempt.</description>
-    <group>pci_dss_6.5,pci_dss_11.4,pci_dss_10.2.4,</group>
+    <group>pci_dss_6.5,pci_dss_11.4,pci_dss_10.2.4,gdpr_IV_35.7.d,</group>
    </rule>
 
   <!-- osCommerce file manager login.php bypass
@@ -50,7 +50,7 @@
     <url>login.php</url>
     <regex>/admin/\w+.php/login.php</regex>
     <description>osCommerce file manager login.php bypass attempt.</description>
-    <group>pci_dss_6.5,pci_dss_11.4,pci_dss_10.2.4,</group>
+    <group>pci_dss_6.5,pci_dss_11.4,pci_dss_10.2.4,gdpr_IV_35.7.d,</group>
    </rule>
 
   <!-- Timthumb backdoor access.
@@ -60,7 +60,7 @@
     <url>/cache/external</url>
     <regex> "GET /\S+/cache/external\S+.php</regex>
     <description>TimThumb backdoor access attempt.</description>
-    <group>pci_dss_6.5,pci_dss_11.4,pci_dss_10.2.4,</group>
+    <group>pci_dss_6.5,pci_dss_11.4,pci_dss_10.2.4,gdpr_IV_35.7.d,</group>
    </rule>
 
   <!-- Timthumb backdoor access.
@@ -70,7 +70,7 @@
     <url>cart.php</url>
     <regex> "GET /\S+cart.php?\S+templatefile=../</regex>
     <description>Cart.php directory transversal attempt.</description>
-    <group>pci_dss_6.5,pci_dss_11.4,pci_dss_10.2.4,pci_dss_6.5.1,</group>
+    <group>pci_dss_6.5,pci_dss_11.4,pci_dss_10.2.4,pci_dss_6.5.1,gdpr_IV_35.7.d,</group>
    </rule>
 
   <!-- MSSQL IIS inject rules -->
@@ -78,7 +78,7 @@
     <if_sid>31100</if_sid>
     <url>DECLARE%20@S%20CHAR|%20AS%20CHAR</url>
     <description>MSSQL Injection attempt (ur.php, urchin.js).</description>
-   <group>pci_dss_6.5,pci_dss_11.4,pci_dss_6.5.1,</group>
+   <group>pci_dss_6.5,pci_dss_11.4,pci_dss_6.5.1,gdpr_IV_35.7.d,</group>
   </rule>
 
   <!-- BAD/Annoying user agents -->
@@ -86,7 +86,7 @@
     <if_sid>31100</if_sid>
     <match> "ZmEu"| "libwww-perl/|"the beast"|"Morfeus|"ZmEu|"Nikto|"w3af.sourceforge.net| Jorgee"|"Proxy Gear Pro|"DataCha0s</match>
     <description>Blacklisted user agent (known malicious user agent).</description>
-   <group>pci_dss_6.5,pci_dss_11.4,</group>
+   <group>pci_dss_6.5,pci_dss_11.4,gdpr_IV_35.7.d,</group>
   </rule>
 
   <!-- WordPress wp-login.php brute force -->
@@ -95,7 +95,7 @@
     <url>wp-login.php|/administrator</url>
     <regex>] "POST \S+wp-login.php| "POST /administrator</regex>
     <description>CMS (WordPress or Joomla) login attempt.</description>
-   <group>pci_dss_6.5,pci_dss_11.4,pci_dss_6.5.10,pci_dss_10.2.4,pci_dss_10.2.5,</group>
+   <group>pci_dss_6.5,pci_dss_11.4,pci_dss_6.5.10,pci_dss_10.2.4,pci_dss_10.2.5,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
   </rule>
 
   <!-- If we see frequent wp-login POST's, it is likely a bot. -->
@@ -103,7 +103,7 @@
     <if_matched_sid>31509</if_matched_sid>
     <same_source_ip />
     <description>CMS (WordPress or Joomla) brute force attempt.</description>
-   <group>pci_dss_6.5,pci_dss_11.4,pci_dss_6.5.10,pci_dss_10.2.4,pci_dss_10.2.5,</group>
+   <group>pci_dss_6.5,pci_dss_11.4,pci_dss_6.5.10,pci_dss_10.2.4,pci_dss_10.2.5,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
   </rule>
 
   <!-- Nothing wrong with wget per se, but it misses a lot of links
@@ -113,7 +113,7 @@
     <if_sid>31100</if_sid>
     <match>" "Wget/</match>
     <description>Blacklisted user agent (wget).</description>
-   <group>pci_dss_6.5,pci_dss_11.4,</group>
+   <group>pci_dss_6.5,pci_dss_11.4,gdpr_IV_35.7.d,</group>
   </rule>
 
   <!-- Uploadify scans.
@@ -123,7 +123,7 @@
     <url>uploadify.php</url>
     <regex> "GET /\S+/uploadify.php?src=http://\S+.php</regex>
     <description>Uploadify vulnerability exploit attempt.</description>
-   <group>pci_dss_6.5,pci_dss_11.4,</group>
+   <group>pci_dss_6.5,pci_dss_11.4,gdpr_IV_35.7.d,</group>
    </rule>
 
   <!-- BBS delete.php skin_path.
@@ -133,7 +133,7 @@
     <url>delete.php</url>
     <regex> "GET \S+/delete.php?board_skin_path=http://\S+.php</regex>
     <description>BBS delete.php exploit attempt.</description>
-   <group>pci_dss_6.5,pci_dss_11.4,</group>
+   <group>pci_dss_6.5,pci_dss_11.4,gdpr_IV_35.7.d,</group>
    </rule>
 
   <!-- Simple shell.php command execution
@@ -143,7 +143,7 @@
     <url>shell.php</url>
     <regex> "GET \S+/shell.php?cmd=</regex>
     <description>Simple shell.php command execution.</description>
-   <group>pci_dss_6.5,pci_dss_11.4,</group>
+   <group>pci_dss_6.5,pci_dss_11.4,gdpr_IV_35.7.d,</group>
    </rule>
 
   <!-- PHPMyAdmin scans
@@ -152,7 +152,7 @@
     <if_sid>31100</if_sid>
     <url>phpMyAdmin/scripts/setup.php</url>
     <description>PHPMyAdmin scans (looking for setup.php).</description>
-   <group>pci_dss_6.5,pci_dss_11.4,</group>
+   <group>pci_dss_6.5,pci_dss_11.4,gdpr_IV_35.7.d,</group>
    </rule>
 
   <!-- Suspicious URL's access
@@ -161,7 +161,7 @@
     <if_sid>31100</if_sid>
     <url>.swp$|.bak$|/.htaccess|/server-status|/.ssh|/.history|/wallet.dat</url>
     <description>Suspicious URL access.</description>
-   <group>pci_dss_6.5,pci_dss_11.4,</group>
+   <group>pci_dss_6.5,pci_dss_11.4,gdpr_IV_35.7.d,</group>
    </rule>
 
   <!-- Checking POST requests - Too many in a small type = likely a bot -->
@@ -182,7 +182,7 @@
     <if_matched_sid>31530</if_matched_sid>
     <same_source_ip />
     <description>High amount of POST requests in a small period of time (likely bot).</description>
-   <group>pci_dss_6.5,pci_dss_11.4,</group>
+   <group>pci_dss_6.5,pci_dss_11.4,gdpr_IV_35.7.d,</group>
    </rule>
 
   <!-- Anomaly rules - Used on common web attacks -->
@@ -191,7 +191,7 @@
     <url>%00</url>
     <regex> "GET /\S+.php?\S+%00</regex>
     <description>Anomaly URL query (attempting to pass null termination).</description>
-   <group>pci_dss_6.5,pci_dss_11.4,</group>
+   <group>pci_dss_6.5,pci_dss_11.4,gdpr_IV_35.7.d,</group>
    </rule>
 
 </group>

--- a/rules/0275-squid_rules.xml
+++ b/rules/0275-squid_rules.xml
@@ -37,7 +37,7 @@
     <id>^401</id>
     <description>Squid: Unauthorized: Failed attempt to access </description>
     <description>authorization-required file or directory.</description>
-    <group>pci_dss_10.2.4,pci_dss_10.2.5,</group>
+    <group>pci_dss_10.2.4,pci_dss_10.2.5,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
   </rule>
 
   <rule id="35005" level="5">
@@ -45,7 +45,7 @@
     <id>^403</id>
     <description>Squid: Forbidden: Attempt to access forbidden file </description>
     <description>or directory.</description>
-    <group>pci_dss_10.2.4,</group>
+    <group>pci_dss_10.2.4,gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="35006" level="5">
@@ -53,7 +53,7 @@
     <id>^404</id>
     <description>Squid: Not Found: Attempt to access non-existent </description>
     <description>file or directory.</description>
-    <group>pci_dss_10.2.4,</group>
+    <group>pci_dss_10.2.4,gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="35007" level="5">
@@ -61,7 +61,7 @@
     <id>^407</id>
     <description>Squid: Proxy Authentication Required: User is not </description>
     <description>authorized to use proxy.</description>
-    <group>pci_dss_10.2.4,pci_dss_10.2.5,</group>
+    <group>pci_dss_10.2.4,pci_dss_10.2.5,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
   </rule>
 
   <rule id="35008" level="5">
@@ -74,14 +74,14 @@
     <if_sid>35002</if_sid>
     <id>^5|^6</id>
     <description>Squid: 500/600 error code (server error).</description>
-    <group>pci_dss_10.6.1,gpg13_4.3,</group>
+    <group>pci_dss_10.6.1,gpg13_4.3,gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="35010" level="4">
     <if_sid>35009</if_sid>
     <id>^503</id>
     <description>Squid: 503 error code (server unavailable).</description>
-    <group>pci_dss_10.6.1,gpg13_4.3,</group>
+    <group>pci_dss_10.6.1,gpg13_4.3,gdpr_IV_35.7.d,</group>
   </rule>
 
   <!-- Special rules for 403/404 errors -->
@@ -92,7 +92,7 @@
     <description>file.</description>
     <info type="link">http://www.symantec.com/avcenter/venc/data/w32.beagle.dp.html</info>
     <info type="text">W32.Beagle.DP is a Worm that drops Trojan.Lodear and opens a back door on the compromised computer.</info>
-    <group>automatic_attack,pci_dss_11.4,pci_dss_6.2,</group>
+    <group>automatic_attack,pci_dss_11.4,pci_dss_6.2,gdpr_IV_35.7.d,</group>
   </rule>
 
   <!-- Other worms -->
@@ -100,7 +100,7 @@
     <if_sid>35006</if_sid>
     <url>/jk/exp.wmf$|/PopupSh.ocx$</url>
     <description>Squid: Attempt to access a worm/trojan related site.</description>
-    <group>automatic_attack,pci_dss_11.4,pci_dss_6.2,</group>
+    <group>automatic_attack,pci_dss_11.4,pci_dss_6.2,gdpr_IV_35.7.d,</group>
   </rule>
 
   <!-- Ignoring google earth, ms web site access and some other
@@ -138,14 +138,14 @@
     <different_url />
     <description>Squid: Multiple attempts to access forbidden file </description>
     <description>or directory from same source ip.</description>
-    <group>pci_dss_10.2.4,pci_dss_11.4,</group>
+    <group>pci_dss_10.2.4,pci_dss_11.4,gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="35052" level="10" frequency="$SQUID_FREQ" timeframe="120">
     <if_matched_sid>35007</if_matched_sid>
     <same_source_ip />
     <description>Squid: Multiple unauthorized attempts to use proxy.</description>
-    <group>pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,</group>
+    <group>pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
   </rule>
 
   <rule id="35053" level="10" frequency="$SQUID_FREQ" timeframe="120">
@@ -153,7 +153,7 @@
     <same_source_ip />
     <different_url />
     <description>Squid: Multiple Bad requests/Invalid syntax.</description>
-    <group>pci_dss_10.6.1,</group>
+    <group>pci_dss_10.6.1,gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="35054" level="12" frequency="$SQUID_FREQ" timeframe="240">
@@ -162,7 +162,7 @@
     <description>Squid: Infected machine with W32.Beagle.DP.</description>
     <info type="link">http://www.symantec.com/avcenter/venc/data/w32.beagle.dp.html</info>
     <info type="text">W32.Beagle.DP is a Worm that drops Trojan.Lodear and opens a back door on the compromised computer.</info>
-    <group>pci_dss_11.4,pci_dss_6.2,</group>
+    <group>pci_dss_11.4,pci_dss_6.2,gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="35055" level="10" frequency="$SQUID_FREQ" timeframe="90">
@@ -170,7 +170,7 @@
     <same_source_ip />
     <different_url />
     <description>Squid: Multiple attempts to access a non-existent file.</description>
-    <group>pci_dss_10.2.4,pci_dss_11.4,</group>
+    <group>pci_dss_10.2.4,pci_dss_11.4,gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="35056" level="12" frequency="$SQUID_FREQ" timeframe="240">
@@ -178,7 +178,7 @@
     <same_source_ip />
     <description>Squid: Multiple attempts to access a worm/trojan/virus </description>
     <description>related web site. System probably infected.</description>
-    <group>pci_dss_10.2.4,pci_dss_11.4,gpg13_4.2,</group>
+    <group>pci_dss_10.2.4,pci_dss_11.4,gpg13_4.2,gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="35057" level="10" frequency="$SQUID_FREQ" timeframe="240">
@@ -186,6 +186,7 @@
     <same_source_ip />
     <different_url />
     <description>Squid: Multiple 400 error codes (requests failed).</description>
+    <group>gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="35058" level="10" frequency="$SQUID_FREQ" timeframe="240">
@@ -193,6 +194,7 @@
     <same_source_ip />
     <different_url />
     <description>Squid: Multiple 500/600 error codes (server error).</description>
+    <group>gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="35095" level="0" frequency="2" timeframe="360">

--- a/rules/0275-squid_rules.xml
+++ b/rules/0275-squid_rules.xml
@@ -186,7 +186,7 @@
     <same_source_ip />
     <different_url />
     <description>Squid: Multiple 400 error codes (requests failed).</description>
-    <group>gdpr_IV_35.7.d,</group>
+    <group>pci_dss_10.6.1,gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="35058" level="10" frequency="$SQUID_FREQ" timeframe="240">
@@ -194,7 +194,7 @@
     <same_source_ip />
     <different_url />
     <description>Squid: Multiple 500/600 error codes (server error).</description>
-    <group>gdpr_IV_35.7.d,</group>
+    <group>pci_dss_10.6.1,gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="35095" level="0" frequency="2" timeframe="360">

--- a/rules/0280-attack_rules.xml
+++ b/rules/0280-attack_rules.xml
@@ -15,44 +15,44 @@
     <if_group>authentication_success</if_group>
     <user>$SYS_USERS</user>
     <description>System user successfully logged to the system.</description>
-    <group>invalid_login,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.8,</group>
+    <group>invalid_login,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.8,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
   </rule>
 
   <rule id="40102" level="14">
     <regex>^rpc.statd[\d+]: gethostbyname error for \W+</regex>
     <description>Buffer overflow attack on rpc.statd</description>
-    <group>exploit_attempt,pci_dss_6.2,pci_dss_6.5.2,pci_dss_11.4,</group>
+    <group>exploit_attempt,pci_dss_6.2,pci_dss_6.5.2,pci_dss_11.4,gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="40103" level="14">
     <regex>ftpd[\d+]: \S+ FTP LOGIN FROM \.+ 0bin0sh</regex>
     <description>Buffer overflow on WU-FTPD versions prior to 2.6</description>
-    <group>exploit_attempt,pci_dss_6.2,pci_dss_6.5.2,pci_dss_11.4,</group>
+    <group>exploit_attempt,pci_dss_6.2,pci_dss_6.5.2,pci_dss_11.4,gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="40104" level="13">
     <match>?????????????????????</match>
     <description>Possible buffer overflow attempt.</description>
-    <group>exploit_attempt,pci_dss_6.2,pci_dss_6.5.2,pci_dss_11.4,</group>
+    <group>exploit_attempt,pci_dss_6.2,pci_dss_6.5.2,pci_dss_11.4,gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="40105" level="12">
     <match>changed by \(\(null\)</match>
     <description>"Null" user changed some information.</description>
-    <group>exploit_attempt,pci_dss_10.2.7,pci_dss_10.6.1,pci_dss_11.4,</group>
+    <group>exploit_attempt,pci_dss_10.2.7,pci_dss_10.6.1,pci_dss_11.4,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
   </rule>
 
   <rule id="40106" level="12">
     <match>@@@@@@@@@@@@@@@@@@@@@@@@@</match>
     <description>Buffer overflow attempt (probably on yppasswd).</description>
-    <group>exploit_attempt,pci_dss_6.2,pci_dss_6.5.2,pci_dss_11.4,</group>
+    <group>exploit_attempt,pci_dss_6.2,pci_dss_6.5.2,pci_dss_11.4,gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="40107" level="14">
     <regex>cachefsd: Segmentation Fault - core dumped</regex>
     <description>Heap overflow in the Solaris cachefsd service.</description>
     <info type='cve'>2002-0033</info>
-    <group>exploit_attempt,pci_dss_6.2,pci_dss_6.5.2,pci_dss_11.4,</group>
+    <group>exploit_attempt,pci_dss_6.2,pci_dss_6.5.2,pci_dss_11.4,gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="40109" level="12">
@@ -60,13 +60,13 @@
     <description>Stack overflow attempt or program exiting </description>
     <description>with SEGV (Solaris).</description>
     <info type="link">http://snap.nlc.dcccd.edu/reference/sysadmin/julian/ch18/389-392.html</info>
-    <group>exploit_attempt,pci_dss_6.2,pci_dss_6.5.2,pci_dss_11.4,</group>
+    <group>exploit_attempt,pci_dss_6.2,pci_dss_6.5.2,pci_dss_11.4,gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="40111" level="10" frequency="10" timeframe="160">
     <if_matched_group>authentication_failed</if_matched_group>
     <description>Multiple authentication failures.</description>
-    <group>authentication_failures,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,gpg13_7.8,</group>
+    <group>authentication_failures,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,gpg13_7.8,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
   </rule>
 
   <rule id="40112" level="12" timeframe="240">
@@ -75,13 +75,13 @@
     <same_source_ip />
     <description>Multiple authentication failures followed </description>
     <description>by a success.</description>
-    <group>pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gpg13_7.1,gpg13_7.8,</group>
+    <group>pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gpg13_7.1,gpg13_7.8,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
   </rule>
 
   <rule id="40113" level="12" frequency="6" timeframe="360">
     <if_matched_group>virus</if_matched_group>
     <description>Multiple viruses detected - Possible outbreak.</description>
-    <group>virus,pci_dss_5.1,pci_dss_5.2,pci_dss_11.4,gpg13_4.2,</group>
+    <group>virus,pci_dss_5.1,pci_dss_5.2,pci_dss_11.4,gpg13_4.2,gdpr_IV_35.7.d,</group>
   </rule>
 
 </group>
@@ -94,7 +94,7 @@
     <same_location/>
     <description>Attacks followed by the addition </description>
     <description>of an user.</description>
-    <group>pci_dss_10.2.7,pci_dss_10.6.1,pci_dss_11.4,</group>
+    <group>pci_dss_10.2.7,pci_dss_10.6.1,pci_dss_11.4,gdpr_IV_35.7.d,</group>
   </rule>
 </group>
 
@@ -105,6 +105,6 @@
     <description>Network scan from same source ip.</description>
     <same_source_ip />
     <info type="link">http://project.honeynet.org/papers/enemy2/</info>
-    <group>pci_dss_11.4,</group>
+    <group>pci_dss_11.4,gdpr_IV_35.7.d,</group>
   </rule>
 </group>

--- a/rules/0285-systemd_rules.xml
+++ b/rules/0285-systemd_rules.xml
@@ -24,14 +24,14 @@
     <if_sid>40700</if_sid>
     <match>Failed to get unit file state for</match>
     <description>Systemd: Failed to get unit state for service. This means that the .service file is missing</description>
-    <group>gpg13_4.3,</group>
+    <group>gpg13_4.3,gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="40703" level="5">
     <if_sid>40700</if_sid>
     <match>entered failed state</match>
     <description>Systemd: Service has entered a failed state, and likely has not started.</description>
-    <group>gpg13_4.3,</group>
+    <group>gpg13_4.3,gdpr_IV_35.7.d,</group>
   </rule>
 
 </group>

--- a/rules/0295-mysql_rules.xml
+++ b/rules/0295-mysql_rules.xml
@@ -16,14 +16,14 @@
     <if_sid>50100</if_sid>
     <regex>^MySQL log: \d+ \S+ \d+ Connect</regex>
     <description>MySQL: authentication success.</description>
-    <group>authentication_success,pci_dss_10.2.5,pci_dss_8.7,gpg13_7.1,gpg13_7.2,</group>
+    <group>authentication_success,pci_dss_10.2.5,pci_dss_8.7,gpg13_7.1,gpg13_7.2,gdpr_IV_32.2,</group>
   </rule>
 
   <rule id="50106" level="9">
     <if_sid>50105</if_sid>
     <match>Access denied for user</match>
     <description>MySQL: authentication failure.</description>
-    <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_8.7,gpg13_7.1,</group>
+    <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_8.7,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
   </rule>
 
   <rule id="50107" level="0">
@@ -36,14 +36,14 @@
     <if_sid>50100</if_sid>
     <regex>^MySQL log: \d+ \S+ \d+ Quit</regex>
     <description>MySQL: User disconnected from database.</description>
-    <group>pci_dss_10.2.5,pci_dss_8.7,gpg13_7.1,gpg13_7.2,</group>
+    <group>pci_dss_10.2.5,pci_dss_8.7,gpg13_7.1,gpg13_7.2,gdpr_IV_32.2,</group>
   </rule>
 
   <rule id="50120" level="12">
     <if_sid>50100</if_sid>
     <match>mysqld ended|Shutdown complete</match>
     <description>MySQL: shutdown message.</description>
-    <group>service_availability,pci_dss_10.6.1,gpg13_4.14,</group>
+    <group>service_availability,pci_dss_10.6.1,gpg13_4.14,gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="50121" level="3">
@@ -57,20 +57,20 @@
     <if_sid>50100</if_sid>
     <regex>^MySQL log: \d+ \S+ \d+ [ERROR]</regex>
     <description>MySQL: error.</description>
-    <group>gpg13_4.3,</group>
+    <group>gpg13_4.3,gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="50126" level="12">
     <if_sid>50125</if_sid>
     <match>Fatal error:</match>
     <description>MySQL: fatal error.</description>
-    <group>service_availability,pci_dss_10.6.1,gpg13_4.1,</group>
+    <group>service_availability,pci_dss_10.6.1,gpg13_4.1,gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="50180" level="10" frequency="6" timeframe="120" ignore="60">
     <if_matched_sid>50125</if_matched_sid>
     <description>MySQL: Multiple errors.</description>
-    <group>service_availability,pci_dss_10.6.1,gpg13_4.3,</group>
+    <group>service_availability,pci_dss_10.6.1,gpg13_4.3,gdpr_IV_35.7.d,</group>
   </rule>
 
 </group>

--- a/rules/0300-postgresql_rules.xml
+++ b/rules/0300-postgresql_rules.xml
@@ -34,7 +34,7 @@
     <if_sid>50500</if_sid>
     <status>^FATAL</status>
     <description>PostgreSQL error message.</description>
-    <group>pci_dss_10.6.1,gpg13_4.3,</group>
+    <group>pci_dss_10.6.1,gpg13_4.3,gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="50505" level="0">
@@ -53,40 +53,40 @@
     <if_sid>50501</if_sid>
     <match>connection authorized</match>
     <description>PostgreSQL: Database authentication success.</description>
-    <group>authentication_success,pci_dss_10.2.5,gpg13_7.1,gpg13_7.2,</group>
+    <group>authentication_success,pci_dss_10.2.5,gpg13_7.1,gpg13_7.2,gdpr_IV_32.2,</group>
   </rule>
 
   <rule id="50512" level="9">
     <if_sid>50504</if_sid>
     <match>authentication failed</match>
     <description>PostgreSQL: Database authentication failure.</description>
-    <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,</group>
+    <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
   </rule>
 
   <rule id="50520" level="12">
     <if_sid>50504</if_sid>
     <match>terminating connection due</match>
     <description>PostgreSQL: Database shutdown message.</description>
-    <group>service_availability,pci_dss_10.6.1,gpg13_4.14,</group>
+    <group>service_availability,pci_dss_10.6.1,gpg13_4.14,gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="50521" level="12">
     <if_sid>50501</if_sid>
     <match>aborting any active transactions|shutting down</match>
     <description>PostgreSQL: Database shutdown message.</description>
-    <group>service_availability,pci_dss_10.6.1,gpg13_4.14,</group>
+    <group>service_availability,pci_dss_10.6.1,gpg13_4.14,gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="50580" level="10" frequency="6" timeframe="120" ignore="60">
     <if_matched_sid>50504</if_matched_sid>
     <description>PostgreSQL: Multiple database errors.</description>
-    <group>service_availability,pci_dss_10.6.1,pci_dss_11.4,gpg13_4.3,</group>
+    <group>service_availability,pci_dss_10.6.1,pci_dss_11.4,gpg13_4.3,gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="50581" level="10" frequency="6" timeframe="120" ignore="60">
     <if_matched_sid>50503</if_matched_sid>
     <description>PostgreSQL: Multiple database errors.</description>
-    <group>service_availability,pci_dss_10.6.1,pci_dss_11.4,gpg13_4.3,</group>
+    <group>service_availability,pci_dss_10.6.1,pci_dss_11.4,gpg13_4.3,gdpr_IV_35.7.d,</group>
   </rule>
 
 </group>

--- a/rules/0305-dropbear_rules.xml
+++ b/rules/0305-dropbear_rules.xml
@@ -29,42 +29,42 @@
     <if_sid>51000</if_sid>
     <match>bad password attempt for</match>
     <description>Dropbear: Bad password attempt.</description>
-    <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_8.1.5,gpg13_7.1,</group>
+    <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_8.1.5,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
   </rule>
 
   <rule id="51093" level="5">
     <if_sid>51000</if_sid>
     <match>attempt for nonexistent user</match>
     <description>Dropbear: Bad password attempt for non existent user.</description>
-    <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_8.1.5,gpg13_7.1,</group>
+    <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_8.1.5,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
   </rule>
 
   <rule id="51004" level="10" frequency="6" timeframe="120" ignore="60">
     <if_matched_group>authentication_failed</if_matched_group>
     <same_source_ip />
     <description>Dropbear: dropbear brute force attempt.</description>
-    <group>authentication_failures,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,pci_dss_8.1.5,</group>
+    <group>authentication_failures,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,pci_dss_8.1.5,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
   </rule>
 
   <rule id="51005" level="0">
     <if_sid>51000</if_sid>
     <regex>exit after auth \(\S+\): Disconnect received</regex>
     <description>Dropbear: User disconnected.</description>
-    <group>pci_dss_10.2.5,pci_dss_8.1.5,gpg13_7.1,gpg13_7.2,</group>
+    <group>pci_dss_10.2.5,pci_dss_8.1.5,gpg13_7.1,gpg13_7.2,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
   </rule>
 
   <rule id="51006" level="2">
     <if_sid>51000</if_sid>
     <match>exit before auth</match>
     <description>Dropbear: Client exited before authentication.</description>
-    <group>recon,pci_dss_10.6.1,pci_dss_11.4,pci_dss_8.1.5,</group>
+    <group>recon,pci_dss_10.6.1,pci_dss_11.4,pci_dss_8.1.5,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
   </rule>
 
   <rule id="51007" level="10" frequency="6" timeframe="120" ignore="60">
     <if_matched_sid>51000</if_matched_sid>
     <same_source_ip />
     <description>Dropbear: brute force attempt.</description>
-    <group>authentication_failures,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,pci_dss_8.1.5,</group>
+    <group>authentication_failures,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,pci_dss_8.1.5,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
   </rule>
 
 
@@ -72,21 +72,21 @@
     <if_sid>51000</if_sid>
     <match>Incompatible remote version</match>
     <description>Dropbear: Incompatible remote version.</description>
-    <group>recon,pci_dss_10.6.1,pci_dss_11.4,</group>
+    <group>recon,pci_dss_10.6.1,pci_dss_11.4,gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="51009" level="0">
     <if_sid>51000</if_sid>
     <match>password auth succeeded for</match>
     <description>Dropbear: User successfully logged in using a password.</description>
-    <group>authentication_success,pci_dss_10.2.5,pci_dss_8.1.5,gpg13_7.1,gpg13_7.2,</group>
+    <group>authentication_success,pci_dss_10.2.5,pci_dss_8.1.5,gpg13_7.1,gpg13_7.2,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
   </rule>
 
   <rule id="51010" level="0">
     <if_sid>51000</if_sid>
     <match>Pubkey auth succeeded</match>
     <description>Dropbear: User successfully logged in using a public key.</description>
-    <group>authentication_success,pci_dss_10.2.5,pci_dss_8.1.5,gpg13_7.1,gpg13_7.2,</group>
+    <group>authentication_success,pci_dss_10.2.5,pci_dss_8.1.5,gpg13_7.1,gpg13_7.2,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
   </rule>
 
 </group>

--- a/rules/0310-openbsd_rules.xml
+++ b/rules/0310-openbsd_rules.xml
@@ -41,14 +41,14 @@
     <if_sid>51500</if_sid>
     <match>was not properly unmounted</match>
     <description>A filesystem was not properly unmounted, likely system crash</description>
-    <group>pci_dss_10.2.7,gpg13_4.3,</group>
+    <group>pci_dss_10.2.7,gpg13_4.3,gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="51506" level="1">
     <if_sid>51500</if_sid>
     <match>UKC> quit</match>
     <description>UKC was used, possibly modifying a kernel at boot time.</description>
-    <group>pci_dss_10.2.7,gpg13_4.12,</group>
+    <group>pci_dss_10.2.7,gpg13_4.12,gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="51507" level="1">
@@ -75,14 +75,14 @@
     <if_sid>51500</if_sid>
     <match>Critical temperature, shutting down</match>
     <description>System shutdown due to temperature</description>
-    <group>pci_dss_10.2.7,gpg13_4.1,</group>
+    <group>pci_dss_10.2.7,gpg13_4.1,gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="51511" level="1">
     <if_sid>51500</if_sid>
     <match>_AL0[0] _PR0 failed</match>
     <description>Unknown ACPI event (bug 6299 in OpenBSD bug tracking system).</description>
-    <group>pci_dss_10.2.7,pci_dss_6.2,gpg13_4.3,</group>
+    <group>pci_dss_10.2.7,pci_dss_6.2,gpg13_4.3,gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="51512" level="1">
@@ -141,14 +141,14 @@
   <rule id="51521" level="0" noalert="1">
     <decoded_as>groupdel</decoded_as>
     <description>Grouping for groupdel rules.</description>
-    <group>groupdel,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,</group>
+    <group>groupdel,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_32.2,</group>
   </rule>
 
   <rule id="51522" level="2">
     <if_sid>51521</if_sid>
     <match>group deleted</match>
     <description>Group deleted.</description>
-    <group>groupdel,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,</group>
+    <group>groupdel,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
   </rule>
 
   <rule id="51523" level="0">
@@ -173,7 +173,7 @@
     <decoded_as>bsd_kernel</decoded_as>
     <match>uncorrectable data error reading fsbn</match>
     <description>Hard drive is dying.</description>
-    <group>pci_dss_10.2.7,gpg13_4.3,</group>
+    <group>pci_dss_10.2.7,gpg13_4.3,gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="51527" level="0">
@@ -188,28 +188,28 @@
     <decoded_as>bsd_kernel</decoded_as>
     <match>duplicate IP6 address</match>
     <description>Duplicate IPv6 address.</description>
-    <group>pci_dss_10.6.1,gpg13_4.12,</group>
+    <group>pci_dss_10.6.1,gpg13_4.12,gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="51529" level="0">
     <decoded_as>bsd_kernel</decoded_as>
     <match>failed loadfirmware of file</match>
     <description>Could not load a firmware.</description>
-    <group>gpg13_4.3,</group>
+    <group>gpg13_4.3,gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="51530" level="0">
     <program_name>^hotplugd</program_name>
     <match>Permission denied$</match>
     <description>hotplugd could not open a file.</description>
-    <group>pci_dss_10.2.4,gpg13_4.6,</group>
+    <group>pci_dss_10.2.4,gpg13_4.6,gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="51531" level="3">
     <decoded_as>open-userdel</decoded_as>
     <match>user removed: name=</match>
     <description>User account deleted.</description>
-    <group>account_changed,pci_dss_10.2.5,pci_dss_8.1.2,gpg13_7.10,</group>
+    <group>account_changed,pci_dss_10.2.5,pci_dss_8.1.2,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
   </rule>
 
   <rule id="51532" level="0">
@@ -263,12 +263,14 @@
     <if_sid>51551</if_sid>
     <match>: Permission denied$</match>
     <description>doas cannot stat a file due to permissions.</description>
+    <group>gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
   </rule>
 
   <rule id="51553" level="5">
     <if_sid>51550</if_sid>
     <match>path not secure$</match>
     <description>A critical path for doas does not have secure permissions.</description>
+    <group>gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
   </rule>
 
   <rule id="51554" level="5">
@@ -287,12 +289,14 @@
     <if_sid>51555</if_sid>
     <match> as root </match>
     <description>A doas command was run as root.</description>
+    <group>gdpr_IV_32.2,</group>
   </rule>
 
   <rule id="51557" level="5">
     <if_sid>51550</if_sid>
     <match>failed auth for</match>
     <description>doas authentication failed.</description>
+    <group>gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
   </rule>
 
 </group> <!-- SYSLOG,LOCAL -->

--- a/rules/0315-apparmor_rules.xml
+++ b/rules/0315-apparmor_rules.xml
@@ -31,14 +31,14 @@
     <if_sid>52002</if_sid>
     <extra_data>exec</extra_data>
     <description>Apparmor DENIED exec operation.</description>
-    <group>pci_dss_10.2.7,pci_dss_10.6.1,</group>
+    <group>pci_dss_10.2.7,pci_dss_10.6.1,gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="52004" level="4">
     <if_sid>52002</if_sid>
     <extra_data>mknod</extra_data>
     <description>Apparmor DENIED mknod operation.</description>
-    <group>pci_dss_10.2.7,pci_dss_10.6.1,</group>
+    <group>pci_dss_10.2.7,pci_dss_10.6.1,gdpr_IV_35.7.d,</group>
   </rule>
 
 </group>

--- a/rules/0320-clam_av_rules.xml
+++ b/rules/0320-clam_av_rules.xml
@@ -22,21 +22,21 @@
     <if_sid>52500</if_sid>
     <match>FOUND</match>
     <description>ClamAV: Virus detected</description>
-    <group>virus,pci_dss_5.1,pci_dss_5.2,pci_dss_11.4,gpg13_4.2,</group>
+    <group>virus,pci_dss_5.1,pci_dss_5.2,pci_dss_11.4,gpg13_4.2,gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="52503" level="10">
     <if_sid>52500</if_sid>
     <match>^ERROR: </match>
     <description>Clamd error</description>
-    <group>virus,gpg13_4.3,</group>
+    <group>virus,gpg13_4.3,gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="52504" level="7">
     <if_sid>52500</if_sid>
     <match>^WARNING: </match>
     <description>Clamd warning</description>
-    <group>virus,gpg13_4.12,</group>
+    <group>virus,gpg13_4.12,gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="52505" level="3">
@@ -50,28 +50,28 @@
     <if_sid>52500</if_sid>
     <match>Database modification detected</match>
     <description>Clamd database updated</description>
-    <group>virus,pci_dss_5.2,gpg13_4.4,</group>
+    <group>virus,pci_dss_5.2,gpg13_4.4,gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="52507" level="3">
     <if_sid>52501</if_sid>
     <match>ClamAV update process started </match>
     <description>ClamAV database update</description>
-    <group>virus,pci_dss_5.2,gpg13_4.4,</group>
+    <group>virus,pci_dss_5.2,gpg13_4.4,gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="52508" level="3">
     <if_sid>52501</if_sid>
     <match>Database updated </match>
     <description>ClamAV database updated</description>
-    <group>virus,pci_dss_5.2,gpg13_4.4,</group>
+    <group>virus,pci_dss_5.2,gpg13_4.4,gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="52509" level="0">
     <if_sid>52501</if_sid>
     <match>Incremental update failed|Error while reading database from|Update failed.</match>
     <description>ClamAV: Could not download the incremental virus definition updates.</description>
-    <group>pci_dss_5.2,pci_dss_11.4,</group>
+    <group>pci_dss_5.2,pci_dss_11.4,gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="52510" level="6">
@@ -85,7 +85,7 @@
     <if_matched_sid>52502</if_matched_sid>
     <same_id />
     <description>ClamAV: Virus detected multiple times</description>
-    <group>virus,pci_dss_5.1,pci_dss_5.2,pci_dss_11.4,gpg13_4.2,</group>
+    <group>virus,pci_dss_5.1,pci_dss_5.2,pci_dss_11.4,gpg13_4.2,gdpr_IV_35.7.d,</group>
   </rule>
 
 </group>

--- a/rules/0325-opensmtpd_rules.xml
+++ b/rules/0325-opensmtpd_rules.xml
@@ -70,6 +70,7 @@ y Error
     <if_sid>53500</if_sid>
     <match>Server certificate verification failed</match>
     <description>Server TLS certificate verification failed.</description>
+    <group>gdpr_IV_35.7.d,</group>
   </rule>
 
 </group>

--- a/rules/0330-sysmon_rules.xml
+++ b/rules/0330-sysmon_rules.xml
@@ -126,7 +126,7 @@
         <if_group>sysmon_event1</if_group>
         <field name="sysmon.image">svchost.exe</field>
         <description>Sysmon - Suspicious Process - svchost.exe</description>
-        <group>pci_dss_10.6.1,pci_dss_11.4,</group>
+        <group>pci_dss_10.6.1,pci_dss_11.4,gdpr_IV_35.7.d,</group>
     </rule>
 
     <rule id="184667" level="0">
@@ -140,7 +140,7 @@
         <if_group>sysmon_event1</if_group>
         <field name="sysmon.image">lsm.exe</field>
         <description>Sysmon - Suspicious Process - lsm.exe</description>
-        <group>pci_dss_10.6.1,pci_dss_11.4,</group>
+        <group>pci_dss_10.6.1,pci_dss_11.4,gdpr_IV_35.7.d,</group>
     </rule>
 
     <rule id="184677" level="0">
@@ -153,7 +153,7 @@
         <if_group>sysmon_event1</if_group>
         <field name="sysmon.parentImage">lsm.exe</field>
         <description>Sysmon - Suspicious Process - lsm.exe is a Parent Image</description>
-        <group>pci_dss_10.6.1,pci_dss_11.4,</group>
+        <group>pci_dss_10.6.1,pci_dss_11.4,gdpr_IV_35.7.d,</group>
     </rule>
 
 
@@ -161,7 +161,7 @@
         <if_group>sysmon_event1</if_group>
         <field name="sysmon.image">csrss.exe</field>
         <description>Sysmon - Suspicious Process - csrss.exe</description>
-        <group>pci_dss_10.6.1,pci_dss_11.4,</group>
+        <group>pci_dss_10.6.1,pci_dss_11.4,gdpr_IV_35.7.d,</group>
     </rule>
 
     <rule id="184687" level="0">
@@ -175,7 +175,7 @@
         <if_group>sysmon_event1</if_group>
         <field name="sysmon.image">lsass.exe</field>
         <description>Sysmon - Suspicious Process - lsass</description>
-        <group>pci_dss_10.6.1,pci_dss_11.4,</group>
+        <group>pci_dss_10.6.1,pci_dss_11.4,gdpr_IV_35.7.d,</group>
     </rule>
 
     <rule id="184697" level="0">
@@ -188,7 +188,7 @@
         <if_group>sysmon_event1</if_group>
         <field name="sysmon.parentImage">lsass.exe</field>
         <description>Sysmon - Suspicious Process - lsass.exe is a Parent Image</description>
-        <group>pci_dss_10.6.1,pci_dss_11.4,</group>
+        <group>pci_dss_10.6.1,pci_dss_11.4,gdpr_IV_35.7.d,</group>
     </rule>
 
 
@@ -196,7 +196,7 @@
         <if_group>sysmon_event1</if_group>
         <field name="sysmon.image">winlogon.exe</field>
         <description>Sysmon - Suspicious Process - winlogon.exe</description>
-        <group>pci_dss_10.6.1,pci_dss_11.4,</group>
+        <group>pci_dss_10.6.1,pci_dss_11.4,gdpr_IV_35.7.d,</group>
     </rule>
 
     <rule id="184707" level="0">
@@ -210,7 +210,7 @@
         <if_group>sysmon_event1</if_group>
         <field name="sysmon.image">wininit.exe</field>
         <description>Sysmon - Suspicious Process - wininit</description>
-        <group>pci_dss_10.6.1,pci_dss_11.4,</group>
+        <group>pci_dss_10.6.1,pci_dss_11.4,gdpr_IV_35.7.d,</group>
     </rule>
 
     <rule id="184717" level="0">
@@ -224,7 +224,7 @@
         <if_group>sysmon_event1</if_group>
         <field name="sysmon.image">smss.exe</field>
         <description>Sysmon - Suspicious Process - smss.exe</description>
-        <group>pci_dss_10.6.1,pci_dss_11.4,</group>
+        <group>pci_dss_10.6.1,pci_dss_11.4,gdpr_IV_35.7.d,</group>
     </rule>
 
     <rule id="184727" level="0">
@@ -238,7 +238,7 @@
         <if_group>sysmon_event1</if_group>
         <field name="sysmon.image">taskhost.exe</field>
         <description>Sysmon - Suspicious Process - taskhost.exe</description>
-        <group>pci_dss_10.6.1,pci_dss_11.4,</group>
+        <group>pci_dss_10.6.1,pci_dss_11.4,gdpr_IV_35.7.d,</group>
     </rule>
 
     <rule id="184737" level="0">
@@ -252,7 +252,7 @@
         <if_group>sysmon_event1</if_group>
         <field name="sysmon.image">/services.exe</field>
         <description>Sysmon - Suspicious Process - services.exe</description>
-        <group>pci_dss_10.6.1,pci_dss_11.4,</group>
+        <group>pci_dss_10.6.1,pci_dss_11.4,gdpr_IV_35.7.d,</group>
     </rule>
 
     <rule id="184747" level="0">
@@ -266,7 +266,7 @@
         <if_group>sysmon_event1</if_group>
         <field name="sysmon.image">dllhost.exe</field>
         <description>Sysmon - Suspicious Process - dllhost.exe</description>
-        <group>pci_dss_10.6.1,pci_dss_11.4,</group>
+        <group>pci_dss_10.6.1,pci_dss_11.4,gdpr_IV_35.7.d,</group>
     </rule>
 
     <rule id="184767" level="0">
@@ -280,7 +280,7 @@
         <if_group>sysmon_event1</if_group>
         <field name="sysmon.image">\\explorer.exe</field>
         <description>Sysmon - Suspicious Process - explorer.exe</description>
-        <group>pci_dss_10.6.1,pci_dss_11.4,</group>
+        <group>pci_dss_10.6.1,pci_dss_11.4,gdpr_IV_35.7.d,</group>
     </rule>
 
     <rule id="184777" level="0">

--- a/rules/0340-puppet_rules.xml
+++ b/rules/0340-puppet_rules.xml
@@ -58,7 +58,7 @@
         <if_sid>80000</if_sid>
         <match>^Permission denied </match>
         <description>Puppet Master: Permission denied</description>
-        <group>gpg13_4.14,</group>
+        <group>gpg13_4.14,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
     </rule>
 
     <!--
@@ -109,7 +109,7 @@
         <if_sid>80000</if_sid>
         <match>^Could not run: Address already in use</match>
         <description>Puppet Master: not run - address in use</description>
-        <group>gpg13_4.3,</group>
+        <group>gpg13_4.3,gdpr_IV_35.7.d,</group>
     </rule>
 
     <rule id="80007" level="5">
@@ -117,14 +117,14 @@
         <match>^Could not|^You cannot|^too few arguments|^Duplicate declaration|^Unrecognised escape sequence|^Invalid parameter|is not|has not been tested|Unknown function|failed|has failure</match>
         <regex>manifests</regex>
         <description>Puppet Master: Manifest Error</description>
-        <group>gpg13_4.3,</group>
+        <group>gpg13_4.3,gdpr_IV_35.7.d,</group>
     </rule>
 
     <rule id="80008" level="4">
         <if_sid>80000</if_sid>
         <match>^Could not|not found|^Not collecting|^The environment must be|^Syntax error|^Failed|failed|has failure</match>
         <description>Puppet Master: Error</description>
-        <group>gpg13_4.3,</group>
+        <group>gpg13_4.3,gdpr_IV_35.7.d,</group>
     </rule>
 
 
@@ -144,6 +144,7 @@
         <program_name>puppet-master</program_name>
         <match>^Compiled catalog|^Reopening log</match>
         <description>Puppet Master: Info</description>
+        <group></group>
     </rule>
 
     <rule id="80010" level="2">
@@ -151,6 +152,7 @@
         <program_name>puppet-master</program_name>
         <match>^Compiled catalog|^Reopening log|is deprecated|are deprecated</match>
         <description>Puppet Master: Deprecated</description>
+        <group></group>
     </rule>
 
 
@@ -261,14 +263,14 @@
         <if_sid>80001</if_sid>
         <match>Connection refused - connect</match>
         <description>Puppet Agent: connection refused</description>
-        <group>gpg13_4.3,</group>
+        <group>gpg13_4.3,gdpr_IV_35.7.d,</group>
     </rule>
 
     <rule id="80059" level="4">
         <if_sid>80001</if_sid>
         <match>^Unable to fetch|does not support|Not using cache|Could not retrieve|Failed|failed|has failure</match>
         <description>Puppet Agent: Error</description>
-        <group>gpg13_4.3,</group>
+        <group>gpg13_4.3,gdpr_IV_35.7.d,</group>
     </rule>
 
     <!--

--- a/rules/0340-puppet_rules.xml
+++ b/rules/0340-puppet_rules.xml
@@ -58,7 +58,7 @@
         <if_sid>80000</if_sid>
         <match>^Permission denied </match>
         <description>Puppet Master: Permission denied</description>
-        <group>gpg13_4.14,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
+        <group>pci_dss_10.2.4,pci_dss_10.2.5,gpg13_4.14,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
     </rule>
 
     <!--

--- a/rules/0345-netscaler_rules.xml
+++ b/rules/0345-netscaler_rules.xml
@@ -23,14 +23,14 @@ id (Decoder): AAA, UI, API, SSLVPN, EVENT, SSLLOG, APPFW, TCP, ROUTING, SNMP, AC
         <if_sid>80100</if_sid>
         <match>AAA LOGIN_FAILED</match>
         <description>Netscaler: AAA module failed to login the user</description>
-        <group>authentication_failed,netscaler-aaa,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,gpg13_3.3,</group>
+        <group>authentication_failed,netscaler-aaa,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,gpg13_3.3,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
     </rule>
 
     <rule id="80102" level="10" frequency="6">
         <if_matched_sid>80101</if_matched_sid>
         <same_source_ip />
         <description>Netscaler: Multiple AAA failed to login the user</description>
-        <group>authentication_failures,netscaler-aaa,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gpg13_7.1,gpg13_3.3,</group>
+        <group>authentication_failures,netscaler-aaa,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gpg13_7.1,gpg13_3.3,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
     </rule>
 
     <!--
@@ -53,14 +53,14 @@ id (Decoder): AAA, UI, API, SSLVPN, EVENT, SSLLOG, APPFW, TCP, ROUTING, SNMP, AC
         <match>UI CMD_EXECUTED|API CMD_EXECUTED</match>
         <status>Error</status>
         <description>Netscaler: UI/API command executed failed</description>
-        <group>netscaler-cmd,gpg13_3.5,</group>
+        <group>netscaler-cmd,gpg13_3.5,gdpr_IV_35.7.d,</group>
     </rule>
 
     <rule id="80105" level="10" frequency="6">
         <if_matched_sid>80104</if_matched_sid>
         <same_source_ip />
         <description>Netscaler: Multiple commands failed</description>
-        <group>netscaler-cmd,pci_dss_10.2.2,pci_dss_10.6.1,gpg13_3.5,</group>
+        <group>netscaler-cmd,pci_dss_10.2.2,pci_dss_10.6.1,gpg13_3.5,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
     </rule>
 
     <!-- 02/14/2012: 14:32:35 GMT CUA30070LBN6202 PPE-1 : UI CMD_EXECUTED 427 :  User ******** - Remote_ip 10.31.66.1 - Command "delete TEST" - Status "Success" -->
@@ -69,7 +69,7 @@ id (Decoder): AAA, UI, API, SSLVPN, EVENT, SSLLOG, APPFW, TCP, ROUTING, SNMP, AC
         <match>UI CMD_EXECUTED|API CMD_EXECUTED</match>
         <regex>Command "(\.*delete\.*)"</regex>
         <description>Netscaler: UI/API dangerous command</description>
-        <group>netscaler-cmd,</group>
+        <group>netscaler-cmd,gdpr_IV_35.7.d,</group>
     </rule>
 
     <!--SSLVPN LOGIN
@@ -79,7 +79,7 @@ id (Decoder): AAA, UI, API, SSLVPN, EVENT, SSLLOG, APPFW, TCP, ROUTING, SNMP, AC
         <if_sid>80100</if_sid>
         <match>SSLVPN LOGIN</match>
         <description>Netscaler: SSLVPN login succeeds</description>
-        <group>netscaler-sslvpn,authentication_success,pci_dss_10.2.5,gpg13_7.1,gpg13_7.2,gpg13_3.6,</group>
+        <group>netscaler-sslvpn,authentication_success,pci_dss_10.2.5,gpg13_7.1,gpg13_7.2,gpg13_3.6,gdpr_IV_32.2,</group>
     </rule>
 
     <!--SSLVPN LOGOUT
@@ -89,7 +89,7 @@ id (Decoder): AAA, UI, API, SSLVPN, EVENT, SSLLOG, APPFW, TCP, ROUTING, SNMP, AC
         <if_sid>80100</if_sid>
         <match>SSLVPN LOGOUT</match>
         <description>Netscaler: SSLVPN session logs out</description>
-        <group>netscaler-sslvpn,pci_dss_10.2.5,gpg13_7.1,gpg13_3.6,</group>
+        <group>netscaler-sslvpn,pci_dss_10.2.5,gpg13_7.1,gpg13_3.6,gdpr_IV_32.2,</group>
     </rule>
 
     <!--SSLVPN ICASTART
@@ -121,13 +121,13 @@ id (Decoder): AAA, UI, API, SSLVPN, EVENT, SSLLOG, APPFW, TCP, ROUTING, SNMP, AC
         <if_sid>80100</if_sid>
         <match>SSLVPN NONHTTP_RESOURCEACCESS_DENIED</match>
         <description>Netscaler: A non-http resource access is denied by policy engine.</description>
-        <group>netscaler-sslvpn,access_denied,pci_dss_10.2.4,</group>
+        <group>netscaler-sslvpn,access_denied,pci_dss_10.2.4,gdpr_IV_35.7.d,</group>
     </rule>
 
     <rule id="80112" level="10" frequency="8" timeframe="120">
         <if_matched_sid>80111</if_matched_sid>
         <description>Netscaler: Multiple non-http resource access denied</description>
-        <group>netscaler-sslvpn,access_denied,pci_dss_10.2.4,pci_dss_11.4,</group>
+        <group>netscaler-sslvpn,access_denied,pci_dss_10.2.4,pci_dss_11.4,gdpr_IV_35.7.d,</group>
     </rule>
 
     <!--
@@ -138,13 +138,13 @@ id (Decoder): AAA, UI, API, SSLVPN, EVENT, SSLLOG, APPFW, TCP, ROUTING, SNMP, AC
         <if_sid>80100</if_sid>
         <match>SSLVPN HTTP_RESOURCEACCESS_DENIED</match>
         <description>Netscaler: A http resource access is denied by policy engine</description>
-        <group>netscaler-sslvpn,access_denied,pci_dss_10.2.4,</group>
+        <group>netscaler-sslvpn,access_denied,pci_dss_10.2.4,gdpr_IV_35.7.d,</group>
     </rule>
 
     <rule id="80114" level="10" frequency="8" timeframe="120">
         <if_matched_sid>80113</if_matched_sid>
         <description>Netscaler: Multiple http resource access denied</description>
-        <group>netscaler-sslvpn,access_denied,pci_dss_10.2.4,pci_dss_11.4,</group>
+        <group>netscaler-sslvpn,access_denied,pci_dss_10.2.4,pci_dss_11.4,gdpr_IV_35.7.d,</group>
     </rule>
 
     <!--
@@ -155,7 +155,7 @@ id (Decoder): AAA, UI, API, SSLVPN, EVENT, SSLLOG, APPFW, TCP, ROUTING, SNMP, AC
         <if_sid>80100</if_sid>
         <match>SSLVPN CLISEC_CHECK</match>
         <description>Netscaler: SSLVPN session: client security check error</description>
-        <group>netscaler-sslvpn,</group>
+        <group>netscaler-sslvpn,gdpr_IV_35.7.d,</group>
     </rule>
 
     <!--
@@ -166,7 +166,7 @@ id (Decoder): AAA, UI, API, SSLVPN, EVENT, SSLLOG, APPFW, TCP, ROUTING, SNMP, AC
         <if_sid>80100</if_sid>
         <match>SSLVPN CLISEC_EXP_EVAL</match>
         <description>Netscaler: SSLVPN session: client security expression evaluates to False</description>
-        <group>netscaler-sslvpn,</group>
+        <group>netscaler-sslvpn,gdpr_IV_35.7.d,</group>
     </rule>
 
     <!--
@@ -256,7 +256,7 @@ id (Decoder): AAA, UI, API, SSLVPN, EVENT, SSLLOG, APPFW, TCP, ROUTING, SNMP, AC
         <if_sid>80100</if_sid>
         <match>EVENT FREEBADMEM|EVENT FREEDUPMEM|EVENT FREEEXTMEM</match>
         <description>Netscaler: Memory internal error</description>
-        <group>netscaler-event,</group>
+        <group>netscaler-event,gdpr_IV_35.7.d,</group>
     </rule>
 
     <!--
@@ -266,7 +266,7 @@ id (Decoder): AAA, UI, API, SSLVPN, EVENT, SSLLOG, APPFW, TCP, ROUTING, SNMP, AC
         <if_sid>80100</if_sid>
         <match>EVENT PROPFAIL</match>
         <description>Netscaler: HA propagation failed</description>
-        <group>netscaler-event,</group>
+        <group>netscaler-event,gdpr_IV_35.7.d,</group>
     </rule>
 
     <!--
@@ -297,7 +297,7 @@ id (Decoder): AAA, UI, API, SSLVPN, EVENT, SSLLOG, APPFW, TCP, ROUTING, SNMP, AC
         <if_sid>80100</if_sid>
         <match>APPFW APPFW_STARTURL|APPFW APPFW_DENYURL|APPFW APPFW_CONTENT_TYPE|APPFW APPFW_REFERER_HEADER|APPFW APPFW_CSRF_TAG|APPFW APPFW_XSS|APPFW APPFW_XML_XSS|APPFW APPFW_SQL|APPFW APPFW_XML_SQL|APPFW APPFW_COOKIE|APPFW APPFW_FIELDCONSISTENCY|APPFWAPPFW_BUFFEROVERFLOW_URL|APPFW APPFW_BUFFEROVER FLOW_COOKIE|APPFW APPFW_BUFFEROVERFLOW_HDR|APPFW APPFW_FIELDFORMAT|APPFW APPFW_SAFECOMMERCE|APPFW APPFW_SAFECOMMERCE_XFORM|APPFW APPFW_SAFEOBJECT|APPFW APPFW_SIGNATURE_MATCH|APPFW_RESP APPFW_XML_XSS|APPFW_RESP APPFW_XML_SQL</match>
         <description>Netscaler: Firewall violation</description>
-        <group>netscaler-appfw,pci_dss_1.4,pci_dss_6.5,pci_dss_6.6,gpg13_3.5,</group>
+        <group>netscaler-appfw,pci_dss_1.4,pci_dss_6.5,pci_dss_6.6,gpg13_3.5,gdpr_IV_35.7.d,</group>
     </rule>
 
 
@@ -308,7 +308,7 @@ id (Decoder): AAA, UI, API, SSLVPN, EVENT, SSLLOG, APPFW, TCP, ROUTING, SNMP, AC
         <if_sid>80100</if_sid>
         <match>APPFW AF_UTHREAD_STACK_ERR</match>
         <description>Netscaler: Firewall: Appsecure uthread at 0x%x had a stack error</description>
-        <group>netscaler-appfw,pci_dss_1.4,pci_dss_6.5.2,gpg13_3.5,</group>
+        <group>netscaler-appfw,pci_dss_1.4,pci_dss_6.5.2,gpg13_3.5,gdpr_IV_35.7.d,</group>
     </rule>
 
     <!--
@@ -322,7 +322,7 @@ id (Decoder): AAA, UI, API, SSLVPN, EVENT, SSLLOG, APPFW, TCP, ROUTING, SNMP, AC
         <if_sid>80100</if_sid>
         <match>APPFW APPFW_XML_ERR_DOS|APPFW APPFW_XML_DDOS_ERR|APPFW_RESP APPFW_XML_DDOS_ERR_MSG_SEND_FAI|APPFW_RESP APPFW_XML_DOS_ERR_CHAR_DATA_LENGTH</match>
         <description>Netscaler: Firewall: DOS\DDOS error</description>
-        <group>netscaler-appfw,pci_dss_1.4,pci_dss_11.4,gpg13_3.5,</group>
+        <group>netscaler-appfw,pci_dss_1.4,pci_dss_11.4,gpg13_3.5,gdpr_IV_35.7.d,</group>
     </rule>
 
     <!--
@@ -365,7 +365,7 @@ id (Decoder): AAA, UI, API, SSLVPN, EVENT, SSLLOG, APPFW, TCP, ROUTING, SNMP, AC
         <if_sid>80100</if_sid>
         <match>TRANSFORM REQ_PARSE_ERROR|TRANSFORM PCRE_ERROR|TRANSFORM REQ_WRITE_ERROR</match>
         <description>Netscaler: URL Transformation error</description>
-        <group>netscaler-transform,</group>
+        <group>netscaler-transform,gdpr_IV_35.7.d,</group>
     </rule>
 
     <!--
@@ -376,7 +376,7 @@ id (Decoder): AAA, UI, API, SSLVPN, EVENT, SSLLOG, APPFW, TCP, ROUTING, SNMP, AC
         <if_sid>80100</if_sid>
         <match>AAATM LOGIN</match>
         <description>Netscaler: Login to AAA TM vserver succeeds</description>
-        <group>netscaler-aaatm,authentication_success,pci_dss_10.2.5,gpg13_3.6,gpg13_7.1,gpg13_7.2,</group>
+        <group>netscaler-aaatm,authentication_success,pci_dss_10.2.5,gpg13_3.6,gpg13_7.1,gpg13_7.2,gdpr_IV_32.2,</group>
     </rule>
 
     <!--
@@ -387,7 +387,7 @@ id (Decoder): AAA, UI, API, SSLVPN, EVENT, SSLLOG, APPFW, TCP, ROUTING, SNMP, AC
         <if_sid>80100</if_sid>
         <match>AAATM LOGOUT</match>
         <description>Netscaler: AAA TM session logged out</description>
-        <group>netscaler-aaatm,pci_dss_10.2.5,gpg13_3.6,gpg13_7.1,</group>
+        <group>netscaler-aaatm,pci_dss_10.2.5,gpg13_3.6,gpg13_7.1,gdpr_IV_32.2,</group>
     </rule>
 
     <!--
@@ -397,13 +397,13 @@ id (Decoder): AAA, UI, API, SSLVPN, EVENT, SSLLOG, APPFW, TCP, ROUTING, SNMP, AC
         <if_sid>80100</if_sid>
         <match>AAATM HTTP_RESOURCEACCESS_DENIED</match>
         <description>Netscaler: A AAATM http resource access is denied by policy engine</description>
-        <group>netscaler-aaatm,access_denied,pci_dss_10.2.4,</group>
+        <group>netscaler-aaatm,access_denied,pci_dss_10.2.4,gdpr_IV_35.7.d,</group>
     </rule>
 
     <rule id="80137" level="10" frequency="8" timeframe="120">
         <if_matched_sid>80136</if_matched_sid>
         <description>Netscaler: Multiple AAATM http resource access denied</description>
-        <group>netscaler-aaatm,access_denied,pci_dss_10.2.4,pci_dss_11.4,</group>
+        <group>netscaler-aaatm,access_denied,pci_dss_10.2.4,pci_dss_11.4,gdpr_IV_35.7.d,</group>
     </rule>
 
     <!--
@@ -419,7 +419,7 @@ id (Decoder): AAA, UI, API, SSLVPN, EVENT, SSLLOG, APPFW, TCP, ROUTING, SNMP, AC
         <regex>Command "login</regex>
         <status>Success</status>
         <description>Netscaler: UI/API login succeeds</description>
-        <group>netscaler-cmd,authentication_success,pci_dss_10.2.5,gpg13_3.5,gpg13_7.1,gpg13_7.2,</group>
+        <group>netscaler-cmd,authentication_success,pci_dss_10.2.5,gpg13_3.5,gpg13_7.1,gpg13_7.2,gdpr_IV_32.2,</group>
     </rule>
 
     <rule id="80139" level="6">
@@ -428,14 +428,14 @@ id (Decoder): AAA, UI, API, SSLVPN, EVENT, SSLLOG, APPFW, TCP, ROUTING, SNMP, AC
         <regex>Command "login</regex>
         <status>Error</status>
         <description>Netscaler: UI/API login failed</description>
-        <group>authentication_failed,netscaler-cmd,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_3.3,gpg13_7.1,</group>
+        <group>authentication_failed,netscaler-cmd,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_3.3,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
     </rule>
 
     <rule id="80140" level="10" frequency="6">
         <if_matched_sid>80139</if_matched_sid>
         <same_source_ip />
         <description>Netscaler: Multiple UI/API login failed</description>
-        <group>authentication_failures,netscaler-cmd,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gpg13_3.3,gpg13_7.1,</group>
+        <group>authentication_failures,netscaler-cmd,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gpg13_3.3,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
     </rule>
 
 </group>

--- a/rules/0350-amazon_rules.xml
+++ b/rules/0350-amazon_rules.xml
@@ -29,7 +29,7 @@ ID: 80200 - 80499
         <if_sid>80201</if_sid>
         <list field="aws.eventName" lookup="match_key">etc/lists/amazon/aws-eventnames</list>
         <description>Amazon: $(aws.eventSource) - $(aws.eventName).</description>
-        <group>pci_dss_10.6.1,</group>
+        <group>pci_dss_10.6.1,gdpr_IV_35.7.d,</group>
     </rule>
 
     <!-- If there is an error code: increase the level and change description -->
@@ -37,7 +37,7 @@ ID: 80200 - 80499
         <if_sid>80202</if_sid>
         <field name="aws.errorCode">\.+</field>
         <description>Amazon: $(aws.eventSource) - $(aws.eventName). Error: $(aws.errorCode).</description>
-        <group>pci_dss_10.6.1,amazon-error,</group>
+        <group>pci_dss_10.6.1,amazon-error,gdpr_IV_35.7.d,</group>
     </rule>
 
 
@@ -48,7 +48,7 @@ ID: 80200 - 80499
         <if_sid>80203</if_sid>
         <field name="aws.errorCode">AccessDenied</field>
         <description>Amazon: $(aws.eventSource) - $(aws.eventName). Error: $(aws.errorCode).</description>
-        <group>pci_dss_10.6.1,pci_dss_10.2.4,pci_dss_10.2.5,</group>
+        <group>pci_dss_10.6.1,pci_dss_10.2.4,pci_dss_10.2.5,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
     </rule>
 
     <!-- Events with no errors -->
@@ -56,13 +56,13 @@ ID: 80200 - 80499
         <if_sid>80201</if_sid>
         <field name="aws.eventName">DeleteObjects</field>
         <description>Amazon: $(aws.eventSource) - $(aws.eventName).</description>
-        <group>pci_dss_10.6.1,</group>
+        <group>pci_dss_10.6.1,gdpr_IV_35.7.d,</group>
     </rule>
 
     <rule id="80252" level="10" frequency="20" timeframe="600">
         <if_matched_sid>80251</if_matched_sid>
         <description>Amazon: $(aws.eventSource) - $(aws.eventName) - high number of deleted object.</description>
-        <group>pci_dss_10.6.1,</group>
+        <group>pci_dss_10.6.1,gdpr_IV_35.7.d,</group>
     </rule>
 
     <!-- Logins -->
@@ -70,20 +70,20 @@ ID: 80200 - 80499
         <if_sid>80202</if_sid>
         <field name="aws.eventName">ConsoleLogin</field>
         <description>Amazon: $(aws.eventSource) - $(aws.eventName) - User Login Success.</description>
-        <group>authentication_success,pci_dss_10.2.5,</group>
+        <group>authentication_success,pci_dss_10.2.5,gdpr_IV_32.2,</group>
     </rule>
 
     <rule id="80254" level="5">
         <if_sid>80253</if_sid>
         <field name="aws.responseElements.ConsoleLogin">Failure</field>
         <description>Amazon: $(aws.eventSource) - $(aws.eventName) - User Login failed.</description>
-        <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,</group>
+        <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
     </rule>
 
     <rule id="80255" level="10" frequency="4" timeframe="360">
         <if_matched_sid>80254</if_matched_sid>
         <description>Amazon: $(aws.eventSource) - $(aws.eventName) - Possible breaking attempt (high number of login attempts).</description>
-        <group>authentication_failures,pci_dss_11.4,pci_dss_10.2.4,pci_dss_10.2.5,</group>
+        <group>authentication_failures,pci_dss_11.4,pci_dss_10.2.4,pci_dss_10.2.5,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
     </rule>
 
 </group>

--- a/rules/0360-serv-u_rules.xml
+++ b/rules/0360-serv-u_rules.xml
@@ -67,7 +67,7 @@ TypeMessage:
         <action>02</action>
         <match>logged in</match>
         <description>Serv-U: User logged in</description>
-        <group>authentication_success,pci_dss_10.2.5,gpg13_7.1,gpg13_7.2,</group>
+        <group>authentication_success,pci_dss_10.2.5,gpg13_7.1,gpg13_7.2,gdpr_IV_32.2,</group>
     </rule>
 
     <!--
@@ -79,7 +79,7 @@ TypeMessage:
         <action>02</action>
         <match>logged out</match>
         <description>Serv-U: User logged out</description>
-        <group>gpg13_7.1,</group>
+        <group>gpg13_7.1,gdpr_IV_32.2,</group>
     </rule>
 
     <!--
@@ -92,14 +92,14 @@ TypeMessage:
         <action>02</action>
         <match>Invalid login credentials|Password wrong too many times</match>
         <description>Serv-U: Invalid credentials</description>
-        <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,</group>
+        <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
     </rule>
 
     <rule id="80506" level="10" frequency="6">
         <if_matched_sid>80505</if_matched_sid>
         <same_user />
         <description>Serv-U: Multiple authentication failures.</description>
-        <group>authentication_failures,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gpg13_7.1,</group>
+        <group>authentication_failures,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
     </rule>
 
     <!--
@@ -111,7 +111,7 @@ TypeMessage:
         <action>02</action>
         <match>Session idle time out</match>
         <description>Serv-U: Session timeout</description>
-        <group>pci_dss_8.1.5,gpg13_7.1,</group>
+        <group>pci_dss_8.1.5,gpg13_7.1,gdpr_IV_35.7.d,</group>
     </rule>
 
     <!--
@@ -123,7 +123,7 @@ TypeMessage:
         <action>02</action>
         <match>Closed session</match>
         <description>Serv-U: Closed session</description>
-        <group>gpg13_7.1,</group>
+        <group>gpg13_7.1,gdpr_IV_32.2,</group>   
     </rule>
 
     <!--
@@ -135,7 +135,7 @@ TypeMessage:
         <action>02</action>
         <match>Connected to</match>
         <description>Serv-U: Remote host connected</description>
-        <group>pci_dss_10.2.1,</group>
+        <group>pci_dss_10.2.1,gdpr_IV_35.7.d,</group>
     </rule>
 
     <!--
@@ -169,6 +169,7 @@ TypeMessage:
         <action>10</action>
         <match>Sent file</match>
         <description>Serv-U: File downloaded</description>
+        <group>gdpr_II_5.1.f,</group>
     </rule>
 
     <rule id="80512" level="0">
@@ -176,6 +177,7 @@ TypeMessage:
         <action>11</action>
         <match>Received file</match>
         <description>Serv-U: File uploaded</description>
+        <group>gdpr_II_5.1.f,</group>
     </rule>
 
     <rule id="80513" level="3">
@@ -183,6 +185,7 @@ TypeMessage:
         <action>12</action>
         <match>File deleted</match>
         <description>Serv-U: File deleted</description>
+        <group>gdpr_II_5.1.f,</group>
     </rule>
 
     <rule id="80514" level="0">
@@ -190,6 +193,7 @@ TypeMessage:
         <action>13</action>
         <match>Renamed</match>
         <description>Serv-U: File/Directory renamed</description>
+        <group>gdpr_II_5.1.f,</group>
     </rule>
 
     <rule id="80515" level="0">
@@ -197,6 +201,7 @@ TypeMessage:
         <action>14</action>
         <match>Directory created</match>
         <description>Serv-U: Directory created</description>
+        <group>gdpr_II_5.1.f,</group>
     </rule>
 
     <rule id="80516" level="3">
@@ -204,6 +209,7 @@ TypeMessage:
         <action>15</action>
         <match>Directory deleted</match>
         <description>Serv-U: Directory deleted</description>
+        <group>gdpr_II_5.1.f,</group>
     </rule>
 
 
@@ -229,7 +235,7 @@ TypeMessage:
         <action>21</action>
         <match>230 User logged in, proceed</match>
         <description>Serv-U: User logged in FTP/FTPS</description>
-        <group>gpg13_7.1,gpg13_7.2,</group>
+        <group>gpg13_7.1,gpg13_7.2,gdpr_IV_32.2,</group>
     </rule>
 
     <!--
@@ -241,7 +247,7 @@ TypeMessage:
         <action>31</action>
         <match>SSH2_MSG_USERAUTH_SUCCESS</match>
         <description>Serv-U: User logged in SFTP (SSH)</description>
-        <group>gpg13_7.1,gpg13_7.2,</group>
+        <group>gpg13_7.1,gpg13_7.2,gdpr_IV_32.2,</group>
     </rule>
 
     <!--
@@ -253,7 +259,7 @@ TypeMessage:
         <action>41</action>
         <match>HTTP_OKAY (200): SESS_OKAY</match>
         <description>Serv-U: User logged in HTTP/HTTPS</description>
-        <group>gpg13_7.1,gpg13_7.2,</group>
+        <group>gpg13_7.1,gpg13_7.2,gdpr_IV_32.2,</group>
     </rule>
 
     <!--
@@ -265,7 +271,7 @@ TypeMessage:
         <action>21</action>
         <match>530 Sorry, no ANONYMOUS access allowed</match>
         <description>Serv-U: Attempt to login using anonymous user</description>
-        <group>authentication_failures,pci_dss_10.2.4,</group>
+        <group>authentication_failures,pci_dss_10.2.4,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
         <group>gpg13_7.1,</group>
     </rule>
 
@@ -280,7 +286,7 @@ TypeMessage:
         <action>21</action>
         <match>Permission denied</match>
         <description>Serv-U: FTP/FTPS Permission denied</description>
-        <group>pci_dss_10.2.4,gpg13_7.1,</group>
+        <group>pci_dss_10.2.4,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
     </rule>
 
     <rule id="80523" level="4">
@@ -288,7 +294,7 @@ TypeMessage:
         <action>31</action>
         <match>Permission denied</match>
         <description>Serv-U: SFTP (SSH) Permission denied</description>
-        <group>pci_dss_10.2.4,gpg13_7.1,</group>
+        <group>pci_dss_10.2.4,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
     </rule>
 
     <rule id="80524" level="4">
@@ -296,7 +302,7 @@ TypeMessage:
         <action>41</action>
         <match>SESS_PERMISSION_DENIED</match>
         <description>Serv-U: HTTP/HTTPS Permission denied</description>
-        <group>pci_dss_10.2.4,gpg13_7.1,</group>
+        <group>pci_dss_10.2.4,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
     </rule>
 
 </group>

--- a/rules/0360-serv-u_rules.xml
+++ b/rules/0360-serv-u_rules.xml
@@ -169,7 +169,7 @@ TypeMessage:
         <action>10</action>
         <match>Sent file</match>
         <description>Serv-U: File downloaded</description>
-        <group>gdpr_II_5.1.f,</group>
+        <group>pci_dss_11.5,gdpr_II_5.1.f,</group>
     </rule>
 
     <rule id="80512" level="0">
@@ -177,7 +177,7 @@ TypeMessage:
         <action>11</action>
         <match>Received file</match>
         <description>Serv-U: File uploaded</description>
-        <group>gdpr_II_5.1.f,</group>
+        <group>pci_dss_11.5,gdpr_II_5.1.f,</group>
     </rule>
 
     <rule id="80513" level="3">
@@ -185,7 +185,7 @@ TypeMessage:
         <action>12</action>
         <match>File deleted</match>
         <description>Serv-U: File deleted</description>
-        <group>gdpr_II_5.1.f,</group>
+        <group>pci_dss_11.5,gdpr_II_5.1.f,</group>
     </rule>
 
     <rule id="80514" level="0">
@@ -193,7 +193,7 @@ TypeMessage:
         <action>13</action>
         <match>Renamed</match>
         <description>Serv-U: File/Directory renamed</description>
-        <group>gdpr_II_5.1.f,</group>
+        <group>pci_dss_11.5,gdpr_II_5.1.f,</group>
     </rule>
 
     <rule id="80515" level="0">
@@ -201,7 +201,7 @@ TypeMessage:
         <action>14</action>
         <match>Directory created</match>
         <description>Serv-U: Directory created</description>
-        <group>gdpr_II_5.1.f,</group>
+        <group>pci_dss_11.5,gdpr_II_5.1.f,</group>
     </rule>
 
     <rule id="80516" level="3">
@@ -209,7 +209,7 @@ TypeMessage:
         <action>15</action>
         <match>Directory deleted</match>
         <description>Serv-U: Directory deleted</description>
-        <group>gdpr_II_5.1.f,</group>
+        <group>pci_dss_11.5,gdpr_II_5.1.f,</group>
     </rule>
 
 

--- a/rules/0365-auditd_rules.xml
+++ b/rules/0365-auditd_rules.xml
@@ -22,7 +22,7 @@
         <field name="audit.type">DAEMON_RESUME|DAEMON_START</field>
         <field name="audit.res">success</field>
         <description>Auditd: Start / Resume</description>
-        <group>gpg13_4.14,gpg13_10.1,</group>
+        <group>gpg13_4.14,gpg13_10.1,gdpr_IV_30.1.g,</group>
     </rule>
 
     <rule id="80702" level="10">
@@ -30,7 +30,7 @@
         <field name="audit.type">DAEMON_RESUME|DAEMON_START</field>
         <field name="audit.res">failed</field>
         <description>Auditd: Start / Resume FAILED</description>
-        <group>audit_daemon,service_availability,pci_dss_10.6.1,gpg13_10.1,gpg13_4.14,</group>
+        <group>audit_daemon,service_availability,pci_dss_10.6.1,gpg13_10.1,gpg13_4.14,gdpr_IV_35.7.d,gdpr_IV_30.1.g,</group>
     </rule>
 
     <!--
@@ -41,7 +41,7 @@
         <field name="audit.type">DAEMON_END</field>
         <field name="audit.res">success</field>
         <description>Auditd: End</description>
-        <group>audit_daemon,service_availability,pci_dss_10.6.1,gpg13_10.1,gpg13_4.14,</group>
+        <group>audit_daemon,service_availability,pci_dss_10.6.1,gpg13_10.1,gpg13_4.14,gdpr_IV_35.7.d,gdpr_IV_30.1.g,</group>
     </rule>
 
     <!--
@@ -51,7 +51,7 @@
         <if_sid>80700</if_sid>
         <field name="audit.type">DAEMON_ABORT</field>
         <description>Auditd: Abort</description>
-        <group>audit_daemon,service_availability,pci_dss_10.6.1,gpg13_10.1,gpg13_4.14,</group>
+        <group>audit_daemon,service_availability,pci_dss_10.6.1,gpg13_10.1,gpg13_4.14,gdpr_IV_35.7.d,gdpr_IV_30.1.g,</group>
     </rule>
 
     <!--
@@ -62,7 +62,7 @@
         <if_sid>80700</if_sid>
         <field name="audit.type">CONFIG_CHANGE|DAEMON_CONFIG</field>
         <description>Auditd: Configuration changed</description>
-        <group>audit_configuration,gpg13_10.1,</group>
+        <group>audit_configuration,gpg13_10.1,gdpr_IV_30.1.g,</group>
     </rule>
 
 
@@ -75,7 +75,7 @@
         <field name="audit.type">ANOM_PROMISCUOUS</field>
         <match>prom=256</match>
         <description>Auditd: device enables promiscuous mode</description>
-        <group>audit_anom,pci_dss_11.4,pci_dss_10.6.1,gpg13_4.14,</group>
+        <group>audit_anom,pci_dss_11.4,pci_dss_10.6.1,gpg13_4.14,gdpr_IV_35.7.d,gdpr_IV_30.1.g,</group>
     </rule>
 
     <!--
@@ -85,7 +85,7 @@
         <if_sid>80700</if_sid>
         <field name="audit.type">ANOM_ABEND</field>
         <description>Auditd: process ended abnormally</description>
-        <group>audit_anom,pci_dss_11.4,pci_dss_10.6.1,gpg13_4.14,</group>
+        <group>audit_anom,pci_dss_11.4,pci_dss_10.6.1,gpg13_4.14,gdpr_IV_35.7.d,gdpr_IV_30.1.g,</group>
     </rule>
 
     <!--
@@ -95,7 +95,7 @@
         <if_sid>80700</if_sid>
         <field name="audit.type">ANOM_EXEC</field>
         <description>Auditd: execution of a file ended abnormally</description>
-        <group>audit_anom,pci_dss_11.4,pci_dss_10.6.1,gpg13_4.14,</group>
+        <group>audit_anom,pci_dss_11.4,pci_dss_10.6.1,gpg13_4.14,gdpr_IV_35.7.d,gdpr_IV_30.1.g,</group>
     </rule>
 
     <!--
@@ -105,7 +105,7 @@
         <if_sid>80700</if_sid>
         <field name="audit.type">ANOM_MK_EXEC</field>
         <description>Auditd: file is made executable</description>
-        <group>audit_anom,pci_dss_11.4,pci_dss_10.6.1,gpg13_4.6,</group>
+        <group>audit_anom,pci_dss_11.4,pci_dss_10.6.1,gpg13_4.6,gdpr_IV_35.7.d,gdpr_IV_30.1.g,</group>
     </rule>
 
     <!--
@@ -115,7 +115,7 @@
         <if_sid>80700</if_sid>
         <field name="audit.type">ANOM_ACCESS_FS</field>
         <description>Auditd: file or a directory access ended abnormally</description>
-        <group>audit_anom,pci_dss_11.4,pci_dss_10.6.1,</group>
+        <group>audit_anom,pci_dss_11.4,pci_dss_10.6.1,gdpr_IV_35.7.d,gdpr_IV_30.1.g,</group>
     </rule>
 
     <!--
@@ -125,7 +125,7 @@
         <if_sid>80700</if_sid>
         <field name="audit.type">ANOM_AMTU_FAIL</field>
         <description>Auditd: failure of the Abstract Machine Test Utility (AMTU) detected</description>
-        <group>audit_anom,pci_dss_11.4,pci_dss_10.6.1,</group>
+        <group>audit_anom,pci_dss_11.4,pci_dss_10.6.1,gdpr_IV_35.7.d,gdpr_IV_30.1.g,</group>
     </rule>
 
     <!--
@@ -136,7 +136,7 @@
         <if_sid>80700</if_sid>
         <field name="audit.type">ANOM_MAX_DAC|ANOM_MAX_MAC</field>
         <description>Auditd: maximum amount of Discretionary Access Control (DAC) or Mandatory Access Control (MAC) failures reached</description>
-        <group>audit_anom,pci_dss_11.4,pci_dss_10.6.1,</group>
+        <group>audit_anom,pci_dss_11.4,pci_dss_10.6.1,gdpr_IV_35.7.d,gdpr_IV_30.1.g,</group>
     </rule>
 
     <!--
@@ -147,7 +147,7 @@
         <if_sid>80700</if_sid>
         <field name="audit.type">ANOM_RBAC_FAIL|ANOM_RBAC_INTEGRITY_FAIL</field>
         <description>Auditd: Role-Based Access Control (RBAC) failure detected.</description>
-        <group>audit_anom,pci_dss_11.4,pci_dss_10.6.1,</group>
+        <group>audit_anom,pci_dss_11.4,pci_dss_10.6.1,gdpr_IV_35.7.d,gdpr_IV_30.1.g,</group>
     </rule>
 
     <!--
@@ -157,7 +157,7 @@
         <if_sid>80700</if_sid>
         <field name="audit.type">ANOM_ADD_ACCT</field>
         <description>Auditd: user-space account addition ended abnormally.</description>
-        <group>audit_anom,pci_dss_11.4,pci_dss_10.6.1,gpg13_7.9,</group>
+        <group>audit_anom,pci_dss_11.4,pci_dss_10.6.1,gpg13_7.9,gdpr_IV_35.7.d,gdpr_IV_30.1.g,</group>
     </rule>
 
     <!--
@@ -167,7 +167,7 @@
         <if_sid>80700</if_sid>
         <field name="audit.type">ANOM_DEL_ACCT</field>
         <description>Auditd: user-space account deletion ended abnormally.</description>
-        <group>audit_anom,pci_dss_11.4,pci_dss_10.6.1,gpg13_7.9,</group>
+        <group>audit_anom,pci_dss_11.4,pci_dss_10.6.1,gpg13_7.9,gdpr_IV_35.7.d,gdpr_IV_30.1.g,</group>
     </rule>
 
     <!--
@@ -177,7 +177,7 @@
         <if_sid>80700</if_sid>
         <field name="audit.type">ANOM_MOD_ACCT</field>
         <description>Auditd: user-space account modification ended abnormally.</description>
-        <group>audit_anom,pci_dss_11.4,pci_dss_10.6.1,gpg13_7.9,</group>
+        <group>audit_anom,pci_dss_11.4,pci_dss_10.6.1,gpg13_7.9,gdpr_IV_35.7.d,gdpr_IV_30.1.g,</group>
     </rule>
 
     <!--
@@ -187,7 +187,7 @@
         <if_sid>80700</if_sid>
         <field name="audit.type">ANOM_ROOT_TRANS</field>
         <description>Auditd: user becomes root</description>
-        <group>audit_anom,pci_dss_11.4,pci_dss_10.6.1,gpg13_7.9,</group>
+        <group>audit_anom,pci_dss_11.4,pci_dss_10.6.1,gpg13_7.9,gdpr_IV_35.7.d,</group>
     </rule>
 
     <!--
@@ -197,7 +197,7 @@
         <if_sid>80700</if_sid>
         <field name="audit.type">ANOM_LOGIN_ACCT</field>
         <description>Auditd: account login attempt ended abnormally.</description>
-        <group>audit_anom,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,pci_dss_10.6.1,gpg13_7.9,</group>
+        <group>audit_anom,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,pci_dss_10.6.1,gpg13_7.9,gdpr_IV_35.7.d,gdpr_IV_32.2,gdpr_IV_30.1.g,</group>
     </rule>
 
     <!--
@@ -207,7 +207,7 @@
         <if_sid>80700</if_sid>
         <field name="audit.type">ANOM_LOGIN_FAILURES</field>
         <description>Auditd: limit of failed login attempts reached.</description>
-        <group>audit_anom,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.5,</group>
+        <group>audit_anom,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.5,gdpr_IV_35.7.d,gdpr_IV_32.2,gdpr_IV_30.1.g,</group>
     </rule>
 
     <!--
@@ -217,7 +217,7 @@
         <if_sid>80700</if_sid>
         <field name="audit.type">ANOM_LOGIN_LOCATION</field>
         <description>Auditd: login attempt from a forbidden location.</description>
-        <group>audit_anom,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_10.6.1,gpg13_7.5,</group>
+        <group>audit_anom,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_10.6.1,gpg13_7.5,gdpr_IV_35.7.d,gdpr_IV_32.2,gdpr_IV_30.1.g,</group>
     </rule>
 
     <!--
@@ -227,7 +227,7 @@
         <if_sid>80700</if_sid>
         <field name="audit.type">ANOM_LOGIN_SESSIONS</field>
         <description>Auditd: login attempt reached the maximum amount of concurrent sessions.</description>
-        <group>audit_anom,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_10.6.1,gpg13_7.5,</group>
+        <group>audit_anom,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_10.6.1,gpg13_7.5,gdpr_IV_35.7.d,gdpr_IV_32.2,gdpr_IV_30.1.g,</group>
     </rule>
 
     <!--
@@ -237,7 +237,7 @@
         <if_sid>80700</if_sid>
         <field name="audit.type">ANOM_LOGIN_TIME</field>
         <description>Auditd: login attempt is made at a time when it is prevented by.</description>
-        <group>audit_anom,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_10.6.1,gpg13_7.5,</group>
+        <group>audit_anom,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_10.6.1,gpg13_7.5,gdpr_IV_35.7.d,gdpr_IV_32.2,gdpr_IV_30.1.g,</group>
     </rule>
 
 
@@ -249,7 +249,7 @@
         <if_sid>80700</if_sid>
         <field name="audit.type">AVC</field>
         <description>Auditd: SELinux permission check</description>
-        <group>audit_selinux,pci_dss_10.6.1,</group>
+        <group>audit_selinux,pci_dss_10.6.1,gdpr_IV_35.7.d,gdpr_IV_30.1.g,</group>
     </rule>
 
     <!--
@@ -259,7 +259,7 @@
         <if_sid>80700</if_sid>
         <field name="audit.type">MAC_STATUS</field>
         <description>Auditd: SELinux mode (enforcing, permissive, off) is changed</description>
-        <group>audit_selinux,pci_dss_10.6.1,gpg13_4.14,</group>
+        <group>audit_selinux,pci_dss_10.6.1,gpg13_4.14,gdpr_IV_35.7.d,gdpr_IV_30.1.g,</group>
     </rule>
 
     <!--
@@ -270,7 +270,7 @@
         <if_sid>80700</if_sid>
         <field name="audit.type">SELINUX_ERR|USER_SELINUX_ERR</field>
         <description>Auditd: SELinux error</description>
-        <group>audit_selinux,pci_dss_10.6.1,gpg13_4.3,</group>
+        <group>audit_selinux,pci_dss_10.6.1,gpg13_4.3,gdpr_IV_35.7.d,gdpr_IV_30.1.g,</group>
     </rule>
 
 
@@ -282,7 +282,7 @@
         <if_sid>80700</if_sid>
         <field name="audit.type">CRYPTO_REPLAY_USER</field>
         <description>Auditd: replay attack detected</description>
-        <group>audit_anom,pci_dss_11.4,</group>
+        <group>audit_anom,pci_dss_11.4,gdpr_IV_35.7.d,gdpr_IV_30.1.g,</group>
     </rule>
 
     <!--
@@ -292,7 +292,7 @@
         <if_sid>80700</if_sid>
         <field name="audit.type">CHGRP_ID</field>
         <description>Auditd: group ID changed</description>
-        <group>audit_anom,pci_dss_10.6.1,gpg13_7.9,</group>
+        <group>audit_anom,pci_dss_10.6.1,gpg13_7.9,gdpr_IV_35.7.d,gdpr_IV_30.1.g,</group>
     </rule>
 
     <!--
@@ -302,7 +302,7 @@
         <if_sid>80700</if_sid>
         <field name="audit.type">CHUSER_ID</field>
         <description>Auditd: user ID changed</description>
-        <group>audit_anom,pci_dss_10.6.1,gpg13_7.9,</group>
+        <group>audit_anom,pci_dss_10.6.1,gpg13_7.9,gdpr_IV_35.7.d,gdpr_IV_30.1.g,</group>
     </rule>
 
 
@@ -311,84 +311,84 @@
         <if_sid>80700</if_sid>
         <list field="audit.key" lookup="match_key_value" check_value="write">etc/lists/audit-keys</list>
         <description>Audit: Watch - Write access</description>
-        <group>audit_watch_write,</group>
+        <group>audit_watch_write,gdpr_IV_30.1.g,</group>
     </rule>
 
     <rule id="80781" level="3">
         <if_sid>80780</if_sid>
         <field name="audit.file.name">\.+</field>
         <description>Audit: Watch - Write access: $(audit.file.name)</description>
-        <group>audit_watch_write,</group>
+        <group>audit_watch_write,gdpr_IV_30.1.g,</group>
     </rule>
 
     <rule id="80782" level="3">
         <if_sid>80780</if_sid>
         <field name="audit.directory.name">\.+</field>
         <description>Audit: Watch - Write access: $(audit.directory.name)</description>
-        <group>audit_watch_write,</group>
+        <group>audit_watch_write,gdpr_IV_30.1.g,</group>
     </rule>
 
     <rule id="80783" level="3">
         <if_sid>80700</if_sid>
         <list field="audit.key" lookup="match_key_value" check_value="read">etc/lists/audit-keys</list>
         <description>Audit: Watch - Read access</description>
-        <group>audit_watch_read,</group>
+        <group>audit_watch_read,gdpr_IV_30.1.g,</group>
     </rule>
 
     <rule id="80784" level="3">
         <if_sid>80783</if_sid>
         <field name="audit.file.name">\.+</field>
         <description>Audit: Watch - Read access: $(audit.file.name)</description>
-        <group>audit_watch_read,</group>
+        <group>audit_watch_read,gdpr_IV_30.1.g,</group>
     </rule>
 
     <rule id="80785" level="3">
         <if_sid>80783</if_sid>
         <field name="audit.directory.name">\.+</field>
         <description>Audit: Watch - Read access: $(audit.directory.name)</description>
-        <group>audit_watch_read,</group>
+        <group>audit_watch_read,gdpr_IV_30.1.g,</group>
     </rule>
 
     <rule id="80786" level="3">
         <if_sid>80700</if_sid>
         <list field="audit.key" lookup="match_key_value" check_value="attribute">etc/lists/audit-keys</list>
         <description>Audit: Watch - Change attribute</description>
-        <group>audit_watch_attribute,</group>
+        <group>audit_watch_attribute,gdpr_IV_30.1.g,</group>
     </rule>
 
     <rule id="80787" level="3">
         <if_sid>80786</if_sid>
         <field name="audit.file.name">\.+</field>
         <description>Audit: Watch - Change attribute: $(audit.file.name)</description>
-        <group>audit_watch_attribute,</group>
+        <group>audit_watch_attribute,gdpr_IV_30.1.g,</group>
     </rule>
 
     <rule id="80788" level="3">
         <if_sid>80786</if_sid>
         <field name="audit.directory.name">\.+</field>
         <description>Audit: Watch - Change attribute: $(audit.directory.name)</description>
-        <group>audit_watch_attribute,</group>
+        <group>audit_watch_attribute,gdpr_IV_30.1.g,</group>
     </rule>
 
     <rule id="80789" level="3">
         <if_sid>80700</if_sid>
         <list field="audit.key" lookup="match_key_value" check_value="execute">etc/lists/audit-keys</list>
         <description>Audit: Watch - Execute access: $(audit.file.name)</description>
-        <group>audit_watch_execute,</group>
+        <group>audit_watch_execute,gdpr_IV_30.1.g,</group>
     </rule>
 
     <rule id="80790" level="3">
         <if_group>audit_watch_write</if_group>
         <match>type=CREATE</match>
         <description>Audit: Created: $(audit.file.name)</description>
-        <group>audit_watch_write,audit_watch_create,</group>
+        <group>audit_watch_write,audit_watch_create,gdpr_II_5.1.f,gdpr_IV_30.1.g,</group>
     </rule>
 
     <rule id="80791" level="3">
         <if_group>audit_watch_write</if_group>
         <match>type=DELETE</match>
         <description>Audit: Deleted: $(audit.file.name)</description>
-        <group>audit_watch_write,audit_watch_delete,</group>
+        <group>audit_watch_write,audit_watch_delete,gdpr_II_5.1.f,gdpr_IV_30.1.g,</group>
     </rule>
 
 
@@ -397,7 +397,7 @@
         <if_sid>80700</if_sid>
         <list field="audit.key" lookup="match_key_value" check_value="command">etc/lists/audit-keys</list>
         <description>Audit: Command: $(audit.exe)</description>
-        <group>audit_command,</group>
+        <group>audit_command,gdpr_IV_30.1.g,</group>
     </rule>
 
     <!--

--- a/rules/0375-usb_rules.xml
+++ b/rules/0375-usb_rules.xml
@@ -27,6 +27,7 @@
         <if_sid>81100</if_sid>
         <match>USB disconnect</match>
         <description>USB device disconnected</description>
+        <group></group>
     </rule>
 
 </group>

--- a/rules/0380-redis_rules.xml
+++ b/rules/0380-redis_rules.xml
@@ -20,6 +20,7 @@
         <if_sid>81300</if_sid>
         <match>Server started</match>
         <description>Redis: started</description>
+        <group></group>
     </rule>
 
     <!--
@@ -29,6 +30,7 @@
         <if_sid>81300</if_sid>
         <match>Redis is now ready to exit, bye bye</match>
         <description>Redis: shutdown</description>
+        <group></group>
     </rule>
 
     <!--
@@ -39,6 +41,7 @@
         <if_sid>81300</if_sid>
         <match>WARNING|can't|not permitted|error|Error|ERROR|Failed</match>
         <description>Redis: Warning / Error</description>
+        <group></group>
     </rule>
 
     <!--
@@ -50,6 +53,7 @@
         <match>Accepted </match>
         <regex>\S+:\d+</regex>
         <description>Redis: Client connected</description>
+        <group></group>
     </rule>
 
     <!--
@@ -59,6 +63,7 @@
         <if_sid>81300</if_sid>
         <match>Client closed connection</match>
         <description>Redis: Client closed connection</description>
+        <group></group>
     </rule>
 
 </group>

--- a/rules/0385-oscap_rules.xml
+++ b/rules/0385-oscap_rules.xml
@@ -62,7 +62,7 @@ Wodle OpenSCAP: 81500 - 81600
         <if_sid>81400</if_sid>
         <match>oscap: ERROR: </match>
         <description>OpenSCAP: Error messages grouped.</description>
-        <group>errors,</group>
+        <group>errors,gdpr_IV_35.7.d,</group>
     </rule>
 
     <!--
@@ -72,7 +72,7 @@ Wodle OpenSCAP: 81500 - 81600
         <if_sid>81501</if_sid>
         <match>OpenSCAP not installed</match>
         <description>OpenSCAP ERROR: OpenSCAP not installed.</description>
-        <group>errors,</group>
+        <group>errors,gdpr_IV_35.7.d,</group>
     </rule>
 
     <!--
@@ -82,7 +82,7 @@ Wodle OpenSCAP: 81500 - 81600
         <if_sid>81501</if_sid>
         <match>Impossible to execute OpenSCAP</match>
         <description>OpenSCAP ERROR: Impossible to execute OpenSCAP.</description>
-        <group>errors,</group>
+        <group>errors,gdpr_IV_35.7.d,</group>
     </rule>
 
     <!--
@@ -92,7 +92,7 @@ Wodle OpenSCAP: 81500 - 81600
         <if_sid>81501</if_sid>
         <match>: File "</match>
         <description>OpenSCAP ERROR: Wrong configuration - Inexistent policy.</description>
-        <group>errors,</group>
+        <group>errors,gdpr_IV_35.7.d,</group>
     </rule>
 
     <!--
@@ -102,7 +102,7 @@ Wodle OpenSCAP: 81500 - 81600
         <if_sid>81501</if_sid>
         <match>Parsing file </match>
         <description>OpenSCAP ERROR: Wrong configuration - Invalid policy.</description>
-        <group>errors,</group>
+        <group>errors,gdpr_IV_35.7.d,</group>
     </rule>
 
     <!--
@@ -112,7 +112,7 @@ Wodle OpenSCAP: 81500 - 81600
         <if_sid>81501</if_sid>
         <match>Executing profile</match>
         <description>OpenSCAP ERROR: Problem executing oscap.</description>
-        <group>errors,</group>
+        <group>errors,gdpr_IV_35.7.d,</group>
     </rule>
 
     <!--
@@ -122,7 +122,7 @@ Wodle OpenSCAP: 81500 - 81600
         <if_sid>81501</if_sid>
         <match>Profile</match>
         <description>OpenSCAP ERROR: Wrong configuration - Inexistent profile.</description>
-        <group>errors,</group>
+        <group>errors,gdpr_IV_35.7.d,</group>
     </rule>
 
     <!--
@@ -132,7 +132,7 @@ Wodle OpenSCAP: 81500 - 81600
         <if_sid>81501</if_sid>
         <match>Timeout expired</match>
         <description>OpenSCAP ERROR: Timeout expired</description>
-        <group>errors,</group>
+        <group>errors,gdpr_IV_35.7.d,</group>
     </rule>
 
     <!--
@@ -142,7 +142,7 @@ Wodle OpenSCAP: 81500 - 81600
         <if_sid>81501</if_sid>
         <match>xsltproc not installed</match>
         <description>OpenSCAP ERROR: xsltproc not installed.</description>
-        <group>errors,</group>
+        <group>errors,gdpr_IV_35.7.d,</group>
     </rule>
 
     <!-- -->

--- a/rules/0390-fortigate_rules.xml
+++ b/rules/0390-fortigate_rules.xml
@@ -37,14 +37,14 @@ ID: 81600 - 80799
         <if_sid>81603</if_sid>
         <status>dpd_failure</status>
         <description>Fortigate: IP Sec DPD Failed.</description>
-        <group>firewall_drop,pci_dss_1.4,</group>
+        <group>firewall_drop,pci_dss_1.4,gdpr_IV_35.7.d,</group>
     </rule>
 
     <rule id="81605" level="7" frequency="16" timeframe="45" ignore="240">
         <if_matched_sid>81604</if_matched_sid>
         <same_source_ip />
         <description>Fortigate: Multiple Firewall drop events from same source.</description>
-        <group>multiple_drops,pci_dss_1.4,pci_dss_10.6.1,</group>
+        <group>multiple_drops,pci_dss_1.4,pci_dss_10.6.1,gdpr_IV_35.7.d,</group>
     </rule>
 
 
@@ -56,7 +56,7 @@ ID: 81600 - 80799
         <action>login</action>
         <status>failed</status>
         <description>Fortigate: Login failed.</description>
-        <group>authentication_failed,invalid_login,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,</group>
+        <group>authentication_failed,invalid_login,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
     </rule>
 
     <rule id="81607" level="7" frequency="16" timeframe="45" ignore="240">
@@ -64,7 +64,7 @@ ID: 81600 - 80799
         <same_source_ip />
         <options>alert_by_email</options>
         <description>Fortigate: Multiple failed login events from same source.</description>
-        <group>authentication_failures,pci_dss_10.6.1,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,</group>
+        <group>authentication_failures,pci_dss_10.6.1,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
     </rule>
 
 
@@ -76,12 +76,14 @@ ID: 81600 - 80799
         <match>Configuration is changed in the admin session</match>
         <options>alert_by_email</options>
         <description>Fortigate: Configuration changed.</description>
+        <group>gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
     </rule>
 
     <rule id="81609" level="8" frequency="16" timeframe="45" ignore="240">
         <if_matched_sid>81608</if_matched_sid>
         <same_source_ip />
         <description>Fortigate: Multiple changed configuration events from same source.</description>
+        <group>gdpr_IV_35.7.d,</group>
     </rule>
 
     <!--
@@ -91,7 +93,7 @@ ID: 81600 - 80799
         <if_sid>81603</if_sid>
         <match>http_decoder: HTTP.Unknown.Tunnelling</match>
         <description>Fortigate: Default tunneling setting. Could be IPS.</description>
-        <group>pci_dss_10.6.1,</group>
+        <group>pci_dss_10.6.1,gdpr_IV_35.7.d,</group>
     </rule>
 
     <rule id="81611" level="7" frequency="16" timeframe="45" ignore="240">
@@ -99,7 +101,7 @@ ID: 81600 - 80799
         <same_source_ip />
         <options>alert_by_email</options>
         <description>Fortigate: Multiple default tunneling setting events from same source.</description>
-        <group>pci_dss_10.6.1,</group>
+        <group>pci_dss_10.6.1,gdpr_IV_35.7.d,</group>
     </rule>
 
     <!--
@@ -109,14 +111,14 @@ ID: 81600 - 80799
         <if_sid>81603</if_sid>
         <action>Edit</action>
         <description>Fortigate: Firewall configuration changes</description>
-        <group>pci_dss_10.6.1,gpg13_4.13,</group>
+        <group>pci_dss_10.6.1,gpg13_4.13,gdpr_IV_35.7.d,</group>
     </rule>
 
     <rule id="81613" level="4" frequency="16" timeframe="45" ignore="240">
         <if_matched_sid>81612</if_matched_sid>
         <same_source_ip />
         <description>Fortigate: Multiple Firewall edit events from same source.</description>
-        <group>pci_dss_10.6.1,gpg13_4.13,</group>
+        <group>pci_dss_10.6.1,gpg13_4.13,gdpr_IV_35.7.d,</group>
     </rule>
 
 
@@ -127,7 +129,7 @@ ID: 81600 - 80799
         <if_sid>81603</if_sid>
         <match>ssl-login-fail</match>
         <description>Fortigate: SSL VPN User failed login attempt</description>
-        <group>authentication_failed,invalid_login,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,</group>
+        <group>authentication_failed,invalid_login,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
     </rule>
 
     <rule id="81615" level="7" frequency="16" timeframe="45" ignore="240">
@@ -135,7 +137,7 @@ ID: 81600 - 80799
         <same_source_ip />
         <options>alert_by_email</options>
         <description>Fortigate: Multiple Firewall SSL VPN failed login events from same source.</description>
-        <group>authentication_failures,pci_dss_10.6.1,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,</group>
+        <group>authentication_failures,pci_dss_10.6.1,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
     </rule>
 
     <!--
@@ -146,14 +148,14 @@ ID: 81600 - 80799
         <action>logout</action>
         <status>success</status>
         <description>Fortigate: User logout successful</description>
-        <group>pci_dss_10.2.5,gpg13_7.1,gpg13_7.2,</group>
+        <group>pci_dss_10.2.5,gpg13_7.1,gpg13_7.2,gdpr_IV_32.2,</group>
     </rule>
 
     <rule id="81617" level="7" frequency="16" timeframe="45" ignore="240">
         <if_matched_sid>81616</if_matched_sid>
         <same_source_ip />
         <description>Fortigate: Multiple Firewall logout events from same source.</description>
-        <group>pci_dss_10.2.5,gpg13_7.1,</group>
+        <group>pci_dss_10.2.5,gpg13_7.1,gdpr_IV_32.2,</group>
     </rule>
 
     <!--
@@ -164,7 +166,7 @@ ID: 81600 - 80799
         <match>type=traffic</match>
         <status>high</status>
         <description>Fortigate: Traffic to be aware of.</description>
-        <group>pci_dss_10.6.1,</group>
+        <group>pci_dss_10.6.1,gdpr_IV_35.7.d,</group>
     </rule>
 
     <rule id="81619" level="3" frequency="16" timeframe="45" ignore="240">
@@ -172,7 +174,7 @@ ID: 81600 - 80799
         <same_source_ip />
         <options>alert_by_email</options>
         <description>Fortigate: Multiple high traffic events from same source.</description>
-        <group>pci_dss_10.6.1,</group>
+        <group>pci_dss_10.6.1,gdpr_IV_35.7.d,</group>
     </rule>
 
     <!--
@@ -183,14 +185,14 @@ ID: 81600 - 80799
         <status>warning</status>
         <action>blocked</action>
         <description>Fortigate: URL Blocked by Firewall.</description>
-        <group>firewall_drop,pci_dss_10.6.1,</group>
+        <group>firewall_drop,pci_dss_10.6.1,gdpr_IV_35.7.d,</group>
     </rule>
 
     <rule id="81621" level="3" frequency="16" timeframe="45" ignore="240">
         <if_matched_sid>81620</if_matched_sid>
         <same_source_ip />
         <description>Fortigate: Multiple URL blocked from same source.</description>
-        <group>multiple_drops,pci_dss_10.6.1,</group>
+        <group>multiple_drops,pci_dss_10.6.1,gdpr_IV_35.7.d,</group>
     </rule>
 
     <!--
@@ -201,14 +203,14 @@ ID: 81600 - 80799
         <match>level=information</match>
         <action>tunnel-up</action>
         <description>Fortigate: VPN User connected.</description>
-        4.13<group>authentication_success,pci_dss_10.2.5,gpg13_7.1,</group>
+        <group>authentication_success,pci_dss_10.2.5,gpg13_7.1,gdpr_IV_32.2,</group>
     </rule>
 
     <rule id="81623" level="4" frequency="16" timeframe="45" ignore="240">
         <if_matched_sid>81622</if_matched_sid>
         <same_source_ip />
         <description>Fortigate: Multiple vpn user connected from same source.</description>
-        <group>authentication_success,pci_dss_10.2.5,gpg13_7.1,</group>
+        <group>authentication_success,pci_dss_10.2.5,gpg13_7.1,gdpr_IV_32.2,</group>
     </rule>
 
     <!--
@@ -219,14 +221,14 @@ ID: 81600 - 80799
         <match>level=information</match>
         <action>tunnel-down</action>
         <description>Fortigate: VPN User disconnected.</description>
-        <group>pci_dss_10.2.5,gpg13_7.1,</group>
+        <group>pci_dss_10.2.5,gpg13_7.1,gdpr_IV_32.2,</group>
     </rule>
 
     <rule id="81625" level="4" frequency="16" timeframe="45" ignore="240">
         <if_matched_sid>81624</if_matched_sid>
         <same_source_ip />
         <description>Fortigate: Multiple user disconnected events from same source.</description>
-        <group>pci_dss_10.2.5,gpg13_7.1,</group>
+        <group>pci_dss_10.2.5,gpg13_7.1,gdpr_IV_32.2,</group>
     </rule>
 
     <!--
@@ -238,14 +240,14 @@ ID: 81600 - 80799
         <status>success</status>
         <action>login</action>
         <description>Fortigate: User successfully logged into firewall interface.</description>
-        <group>pci_dss_10.6.1,gpg13_7.1,gpg13_7.2,</group>
+        <group>pci_dss_10.6.1,gpg13_7.1,gpg13_7.2,gdpr_IV_32.2,</group>
     </rule>
 
     <rule id="81627" level="4" frequency="16" timeframe="45" ignore="240">
         <if_matched_sid>81626</if_matched_sid>
         <same_source_ip />
         <description>Fortigate: Multiple Firewall login events from same source.</description>
-        <group>pci_dss_10.6.1,gpg13_7.1,gpg13_7.2,</group>
+        <group>pci_dss_10.6.1,gpg13_7.1,gpg13_7.2,gdpr_IV_35.7.d,</group>
     </rule>
 
 
@@ -259,7 +261,7 @@ ID: 81600 - 80799
         <match>attack</match>
         <action>detected</action>
         <description>Fortigate Attack Detected</description>
-        <group>attack,</group>
+        <group>attack,gdpr_IV_35.7.d,</group>
     </rule>
 
     <rule id="81629" level="3">
@@ -267,7 +269,7 @@ ID: 81600 - 80799
         <match>attack</match>
         <action>dropped</action>
         <description>Fortigate Attack Dropped</description>
-        <group>attack,</group>
+        <group>attack,gdpr_IV_35.7.d,</group>
     </rule>
 
 </group>

--- a/rules/0395-hp_rules.xml
+++ b/rules/0395-hp_rules.xml
@@ -38,7 +38,7 @@ Jun  8 11:54:52 HP-5500EI-HO %%10SHELL/4/LOGINAUTHFAIL(t): Trap 1.1.1.1.1.1.2550
         <if_sid>81700</if_sid>
         <id>0</id>
         <description>HP 5500 EI - Emergency event</description>
-        <group>hp-emergency,</group>
+        <group>hp-emergency,gdpr_IV_35.7.d,</group>
     </rule>
 
     <rule id="81702" level="6">
@@ -97,14 +97,14 @@ Jun  8 11:54:52 HP-5500EI-HO %%10SHELL/4/LOGINAUTHFAIL(t): Trap 1.1.1.1.1.1.2550
         <if_sid>81705</if_sid>
         <match>failed to log in|failed to login|authentication failed|Authentication is failed</match>
         <description>HP 5500 EI - Warning event: Authentication failure</description>
-        <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,</group>
+        <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
     </rule>
 
     <rule id="81710" level="10" frequency="6">
       <if_matched_sid>81709</if_matched_sid>
       <same_source_ip />
       <description>HP 5500 EI: Multiple authentication failures.</description>
-      <group>authentication_failures,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gpg13_7.1,</group>
+      <group>authentication_failures,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
     </rule>
 
 </group>

--- a/rules/0400-openvpn_rules.xml
+++ b/rules/0400-openvpn_rules.xml
@@ -20,7 +20,7 @@
         <if_sid>81800</if_sid>
         <match>Peer Connection Initiated with</match>
         <description>OpenVPN: User logged in</description>
-        <group>authentication_success,pci_dss_10.2.5,gpg13_7.1,gpg13_7.2,</group>
+        <group>authentication_success,pci_dss_10.2.5,gpg13_7.1,gpg13_7.2,gdpr_IV_32.2,</group>
     </rule>
 
     <rule id="81802" level="3" frequency="1" timeframe="60">
@@ -39,14 +39,14 @@
         <if_sid>81800</if_sid>
         <match>TLS Error|TLS Auth Error</match>
         <description>OpenVPN: Connection Certificate Failed</description>
-        <group>openvpn-error,</group>
+        <group>openvpn-error,gdpr_IV_35.7.d,</group>
     </rule>
 
     <rule id="81804" level="4" frequency="1" timeframe="60">
         <if_matched_sid>81803</if_matched_sid>
         <options>alert_by_email</options>
         <description>OpenVPN: Certificate failed - Possible revoked user</description>
-        <group>openvpn-error,</group>
+        <group>openvpn-error,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
     </rule>
 
 </group>

--- a/rules/0405-rsa-auth-manager_rules.xml
+++ b/rules/0405-rsa-auth-manager_rules.xml
@@ -24,7 +24,7 @@
         <id>AUTHN_LOGIN_EVENT</id>
         <action>SUCCESS</action>
         <description>RSA Authentication Manager: Authentication success</description>
-        <group>authentication_success,pci_dss_10.2.5,gpg13_7.1,gpg13_7.2,</group>
+        <group>authentication_success,pci_dss_10.2.5,gpg13_7.1,gpg13_7.2,gdpr_IV_32.2,</group>
     </rule>
 
     <rule id="81903" level="5">
@@ -32,14 +32,14 @@
         <id>AUTHN_LOGIN_EVENT</id>
         <action>FAIL</action>
         <description>RSA Authentication Manager: Authentication fail</description>
-        <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,</group>
+        <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
     </rule>
 
     <rule id="81904" level="10" frequency="6" timeframe="120">
         <if_matched_sid>81903</if_matched_sid>
         <same_user />
         <description>RSA Authentication Manager: Multiple authentication failures.</description>
-        <group>authentication_failures,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gpg13_7.1,</group>
+        <group>authentication_failures,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
     </rule>
 
 </group>

--- a/rules/0415-sophos_rules.xml
+++ b/rules/0415-sophos_rules.xml
@@ -18,23 +18,27 @@
 		<if_sid>82100</if_sid>
 		<match>Scan 'Sophos Cloud Scheduled Scan' started</match>
 		<description>Sophos Cloud Scheduled Scan started</description>
+		<group></group>
 	</rule>
 
 	<rule id="82102" level="3">
 		<if_sid>82100</if_sid>
 		<match>Scan 'Sophos Cloud Scheduled Scan' completed</match>
 		<description>Sophos Cloud Scheduled Scan completed</description>
+		<group></group>
 	</rule>
 
 	<rule id="82103" level="3">
 		<if_sid>82100</if_sid>
 		<match>has started</match>
 		<description>User has started on-access scanning for this machine.</description>
+		<group></group>
 	</rule>
 	<rule id="82104" level="3">
 		<if_sid>82100</if_sid>
 		<match>has stopped</match>
 		<description>User has stopped on-access scanning for this machine.</description>
+		<group></group>
 	</rule>
 
 	<rule id="82105" level="3">

--- a/rules/0420-freeipa_rules.xml
+++ b/rules/0420-freeipa_rules.xml
@@ -31,7 +31,7 @@
         <if_sid>82202</if_sid>
         <match>Password incorrect</match>
         <description>FreeIPA: Authentication fail</description>
-        <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,</group>
+        <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
     </rule>
 
 </group>

--- a/rules/0425-cisco-estreamer_rules.xml
+++ b/rules/0425-cisco-estreamer_rules.xml
@@ -18,7 +18,7 @@
         <id>SERVER-MYSQL</id>
         <match>failed Oracle Mysql login attempt</match>
         <description>Cisco eStreamer: SERVER-MYSQL failed login attempt</description>
-        <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,</group>
+        <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
     </rule>
 
 	<rule id="82402" level="5">
@@ -26,7 +26,7 @@
         <id>SERVER-MYSQL</id>
         <match>login attempt from unauthorized location</match>
         <description>Cisco eStreamer: SERVER-MYSQL login attempt from unauthorized location</description>
-        <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,</group>
+        <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
     </rule>
 
 	<rule id="82403" level="5">
@@ -34,7 +34,7 @@
         <id>SERVER-MYSQL</id>
         <match>client authentication bypass attempt</match>
         <description>Cisco eStreamer: SERVER-MYSQL client authentication bypass attempt</description>
-        <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,</group>
+        <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
     </rule>
 
 	<rule id="82404" level="5">
@@ -42,6 +42,7 @@
         <id>SERVER-MYSQL</id>
         <match>show databases attempt</match>
         <description>Cisco eStreamer: SERVER-MYSQL show databases attempt</description>
+        <group>gdpr_IV_35.7.d,</group>
     </rule>
 
 	<rule id="82405" level="9">
@@ -49,6 +50,7 @@
         <id>APP-DETECT</id>
         <match>DNS request for potential malware</match>
         <description>Cisco eStreamer: APP-DETECT DNS request for potential malware</description>
+        <group>gdpr_IV_35.7.d,</group>
     </rule>
 
 </group>

--- a/rules/0425-cisco-estreamer_rules.xml
+++ b/rules/0425-cisco-estreamer_rules.xml
@@ -50,7 +50,7 @@
         <id>APP-DETECT</id>
         <match>DNS request for potential malware</match>
         <description>Cisco eStreamer: APP-DETECT DNS request for potential malware</description>
-        <group>gdpr_IV_35.7.d,</group>
+        <group>pci_dss_10.6.1,gdpr_IV_35.7.d,</group>
     </rule>
 
 </group>

--- a/rules/0430-ms_wdefender_rules.xml
+++ b/rules/0430-ms_wdefender_rules.xml
@@ -21,6 +21,7 @@
         <if_sid>83000</if_sid>
         <id>1116</id>
         <description>Windows Defender: detected potentially unwanted software</description>
+        <group>gdpr_IV_35.7.d,</group>
     </rule>
 
     <!--
@@ -30,6 +31,7 @@
         <if_sid>83000</if_sid>
         <id>1117</id>
         <description>Windows Defender: error when taking action on potentially unwanted software</description>
+        <group>gdpr_IV_35.7.d,</group>
     </rule>
 
 </group>

--- a/rules/0430-ms_wdefender_rules.xml
+++ b/rules/0430-ms_wdefender_rules.xml
@@ -21,7 +21,7 @@
         <if_sid>83000</if_sid>
         <id>1116</id>
         <description>Windows Defender: detected potentially unwanted software</description>
-        <group>gdpr_IV_35.7.d,</group>
+        <group>pci_dss_10.6.1,gdpr_IV_35.7.d,</group>
     </rule>
 
     <!--
@@ -31,7 +31,7 @@
         <if_sid>83000</if_sid>
         <id>1117</id>
         <description>Windows Defender: error when taking action on potentially unwanted software</description>
-        <group>gdpr_IV_35.7.d,</group>
+        <group>pci_dss_10.6.1,gdpr_IV_35.7.d,</group>
     </rule>
 
 </group>

--- a/rules/0435-ms_logs_rules.xml
+++ b/rules/0435-ms_logs_rules.xml
@@ -15,7 +15,7 @@
         <if_sid>18101</if_sid>
         <id>1102</id>
         <description>The audit log was cleared</description>
-        <group>log_clearing_auditlog,gpg13_10.1,</group>
+        <group>log_clearing_auditlog,gpg13_10.1,gdpr_II_5.1.f,gdpr_IV_30.1.g,</group>
     </rule>
 
     <!--
@@ -25,7 +25,7 @@
         <if_sid>18101</if_sid>
         <id>^104$</id>
         <description>The Internet Explorer log file was cleared</description>
-        <group>log_clearing_ie,gpg13_10.1,</group>
+        <group>log_clearing_ie,gpg13_10.1,gdpr_II_5.1.f,</group>
     </rule>
 
     <!--

--- a/rules/0440-ms_sqlserver_rules.xml
+++ b/rules/0440-ms_sqlserver_rules.xml
@@ -21,6 +21,7 @@
         <if_sid>85000</if_sid>
         <match>Starting up database</match>
         <description>Starting up database.</description>
+        <group></group>
     </rule>
   
 <!--
@@ -51,7 +52,7 @@
         <if_sid>85000</if_sid>
         <match>Login succeeded for user</match>
         <description>SQL Server login success.</description>
-        <group>sqlserver_login,,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,gpg13_7.2,</group>
+        <group>sqlserver_login,pci_dss_10.2.5,gpg13_7.1,gpg13_7.2,gdpr_IV_32.2,</group>
     </rule>  
   
 <!--
@@ -62,14 +63,14 @@
         <if_sid>85000</if_sid>
         <match>Login failed for user</match>
         <description>SQL Server login failed.</description>
-        <group>sqlserver_login, authentication_failed,,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,</group>
+        <group>sqlserver_login, authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
     </rule>
 
     <rule id="85006" level="10" frequency="6">
         <if_matched_sid>85005</if_matched_sid>
         <same_source_ip />
         <description>SQL Server: Multiple authentication failures.</description>
-        <group>identityguard_login,authentication_failures,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gpg13_7.1,</group>
+        <group>identityguard_login,authentication_failures,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
     </rule>  
 
 <!--
@@ -91,7 +92,7 @@
         <if_sid>85000</if_sid>
         <match>The SQL Server Network Interface library could not register the Service Principal Name</match>
         <description>SQL Server Network Interface library unregistered </description>
-        <group>sqlservererror, sqlserverlibraries,</group>
+        <group>sqlservererror, sqlserverlibraries,gdpr_IV_35.7.d,</group>
     </rule> 
   
 <!--
@@ -102,7 +103,7 @@
         <if_sid>85000</if_sid>
         <match>Error: </match>
         <description>SQL Server error.</description>
-        <group>sqlservererror,</group>
+        <group>sqlservererror,gdpr_IV_35.7.d,</group>
     </rule> 
     
 <!--

--- a/rules/0445-identity_guard_rules.xml
+++ b/rules/0445-identity_guard_rules.xml
@@ -22,7 +22,7 @@
         <if_sid>85500</if_sid>
         <match>failed authentication</match>
         <description>Identity Guard: User authentication failed.</description>
-        <group>identityguard_login,authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,</group>
+        <group>identityguard_login,authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
     </rule>
 
 
@@ -30,7 +30,7 @@
         <if_matched_sid>85501</if_matched_sid>
         <same_source_ip />
         <description>Identity Guard: Multiple authentication failures.</description>
-        <group>identityguard_login,authentication_failures,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gpg13_7.1,</group>
+        <group>identityguard_login,authentication_failures,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
     </rule>	
 	
 </group>

--- a/rules/0450-mongodb_rules.xml
+++ b/rules/0450-mongodb_rules.xml
@@ -31,6 +31,7 @@ D	Debug, for All Verbosity Levels > 0
         <if_sid>85750</if_sid>
         <field name="mongodb.severity">F</field>
         <description>MongoDB: Fatal message</description>
+        <group>gdpr_IV_35.7.d,</group>
     </rule>
 
     <!--
@@ -77,6 +78,7 @@ D	Debug, for All Verbosity Levels > 0
         <field name="mongodb.component">NETWORK</field>
         <match>connection accepted</match>
         <description>MongoDB: Connection accepted</description>
+        <group></group>
     </rule>
 
     <!--
@@ -87,6 +89,7 @@ D	Debug, for All Verbosity Levels > 0
         <field name="mongodb.component">NETWORK</field>
         <match>end connection</match>
         <description>MongoDB: End connection</description>
+        <group></group>
     </rule>
 
     <!--
@@ -97,7 +100,7 @@ D	Debug, for All Verbosity Levels > 0
         <field name="mongodb.component">ACCESS</field>
         <match>Successfully authenticated</match>
         <description>MongoDB: Successfully authentication</description>
-        <group>authentication_success,pci_dss_10.2.5,gpg13_7.1,gpg13_7.2,</group>
+        <group>authentication_success,pci_dss_10.2.5,gpg13_7.1,gpg13_7.2,gdpr_IV_32.2,</group>
     </rule>
 
     <!--
@@ -108,14 +111,14 @@ D	Debug, for All Verbosity Levels > 0
         <field name="mongodb.component">ACCESS</field>
         <match>authentication failed for</match>
         <description>MongoDB: Failed authentication</description>
-        <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,</group>
+        <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
     </rule>
 
     <rule id="85760" level="10" frequency="6">
       <if_matched_sid>85759</if_matched_sid>
       <same_source_ip />
       <description>MongoDB: Multiple authentication failures.</description>
-      <group>authentication_failures,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gpg13_7.1,</group>
+      <group>authentication_failures,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
     </rule>
 
     <!--
@@ -126,6 +129,7 @@ D	Debug, for All Verbosity Levels > 0
         <field name="mongodb.component">ACCESS</field>
         <regex>Unauthorized not authorized on \S+ to execute command</regex>
         <description>MongoDB: Execute commands without the necessary privileges</description>
+        <group>gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
     </rule>
 
 </group>

--- a/rules/0450-mongodb_rules.xml
+++ b/rules/0450-mongodb_rules.xml
@@ -129,7 +129,7 @@ D	Debug, for All Verbosity Levels > 0
         <field name="mongodb.component">ACCESS</field>
         <regex>Unauthorized not authorized on \S+ to execute command</regex>
         <description>MongoDB: Execute commands without the necessary privileges</description>
-        <group>gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
+        <group>pci_dss_10.2.5,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
     </rule>
 
 </group>

--- a/rules/0455-docker_rules.xml
+++ b/rules/0455-docker_rules.xml
@@ -61,7 +61,7 @@
         <if_sid>86003</if_sid>
         <match>unauthorized</match>
         <description>Docker: Error - unauthorized action</description>
-        <group>docker-error,</group>
+        <group>docker-error,gdpr_IV_35.7.d,</group>
     </rule>
 
     <!--
@@ -73,7 +73,7 @@
         <if_sid>86003</if_sid>
         <match>denied: User</match>
         <description>Docker: Error - denied action</description>
-        <group>docker-error,</group>
+        <group>docker-error,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
     </rule>
 
 </group>

--- a/rules/0455-docker_rules.xml
+++ b/rules/0455-docker_rules.xml
@@ -61,7 +61,7 @@
         <if_sid>86003</if_sid>
         <match>unauthorized</match>
         <description>Docker: Error - unauthorized action</description>
-        <group>docker-error,gdpr_IV_35.7.d,</group>
+        <group>docker-error,pci_dss_10.2.4,pci_dss_10.2.5,gdpr_IV_35.7.d,</group>
     </rule>
 
     <!--
@@ -73,7 +73,7 @@
         <if_sid>86003</if_sid>
         <match>denied: User</match>
         <description>Docker: Error - denied action</description>
-        <group>docker-error,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
+        <group>docker-error,pci_dss_10.2.5,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
     </rule>
 
 </group>

--- a/rules/0470-vshell_rules.xml
+++ b/rules/0470-vshell_rules.xml
@@ -16,42 +16,46 @@
     <if_sid>86800</if_sid>
     <match>Connection accepted from</match>
     <description>VShell connection attempt successful</description>
+    <group>gdpr_IV_32.2,</group>
   </rule>
 
   <rule id="86802" level="5">
     <if_sid>86800</if_sid>
     <regex>Login failed|Authentication for (\w+) failed</regex>
     <description>VShell user failed to login or user does not exist</description>
-    <group>gpg13_7.1,</group>
+    <group>gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
   </rule>
 
   <rule id="86803" level="7">
     <if_sid>86802</if_sid>
     <regex>Maximum authentication retries for user (\w+) exceeded</regex>
     <description>VShell user used the maximum number of password attempts.</description>
-    <group>gpg13_7.1,</group>
+    <group>gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
   </rule>
 
   <rule id="86804" level="10">
     <if_sid>86800</if_sid>
     <regex>Connection from (\d+.\d+.\d+.\d+) rejected by Deny Hosts file</regex>
     <description>Host is trying to connect to VShell server but exists in the deny file.</description>
+    <group>gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="86805" level="3">
     <if_sid>86800</if_sid>
     <regex>password for user (\S+) accepted</regex>
     <description>VShell user successfully authenticated.</description>
-    <group>gpg13_7.1,gpg13_7.2,</group>
+    <group>gpg13_7.1,gpg13_7.2,gdpr_IV_32.2,</group>
   </rule>
 
   <rule id="86806" level="12" frequency="5" timeframe="120">
     <if_matched_sid>86804</if_matched_sid>
     <description>VShell multiple connection attempts within 2 minute by a host in the deny file, potential DOS or brute force attempt.</description>
+    <group>gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
   </rule>
 
   <rule id="86807" level="12" frequency="5" timeframe="60">
     <if_matched_sid>86802</if_matched_sid>
     <description>VShell host has exceeded the number of failed login attempts and has been added to the Hosts Deny file.</description>
+    <group>gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
   </rule>
 </group>

--- a/rules/0470-vshell_rules.xml
+++ b/rules/0470-vshell_rules.xml
@@ -16,21 +16,21 @@
     <if_sid>86800</if_sid>
     <match>Connection accepted from</match>
     <description>VShell connection attempt successful</description>
-    <group>gdpr_IV_32.2,</group>
+    <group>pci_dss_10.2.5,gdpr_IV_32.2,</group>
   </rule>
 
   <rule id="86802" level="5">
     <if_sid>86800</if_sid>
     <regex>Login failed|Authentication for (\w+) failed</regex>
     <description>VShell user failed to login or user does not exist</description>
-    <group>gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
+    <group>pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
   </rule>
 
   <rule id="86803" level="7">
     <if_sid>86802</if_sid>
     <regex>Maximum authentication retries for user (\w+) exceeded</regex>
     <description>VShell user used the maximum number of password attempts.</description>
-    <group>gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
+    <group>pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
   </rule>
 
   <rule id="86804" level="10">
@@ -44,18 +44,18 @@
     <if_sid>86800</if_sid>
     <regex>password for user (\S+) accepted</regex>
     <description>VShell user successfully authenticated.</description>
-    <group>gpg13_7.1,gpg13_7.2,gdpr_IV_32.2,</group>
+    <group>pci_dss_10.2.5,gpg13_7.1,gpg13_7.2,gdpr_IV_32.2,</group>
   </rule>
 
   <rule id="86806" level="12" frequency="5" timeframe="120">
     <if_matched_sid>86804</if_matched_sid>
     <description>VShell multiple connection attempts within 2 minute by a host in the deny file, potential DOS or brute force attempt.</description>
-    <group>gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
+    <group>pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
   </rule>
 
   <rule id="86807" level="12" frequency="5" timeframe="60">
     <if_matched_sid>86802</if_matched_sid>
     <description>VShell host has exceeded the number of failed login attempts and has been added to the Hosts Deny file.</description>
-    <group>gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
+    <group>pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
   </rule>
 </group>

--- a/rules/0480-qualysguard_rules.xml
+++ b/rules/0480-qualysguard_rules.xml
@@ -19,6 +19,7 @@
        <if_sid>86900</if_sid>
        <field name="qualysguard.severity">^Potential Vulnerability - level 3</field>
        <description>Qualysguard: $(qualysguard.vulnerability_title).</description>
+       <group>gdpr_IV_35.7.d,</group>
     </rule>
 
     <!-- 
@@ -28,6 +29,7 @@
        <if_sid>86900</if_sid>
        <field name="qualysguard.severity">^Vulnerability - level 3</field>
        <description>Qualysguard: $(qualysguard.vulnerability_title).</description>
+       <group>gdpr_IV_35.7.d,</group>
     </rule>
 
     <!-- Level 4 Rules -->
@@ -38,6 +40,7 @@
        <if_sid>86900</if_sid>
        <field name="qualysguard.severity">^Potential Vulnerability - level 4</field>
        <description>Qualysguard: $(qualysguard.vulnerability_title).</description>
+       <group>gdpr_IV_35.7.d,</group>
     </rule>
 
     <!-- 
@@ -47,6 +50,7 @@
        <if_sid>86900</if_sid>
        <field name="qualysguard.severity">^Vulnerability - level 4</field>
        <description>Qualysguard: $(qualysguard.vulnerability_title).</description>
+       <group>gdpr_IV_35.7.d,</group>
     </rule>
 
     <!-- Level 5 Rules -->
@@ -57,6 +61,7 @@
        <if_sid>86900</if_sid>
        <field name="qualysguard.severity">^Potential Vulnerability - level 5</field>
        <description>Qualysguard: $(qualysguard.vulnerability_title).</description>
+       <group>gdpr_IV_35.7.d,</group>
     </rule>
 
     <!-- 
@@ -66,5 +71,6 @@
        <if_sid>86900</if_sid>
        <field name="qualysguard.severity">^Vulnerability - level 5</field>
        <description>Qualysguard: $(qualysguard.vulnerability_title).</description>
+       <group>gdpr_IV_35.7.d,</group>
     </rule>
 </group>

--- a/rules/0480-qualysguard_rules.xml
+++ b/rules/0480-qualysguard_rules.xml
@@ -19,7 +19,7 @@
        <if_sid>86900</if_sid>
        <field name="qualysguard.severity">^Potential Vulnerability - level 3</field>
        <description>Qualysguard: $(qualysguard.vulnerability_title).</description>
-       <group>gdpr_IV_35.7.d,</group>
+       <group>pci_dss_10.6.1,gdpr_IV_35.7.d,</group>
     </rule>
 
     <!-- 
@@ -29,7 +29,7 @@
        <if_sid>86900</if_sid>
        <field name="qualysguard.severity">^Vulnerability - level 3</field>
        <description>Qualysguard: $(qualysguard.vulnerability_title).</description>
-       <group>gdpr_IV_35.7.d,</group>
+       <group>pci_dss_10.6.1,gdpr_IV_35.7.d,</group>
     </rule>
 
     <!-- Level 4 Rules -->
@@ -40,7 +40,7 @@
        <if_sid>86900</if_sid>
        <field name="qualysguard.severity">^Potential Vulnerability - level 4</field>
        <description>Qualysguard: $(qualysguard.vulnerability_title).</description>
-       <group>gdpr_IV_35.7.d,</group>
+       <group>pci_dss_10.6.1,gdpr_IV_35.7.d,</group>
     </rule>
 
     <!-- 
@@ -50,7 +50,7 @@
        <if_sid>86900</if_sid>
        <field name="qualysguard.severity">^Vulnerability - level 4</field>
        <description>Qualysguard: $(qualysguard.vulnerability_title).</description>
-       <group>gdpr_IV_35.7.d,</group>
+       <group>pci_dss_10.6.1,gdpr_IV_35.7.d,</group>
     </rule>
 
     <!-- Level 5 Rules -->
@@ -61,7 +61,7 @@
        <if_sid>86900</if_sid>
        <field name="qualysguard.severity">^Potential Vulnerability - level 5</field>
        <description>Qualysguard: $(qualysguard.vulnerability_title).</description>
-       <group>gdpr_IV_35.7.d,</group>
+       <group>pci_dss_10.6.1,gdpr_IV_35.7.d,</group>
     </rule>
 
     <!-- 
@@ -71,6 +71,6 @@
        <if_sid>86900</if_sid>
        <field name="qualysguard.severity">^Vulnerability - level 5</field>
        <description>Qualysguard: $(qualysguard.vulnerability_title).</description>
-       <group>gdpr_IV_35.7.d,</group>
+       <group>pci_dss_10.6.1,gdpr_IV_35.7.d,</group>
     </rule>
 </group>

--- a/rules/0485-cylance_rules.xml
+++ b/rules/0485-cylance_rules.xml
@@ -21,6 +21,7 @@
         <if_sid>87000</if_sid>
         <field name="cylance_events.eventstatus">unsafe</field>
         <description>Cylance: File $(cylance_events.filepath) is unsafe.</description>
+        <group>gdpr_IV_35.7.d,</group>
     </rule>
 
     <!-- 
@@ -43,6 +44,7 @@
         <if_sid>87000</if_sid>
         <field name="cylance_events.eventstatus">quarantined</field>
         <description>Cylance: File $(cylance_events.filepath) is quarantined.</description>
+        <group>gdpr_IV_35.7.d,</group>
     </rule>
 
     <!-- 
@@ -81,6 +83,7 @@
     	<if_sid>87050</if_sid>
     	<field name="cylance_threats.file_status">quarantined</field>
     	<description>Cylance Threat: File $(cylance_threats.file_path) is quarantined</description>
+        <group>gdpr_IV_35.7.d,</group>
     </rule>
 
     <!-- 
@@ -99,5 +102,6 @@
     	<if_sid>87050</if_sid>
     	<field name="cylance_threats.file_status">unsafe</field>
     	<description>Cylance Threat: File $(cylance_threats.file_path) is unsafe</description>
+        <group>gdpr_IV_35.7.d,</group>
     </rule> 
 </group>

--- a/rules/0485-cylance_rules.xml
+++ b/rules/0485-cylance_rules.xml
@@ -21,7 +21,7 @@
         <if_sid>87000</if_sid>
         <field name="cylance_events.eventstatus">unsafe</field>
         <description>Cylance: File $(cylance_events.filepath) is unsafe.</description>
-        <group>gdpr_IV_35.7.d,</group>
+        <group>pci_dss_10.6.1,gdpr_IV_35.7.d,</group>
     </rule>
 
     <!-- 
@@ -102,6 +102,6 @@
     	<if_sid>87050</if_sid>
     	<field name="cylance_threats.file_status">unsafe</field>
     	<description>Cylance Threat: File $(cylance_threats.file_path) is unsafe</description>
-        <group>gdpr_IV_35.7.d,</group>
+        <group>pci_dss_10.6.1,gdpr_IV_35.7.d,</group>
     </rule> 
 </group>

--- a/rules/0490-virustotal_rules.xml
+++ b/rules/0490-virustotal_rules.xml
@@ -24,6 +24,7 @@
         <if_sid>87100</if_sid>
         <field name="virustotal.error">403</field>
         <description>VirusTotal: Error: Check credentials</description>
+        <group>gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
     </rule>
 
     <rule id="87103" level="3">
@@ -43,6 +44,7 @@
         <if_sid>87100</if_sid>
         <field name="virustotal.malicious">1</field>
         <description>VirusTotal: Alert - $(virustotal.source.file) - $(virustotal.positives) engines detected this file</description>
+        <group>gdpr_IV_35.7.d,</group>
     </rule>
  
 </group>

--- a/rules/0490-virustotal_rules.xml
+++ b/rules/0490-virustotal_rules.xml
@@ -44,7 +44,7 @@
         <if_sid>87100</if_sid>
         <field name="virustotal.malicious">1</field>
         <description>VirusTotal: Alert - $(virustotal.source.file) - $(virustotal.positives) engines detected this file</description>
-        <group>gdpr_IV_35.7.d,</group>
+        <group>pci_dss_10.6.1,pci_dss_11.4,gdpr_IV_35.7.d,</group>
     </rule>
  
 </group>

--- a/rules/0495-proxmox-ve_rules.xml
+++ b/rules/0495-proxmox-ve_rules.xml
@@ -14,21 +14,21 @@
     <if_sid>87200</if_sid>
     <match>authentication failure; </match>
     <description>Proxmox VE authentication failed.</description>
-    <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,</group>
+    <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
   </rule>
 
   <rule id="87202" level="10" frequency="6" timeframe="120">
     <if_matched_sid>87201</if_matched_sid>
     <same_source_ip />
     <description>Proxmox VE brute force (multiple failed logins).</description>
-    <group>authentication_failures,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,</group>
+    <group>authentication_failures,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
   </rule>
 
   <rule id="87203" level="3">
     <if_sid>87200</if_sid>
     <match> successful auth for user </match>
     <description>Proxmox VE authentication succeeded.</description>
-    <group>authentication_success,pci_dss_10.2.5,</group>
+    <group>authentication_success,pci_dss_10.2.5,gdpr_IV_32.2,</group>
   </rule>
 
 </group>

--- a/rules/0500-owncloud_rules.xml
+++ b/rules/0500-owncloud_rules.xml
@@ -57,27 +57,28 @@
     <if_sid>87300,87310</if_sid>
     <match>Login failed: </match>
     <description>ownCloud authentication failed.</description>
-    <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,</group>
+    <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
   </rule>
 
   <rule id="87302" level="10" frequency="6" timeframe="120">
     <if_matched_sid>87301</if_matched_sid>
     <same_source_ip />
     <description>ownCloud brute force (multiple failed logins).</description>
-    <group>authentication_failures,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,</group>
+    <group>authentication_failures,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
   </rule>
 
   <rule id="87303" level="6">
     <if_sid>87300,87310</if_sid>
     <match>Passed filename is not valid, might be malicious </match>
     <description>ownCloud possible malicious request.</description>
-    <group>web,appsec,attack,pci_dss_6.5,pci_dss_11.4,</group>
+    <group>web,appsec,attack,pci_dss_6.5,pci_dss_11.4,gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="87304" level="8">
     <if_sid>87300,87310</if_sid>
     <status>^4$</status>
     <description>ownCloud FATAL message.</description>
+    <group>gdpr_IV_35.7.d,</group>
   </rule>
 
  <rule id="87305" level="4">

--- a/rules/0505-vuls_rules.xml
+++ b/rules/0505-vuls_rules.xml
@@ -27,36 +27,42 @@
       <field name="vuls.event">\.+</field>
       <match>has a update date lower</match>
       <description>$(vuls.scanned_cve) has a update date lower than $(vuls.days) days.</description>
+      <group>gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="22403" level="5">
       <if_sid>22401</if_sid>
       <field name="vuls.affected_packages">\.+</field>
       <description>Low vulnerability $(vuls.scanned_cve) detected in scanning launched on c with $(vuls.assurance) reliability ($(vuls.detection_method)). Score: $(vuls.core) ($(vuls.source)). Affected packages: $(vuls.affected_packages)</description>
+      <group>gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="22404" level="7">
       <if_sid>22403</if_sid>
       <field name="vuls.score">^4|^5|^6</field>
       <description>Medium vulnerability $(vuls.scanned_cve) detected in scanning launched on $(vuls.scan_date) with $(vuls.assurance) reliability ($(vuls.detection_method)). $(vuls.tittle). Score: $(vuls.score) ($(vuls.source)). Affected packages: $(vuls.affected_packages)</description>
+      <group>gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="22405" level="10">
       <if_sid>22403</if_sid>
       <field name="vuls.score">^7|^8</field>
       <description>High vulnerability $(vuls.scanned_cve) detected in scanning launched on $(vuls.scan_date) with $(vuls.assurance) reliability ($(vuls.detection_method)). $(vuls.tittle). Score: $(vuls.score) ($(vuls.source)). Affected packages: $(vuls.affected_packages)</description>
+      <group>gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="22406" level="13">
       <if_sid>22403</if_sid>
       <field name="vuls.score">^9|^10</field>
       <description>Critical vulnerability $(vuls.scanned_cve) detected in scanning launched on $(vuls.scan_date) with $(vuls.assurance) reliability ($(vuls.detection_method)). $(vuls.tittle). Score: $(vuls.score) ($(vuls.source)). Affected packages: $(vuls.affected_packages)</description>
+      <group>gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="22407" level="7">
       <if_sid>22401</if_sid>
       <field name="vuls.affected_packages">kernel</field>
       <description>Vulnerability $(vuls.scanned_cve) affects critical parts of the system.</description>
+      <group>gdpr_IV_35.7.d,</group>
   </rule>
 
 </group>

--- a/rules/0505-vuls_rules.xml
+++ b/rules/0505-vuls_rules.xml
@@ -41,28 +41,28 @@
       <if_sid>22403</if_sid>
       <field name="vuls.score">^4|^5|^6</field>
       <description>Medium vulnerability $(vuls.scanned_cve) detected in scanning launched on $(vuls.scan_date) with $(vuls.assurance) reliability ($(vuls.detection_method)). $(vuls.tittle). Score: $(vuls.score) ($(vuls.source)). Affected packages: $(vuls.affected_packages)</description>
-      <group>gdpr_IV_35.7.d,</group>
+      <group>pci_dss_10.6.1,gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="22405" level="10">
       <if_sid>22403</if_sid>
       <field name="vuls.score">^7|^8</field>
       <description>High vulnerability $(vuls.scanned_cve) detected in scanning launched on $(vuls.scan_date) with $(vuls.assurance) reliability ($(vuls.detection_method)). $(vuls.tittle). Score: $(vuls.score) ($(vuls.source)). Affected packages: $(vuls.affected_packages)</description>
-      <group>gdpr_IV_35.7.d,</group>
+      <group>pci_dss_10.6.1,gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="22406" level="13">
       <if_sid>22403</if_sid>
       <field name="vuls.score">^9|^10</field>
       <description>Critical vulnerability $(vuls.scanned_cve) detected in scanning launched on $(vuls.scan_date) with $(vuls.assurance) reliability ($(vuls.detection_method)). $(vuls.tittle). Score: $(vuls.score) ($(vuls.source)). Affected packages: $(vuls.affected_packages)</description>
-      <group>gdpr_IV_35.7.d,</group>
+      <group>pci_dss_10.6.1,gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="22407" level="7">
       <if_sid>22401</if_sid>
       <field name="vuls.affected_packages">kernel</field>
       <description>Vulnerability $(vuls.scanned_cve) affects critical parts of the system.</description>
-      <group>gdpr_IV_35.7.d,</group>
+      <group>pci_dss_10.6.1,gdpr_IV_35.7.d,</group>
   </rule>
 
 </group>

--- a/rules/0510-ciscat_rules.xml
+++ b/rules/0510-ciscat_rules.xml
@@ -36,6 +36,7 @@
       <if_sid>87401</if_sid>
       <field name="type">^scan_info$</field>
       <description>CIS-CAT: assessment information for scan $(scan_id)</description>
+      <group></group>
   </rule>
 
   <!-- Rule to support CIS-CAT rules of Wazuh 3.1 -->
@@ -43,6 +44,7 @@
       <if_sid>87402</if_sid>
       <field name="type">^scan_info$</field>
       <description>CIS-CAT: assessment information for scan $(scan_id)</description>
+      <group></group>
   </rule>
 
   <rule id="87405" level="0">
@@ -134,6 +136,7 @@
       <field name="type">^scan_result$</field>
       <field name="cis.result">^fail$</field>
       <description>CIS-CAT: $(cis.rule_title) (failed)</description>
+      <group>gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="87418" level="7">
@@ -141,6 +144,7 @@
       <field name="type">^scan_result$</field>
       <field name="cis-data.result">^fail$</field>
       <description>CIS-CAT: $(cis-data.rule_title) (failed)</description>
+      <group>gdpr_IV_35.7.d,</group>
   </rule>
 
 <!-- Example JSON event
@@ -175,24 +179,28 @@
     <if_sid>87401</if_sid>
     <field name="cis.score">^4\d|^3\d</field>
     <description>CIS-CAT Report overview: Score less than 50% ($(cis.score))</description>
+    <group>gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="87424" level="7">
     <if_sid>87402</if_sid>
     <field name="cis-data.score">^4\d|^3\d</field>
     <description>CIS-CAT Report overview: Score less than 50% ($(cis-data.score) %)</description>
+    <group>gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="87425" level="9">
     <if_sid>87401</if_sid>
     <field name="cis.score">^2\d|^1\d|^\d$</field>
     <description>CIS-CAT Report overview: Score less than 30% ($(cis.score))</description>
+    <group>gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="87426" level="9">
     <if_sid>87402</if_sid>
     <field name="cis-data.score">^2\d|^1\d|^\d$</field>
     <description>CIS-CAT Report overview: Score less than 30% ($(cis-data.score) %)</description>
+    <group>gdpr_IV_35.7.d,</group>
   </rule>
 
 </group>

--- a/rules/0510-ciscat_rules.xml
+++ b/rules/0510-ciscat_rules.xml
@@ -179,28 +179,28 @@
     <if_sid>87401</if_sid>
     <field name="cis.score">^4\d|^3\d</field>
     <description>CIS-CAT Report overview: Score less than 50% ($(cis.score))</description>
-    <group>gdpr_IV_35.7.d,</group>
+    <group>pci_dss_10.6.1,gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="87424" level="7">
     <if_sid>87402</if_sid>
     <field name="cis-data.score">^4\d|^3\d</field>
     <description>CIS-CAT Report overview: Score less than 50% ($(cis-data.score) %)</description>
-    <group>gdpr_IV_35.7.d,</group>
+    <group>pci_dss_10.6.1,gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="87425" level="9">
     <if_sid>87401</if_sid>
     <field name="cis.score">^2\d|^1\d|^\d$</field>
     <description>CIS-CAT Report overview: Score less than 30% ($(cis.score))</description>
-    <group>gdpr_IV_35.7.d,</group>
+    <group>pci_dss_10.6.1,gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="87426" level="9">
     <if_sid>87402</if_sid>
     <field name="cis-data.score">^2\d|^1\d|^\d$</field>
     <description>CIS-CAT Report overview: Score less than 30% ($(cis-data.score) %)</description>
-    <group>gdpr_IV_35.7.d,</group>
+    <group>pci_dss_10.6.1,gdpr_IV_35.7.d,</group>
   </rule>
 
 </group>

--- a/rules/0515-exim_rules.xml
+++ b/rules/0515-exim_rules.xml
@@ -23,14 +23,14 @@
       <if_sid>87501</if_sid>
       <match>authenticator failed</match>
       <description>Exim Auth failed</description>
-      <group>invalid_login,authentication_failed,</group>
+      <group>invalid_login,authentication_failed,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
     </rule>
 
     <rule id="87507" level="10" frequency="6" timeframe="240">
       <if_matched_sid>87506</if_matched_sid>
       <same_source_ip />
       <description>Exim brute force attack (multiple auth failures).</description>
-      <group>authentication_failures,</group>
+      <group>authentication_failures,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
     </rule>
 
     <rule id="87508" level="0">

--- a/rules/0515-exim_rules.xml
+++ b/rules/0515-exim_rules.xml
@@ -23,14 +23,14 @@
       <if_sid>87501</if_sid>
       <match>authenticator failed</match>
       <description>Exim Auth failed</description>
-      <group>invalid_login,authentication_failed,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
+      <group>invalid_login,authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
     </rule>
 
     <rule id="87507" level="10" frequency="6" timeframe="240">
       <if_matched_sid>87506</if_matched_sid>
       <same_source_ip />
       <description>Exim brute force attack (multiple auth failures).</description>
-      <group>authentication_failures,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
+      <group>authentication_failures,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
     </rule>
 
     <rule id="87508" level="0">

--- a/rules/0520-vulnerability-detector.xml
+++ b/rules/0520-vulnerability-detector.xml
@@ -31,7 +31,7 @@
       <options>no_full_log</options>
       <field name="vulnerability.severity">Medium|Moderate</field>
       <description>$(vulnerability.title)</description>
-      <group>gdpr_IV_35.7.d,</group>
+      <group>pci_dss_10.6.1,gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="23505" level="10">
@@ -39,7 +39,7 @@
       <options>no_full_log</options>
       <field name="vulnerability.severity">High|Important </field>
       <description>$(vulnerability.title)</description>
-      <group>gdpr_IV_35.7.d,</group>
+      <group>pci_dss_10.6.1,gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="23506" level="13">
@@ -47,6 +47,6 @@
       <options>no_full_log</options>
       <field name="vulnerability.severity">Critical</field>
       <description>$(vulnerability.title)</description>
-      <group>gdpr_IV_35.7.d,</group>
+      <group>pci_dss_10.6.1,gdpr_IV_35.7.d,</group>
   </rule>
 </group>

--- a/rules/0520-vulnerability-detector.xml
+++ b/rules/0520-vulnerability-detector.xml
@@ -31,6 +31,7 @@
       <options>no_full_log</options>
       <field name="vulnerability.severity">Medium|Moderate</field>
       <description>$(vulnerability.title)</description>
+      <group>gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="23505" level="10">
@@ -38,6 +39,7 @@
       <options>no_full_log</options>
       <field name="vulnerability.severity">High|Important </field>
       <description>$(vulnerability.title)</description>
+      <group>gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="23506" level="13">
@@ -45,5 +47,6 @@
       <options>no_full_log</options>
       <field name="vulnerability.severity">Critical</field>
       <description>$(vulnerability.title)</description>
+      <group>gdpr_IV_35.7.d,</group>
   </rule>
 </group>

--- a/rules/0525-openvas_rules.xml
+++ b/rules/0525-openvas_rules.xml
@@ -15,27 +15,28 @@
     <if_sid>87600</if_sid>
     <match>Authentication failure for </match>
     <description>OpenVAS (gsad) authentication failed.</description>
-    <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,</group>
+    <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
   </rule>
 
   <rule id="87602" level="10" frequency="6" timeframe="120">
     <if_matched_sid>87601</if_matched_sid>
     <same_source_ip />
     <description>OpenVAS (gsad) brute force (multiple failed logins).</description>
-    <group>authentication_failures,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,</group>
+    <group>authentication_failures,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
   </rule>
 
   <rule id="87603" level="3">
     <if_sid>87600</if_sid>
     <match>Authentication success for </match>
     <description>OpenVAS (gsad) authentication succeeded.</description>
-    <group>authentication_success,pci_dss_10.2.5,</group>
+    <group>authentication_success,pci_dss_10.2.5,gdpr_IV_32.2,</group>
   </rule>
 
   <rule id="87604" level="6">
     <if_sid>87600</if_sid>
     <status>^ERROR$</status>
     <description>OpenVAS (gsad) ERROR message.</description>
+    <group>gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="87605" level="4">
@@ -67,20 +68,21 @@
     <if_sid>87608</if_sid>
     <match>Authentication failure for </match>
     <description>OpenVAS (openvasmd) authentication failed.</description>
-    <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,</group>
+    <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
   </rule>
 
   <rule id="87610" level="10" frequency="6" timeframe="120">
     <if_matched_sid>87609</if_matched_sid>
     <same_source_ip />
     <description>OpenVAS (openvasmd) brute force (multiple failed logins).</description>
-    <group>authentication_failures,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,</group>
+    <group>authentication_failures,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
   </rule>
 
   <rule id="87611" level="6">
     <if_sid>87608</if_sid>
     <status>^ERROR$</status>
     <description>OpenVAS (openvasmd) ERROR message.</description>
+    <group>gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="87612" level="4">

--- a/rules/0530-mysql_audit_rules.xml
+++ b/rules/0530-mysql_audit_rules.xml
@@ -35,14 +35,14 @@ logcollector must be configured with the following labels
       <field name="audit_record.name">^Connect$</field>
       <field name="audit_record.status">^0$</field>
       <description>Percona audit: authentication success.</description>
-      <group>authentication_success,pci_dss_10.2.5,pci_dss_8.7,gpg13_7.1,gpg13_7.2,</group>
+      <group>authentication_success,pci_dss_10.2.5,pci_dss_8.7,gpg13_7.1,gpg13_7.2,gdpr_IV_32.2,</group>
     </rule>
 
     <rule id="88002" level="3">
       <if_sid>88000</if_sid>
       <field name="audit_record.name">^Quit$</field>
       <description>Percona audit: user logout.</description>
-      <group>pci_dss_10.2.5,pci_dss_8.7,gpg13_7.1,gpg13_7.2,</group>
+      <group>pci_dss_10.2.5,pci_dss_8.7,gpg13_7.1,gpg13_7.2,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
     </rule>
 
     <rule id="88003" level="9">
@@ -50,7 +50,7 @@ logcollector must be configured with the following labels
       <field name="audit_record.name">^Connect$</field>
       <field name="audit_record.status">^1</field>
       <description>Percona audit: authentication failure.</description>
-      <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_8.7,gpg13_7.1,</group>
+      <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_8.7,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
     </rule>
 
     <rule id="88004" level="3">
@@ -58,7 +58,7 @@ logcollector must be configured with the following labels
       <field name="audit_record.name">^Query$</field>
       <field name="audit_record.status">^0$</field>
       <description>Percona audit success: $(audit_record.command_class) statement.</description>
-      <group>pci_dss_8.7,gpg13_7.1</group>
+      <group>pci_dss_8.7,gpg13_7.1,gdpr_IV_35.7.d,</group>
     </rule>
 
     <rule id="88005" level="5">
@@ -66,7 +66,7 @@ logcollector must be configured with the following labels
       <field name="audit_record.name">^Query$</field>
       <field name="audit_record.command_class">^drop|^alter|^insert|^update|^grant|^delete</field>
       <description>Percona audit success: $(audit_record.command_class) statement.</description>
-      <group>pci_dss_8.7,gpg13_7.1</group>
+      <group>pci_dss_8.7,gpg13_7.1,gdpr_IV_35.7.d,</group>
     </rule>
 
     <rule id="88006" level="3">
@@ -74,7 +74,7 @@ logcollector must be configured with the following labels
       <field name="audit_record.name">^Query$</field>
       <field name="audit_record.status">^1</field>
       <description>Percona audit failed: $(audit_record.command_class) statement.</description>
-      <group>pci_dss_8.7,gpg13_7.1</group>
+      <group>pci_dss_8.7,gpg13_7.1,gdpr_IV_35.7.d,</group>
     </rule>
 
     <rule id="88007" level="5">
@@ -82,7 +82,7 @@ logcollector must be configured with the following labels
       <field name="audit_record.name">^Query$</field>
       <field name="audit_record.command_class">^drop|^alter|^insert|^update|^grant|^delete</field>
       <description>Percona audit failed: $(audit_record.command_class) statement.</description>
-      <group>pci_dss_8.7,gpg13_7.1</group>
+      <group>pci_dss_8.7,gpg13_7.1,gdpr_IV_35.7.d,</group>
     </rule>
 
     <rule id="89050" level="0">
@@ -95,49 +95,49 @@ logcollector must be configured with the following labels
       <if_sid>89050</if_sid>
       <field name="cmd">^Connect$</field>
       <description>McAfee MySQL audit: authentication attempt.</description>
-      <group>pci_dss_10.2.5,pci_dss_8.7,gpg13_7.1,gpg13_7.2,</group>
+      <group>pci_dss_10.2.5,pci_dss_8.7,gpg13_7.1,gpg13_7.2,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
     </rule>
 
     <rule id="89052" level="3">
       <if_sid>89050</if_sid>
       <field name="cmd">^Quit$</field>
       <description>McAfee MySQL audit: user logout.</description>
-      <group>pci_dss_10.2.5,pci_dss_8.7,gpg13_7.1,gpg13_7.2,</group>
+      <group>pci_dss_10.2.5,pci_dss_8.7,gpg13_7.1,gpg13_7.2,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
     </rule>
 
     <rule id="89053" level="9">
       <if_sid>89050</if_sid>
       <field name="cmd">^Failed Login$</field>
       <description>McAfee MySQL audit: authentication failure.</description>
-      <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_8.7,gpg13_7.1,</group>
+      <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_8.7,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
     </rule>
 
     <rule id="89054" level="3">
       <if_sid>89050</if_sid>
       <status>^0$</status>
       <description>McAfee MySQL audit success: $(cmd) statement.</description>
-      <group>pci_dss_8.7,gpg13_7.1</group>
+      <group>pci_dss_8.7,gpg13_7.1,gdpr_IV_35.7.d,</group>
     </rule>
 
     <rule id="89055" level="5">
       <if_sid>89054</if_sid>
       <field name="cmd">^drop|^alter|^insert|^update|^grant|^delete</field>
       <description>McAfee MySQL audit success: $(cmd) statement.</description>
-      <group>pci_dss_8.7,gpg13_7.1</group>
+      <group>pci_dss_8.7,gpg13_7.1,gdpr_IV_35.7.d,</group>
     </rule>
 
     <rule id="89056" level="3">
       <if_sid>89050</if_sid>
       <status>^1</status>
       <description>McAfee MySQL audit failed: $(cmd) statement.</description>
-      <group>pci_dss_8.7,gpg13_7.1</group>
+      <group>pci_dss_8.7,gpg13_7.1,gdpr_IV_35.7.d,</group>
     </rule>
 
     <rule id="89057" level="5">
       <if_sid>89056</if_sid>
       <field name="cmd">^drop|^alter|^insert|^update|^grant|^delete</field>
       <description>McAfee MySQL audit failed: $(cmd) statement.</description>
-      <group>pci_dss_8.7,gpg13_7.1</group>
+      <group>pci_dss_8.7,gpg13_7.1,gdpr_IV_35.7.d,</group>
     </rule>
 
 </group>

--- a/rules/0535-mariadb_rules.xml
+++ b/rules/0535-mariadb_rules.xml
@@ -18,6 +18,7 @@ ID: 87600--87700
     <if_sid>88100</if_sid>
     <field name="mariadb.type">[ERROR]</field>
     <description>MariaDB error message</description>
+    <group>gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="88102" level="3">

--- a/rules/0540-pfsense_rules.xml
+++ b/rules/0540-pfsense_rules.xml
@@ -1,0 +1,33 @@
+<!--
+  pfSense ruleset
+  Created by Wazuh, Inc. <support@wazuh.com>.
+  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2.
+  ID: 87700--87799
+-->
+
+<group name="pfsense,">
+  <rule id="87700" level="0">
+    <decoded_as>pf</decoded_as>
+    <program_name>filterlog</program_name>
+    <description>pfSense firewall rules grouped.</description>
+  </rule>
+
+  <!-- We don't log firewall events, because they go
+    -  to their own log file.
+    -->
+  <rule id="87701" level="5">
+    <if_sid>87700</if_sid>
+    <action>block</action>
+    <options>no_log</options>
+    <description>pfSense firewall drop event.</description>
+    <group>firewall_block,pci_dss_1.4,gpg13_4.12,</group>
+  </rule>
+
+  <rule id="87702" level="10" frequency="16" timeframe="45" ignore="240">
+    <if_matched_sid>87701</if_matched_sid>
+    <same_source_ip />
+    <description>Multiple pfSense firewall blocks events from same source.</description>
+    <group>multiple_blocks,pci_dss_1.4,pci_dss_10.6.1,gpg13_4.12,</group>
+  </rule>
+</group>
+

--- a/tools/amazon/getawslog.py
+++ b/tools/amazon/getawslog.py
@@ -119,6 +119,11 @@ def main(argv):
                             new_dict[key] = json_event[key]
                     new_dict['log_file'] = newFile
                     aws_log = {'aws': new_dict}
+                    # Copy 'aws.sourceIPAddress' and 'aws.userIdentity.userName' to standard fields 'srcip' and 'user' so 'srcip' can be used in Wazuh GeoIP lookups and <same_user /> and <same_source_ip /> can be used in composite rules.
+                    if 'sourceIPAddress' in aws_log["aws"]:
+                        aws_log["srcip"]=aws_log["aws"]["sourceIPAddress"]
+                    if 'userIdentity' in aws_log["aws"] and 'userName' in aws_log["aws"]["userIdentity"]:
+                        aws_log["user"]=aws_log["aws"]["userIdentity"]["userName"]
                     log.write("{0}\n".format(json.dumps(aws_log)))
             log.close()
 

--- a/update_ruleset
+++ b/update_ruleset
@@ -30,6 +30,7 @@ try:
     from urllib2 import urlopen, URLError, HTTPError
 except:
     from urllib.request import urlopen  # Python 3
+    from urllib.error import URLError, HTTPError
 
 
 class RulesetLogger:


### PR DESCRIPTION
We have revised the ruleset with the aim of updating the missing PCI groups in new rules and checking the old ones.

The added groups are as follows:

pci_dss_10.2.4
pci_dss_10.2.5
pci_dss_10.6.1
pci_dss_11.4
pci_dss_11.5