### PR TITLE
PCI Rules Review

### DIFF
--- a/rules/0015-ossec_rules.xml
+++ b/rules/0015-ossec_rules.xml
@@ -56,7 +56,7 @@
   <rule id="510" level="7">
     <if_sid>509</if_sid>
     <description>Host-based anomaly detection event (rootcheck).</description>
-    <group>rootcheck,gdpr_IV_35.7.d,</group>
+    <group>rootcheck,pci_dss_10.6.1,gdpr_IV_35.7.d,</group>
    <!-- <if_fts />  -->
   </rule>
 
@@ -80,7 +80,7 @@
     <if_sid>510</if_sid>
     <match>^Windows Malware</match>
     <description>Windows malware detected.</description>
-    <group>rootcheck,gpg13_4.2,gdpr_IV_35.7.d,</group>
+    <group>rootcheck,pci_dss_10.6.1,gpg13_4.2,gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="514" level="2">
@@ -111,14 +111,14 @@
     <if_sid>514</if_sid>
     <match>Adware|Spyware</match>
     <description>Windows Adware/Spyware application found.</description>
-    <group>rootcheck,gpg13_4.2,gdpr_IV_35.7.d,</group>
+    <group>rootcheck,pci_dss_10.6.1,gpg13_4.2,gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="519" level="7">
     <if_sid>516</if_sid>
     <match>^System Audit: Web vulnerability</match>
     <description>System Audit: Vulnerable web application found.</description>
-    <group>rootcheck,gdpr_IV_35.7.d,gdpr_IV_30.1.g,</group>
+    <group>rootcheck,pci_dss_10.6.1,gdpr_IV_35.7.d,gdpr_IV_30.1.g,</group>
   </rule>
 
   <rule id="520" level="3">

--- a/rules/0016-wazuh_rules.xml
+++ b/rules/0016-wazuh_rules.xml
@@ -22,21 +22,21 @@
     <if_sid>201</if_sid>
     <field name="level">%</field>
     <description>Agent event queue is $(level) full.</description>
-    <group>agent_flooding,gdpr_IV_35.7.d,</group>
+    <group>agent_flooding,pci_dss_10.6.1,gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="203" level="9">
     <if_sid>201</if_sid>
     <field name="level">full</field>
     <description>Agent event queue is full. Events may be lost.</description>
-    <group>agent_flooding,gdpr_IV_35.7.d,</group>
+    <group>agent_flooding,pci_dss_10.6.1,gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="204" level="12">
     <if_sid>201</if_sid>
     <field name="level">flooded</field>
     <description>Agent event queue is flooded. Check the agent configuration.</description>
-    <group>agent_flooding,gdpr_IV_35.7.d,</group>
+    <group>agent_flooding,pci_dss_10.6.1,gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="205" level="3">

--- a/rules/0020-syslog_rules.xml
+++ b/rules/0020-syslog_rules.xml
@@ -179,7 +179,7 @@
     <if_sid>2507</if_sid>
     <match>ACCEPT from</match>
     <description>OpenLDAP connection open.</description>
-    <group>gdpr_IV_32.2,</group>
+    <group>pci_dss_10.2.5,gdpr_IV_32.2,</group>
   </rule>
 
   <rule id="2509" level="5" timeframe="10" frequency="0">
@@ -740,14 +740,14 @@
     <decoded_as>gpasswd</decoded_as>
     <match>added by</match>
     <description>User added to group.</description>
-    <group>gpg13_7.9,gpg13_4.13,gdpr_IV_32.2,</group>
+    <group>pci_dss_10.2.5,gpg13_7.9,gpg13_4.13,gdpr_IV_32.2,</group>
   </rule>
 
   <rule id="2961" level="5">
     <if_sid>2960</if_sid>
     <field name="group">sudo</field>
     <description>User added to group sudo.</description>
-    <group>gpg13_7.9,gpg13_4.13,gdpr_IV_32.2,</group>
+    <group>pci_dss_10.2.5,gpg13_7.9,gpg13_4.13,gdpr_IV_32.2,</group>
   </rule>
 
 </group>

--- a/rules/0065-pix_rules.xml
+++ b/rules/0065-pix_rules.xml
@@ -102,21 +102,21 @@
     <if_sid>4310</if_sid>
     <id>^1-106021|^1-106022</id>
     <description>PIX: Attack in progress detected.</description>
-    <group>gdpr_IV_35.7.d,</group>
+    <group>pci_dss_11.4,gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="4331" level="8">
     <if_sid>4311</if_sid>
     <id>^2-106012|^2-106017|^2-106020</id>
     <description>PIX: Attack in progress detected.</description>
-    <group>gdpr_IV_35.7.d,</group>
+    <group>pci_dss_11.4,gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="4332" level="8">
     <if_sid>4313</if_sid>
     <id>^4-4000</id>
     <description>PIX: Attack in progress detected.</description>
-    <group>gdpr_IV_35.7.d,</group>
+    <group>pci_dss_11.4,gdpr_IV_35.7.d,</group>
   </rule>
 
   <!-- Grouping of attack in progress messages. The three above

--- a/rules/0090-telnetd_rules.xml
+++ b/rules/0090-telnetd_rules.xml
@@ -24,14 +24,14 @@
     <if_sid>5600</if_sid>
     <match>: connect from </match>
     <description>telnetd: Remote host established a telnet connection.</description>
-    <group>gdpr_IV_32.2,</group>
+    <group>pci_dss_10.2.5,gdpr_IV_32.2,</group>
   </rule>
 
   <rule id="5603" level="5" timeframe="1">
     <match>ttloop:  peer died:|ttloop:  read:</match>
     <if_matched_sid>5602</if_matched_sid>
     <description>telnetd: Remote host invalid connection.</description>
-    <group>gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
+    <group>pci_dss_10.2.4,pci_dss_10.2.5,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
   </rule>
 
   <rule id="5604" level="5">
@@ -45,7 +45,7 @@
     <same_source_ip />
     <description>telnetd: Multiple connection attempts from same source </description>
     <description>(possible scan).</description>
-    <group>gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
+    <group>pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
   </rule>
 
 </group>

--- a/rules/0220-msauth_rules.xml
+++ b/rules/0220-msauth_rules.xml
@@ -964,7 +964,7 @@
       <match>chromoting</match>
       <regex>: chromoting: \.* Access denied for client: </regex>
       <description>Chrome Remote Desktop attempt - access denied</description>
-      <group>gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
+      <group>pci_dss_10.2.4,pci_dss_10.2.5,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
   </rule>
 
   <rule id="18159" level="5">
@@ -972,7 +972,7 @@
       <match>chromoting</match>
       <regex>: chromoting: \.* Client connected:</regex>
       <description>Chrome Remote Desktop attempt - connected</description>
-      <group>gdpr_IV_32.2,</group>
+      <group>pci_dss_10.2.5,gdpr_IV_32.2,</group>
   </rule>
 
   <rule id="18160" level="5">
@@ -980,7 +980,7 @@
       <match>chromoting</match>
       <regex>: chromoting: \.* Client disconnected:</regex>
       <description>Chrome Remote Desktop attempt - disconnected</description>
-      <group>gdpr_IV_32.2,</group>
+      <group>pci_dss_10.2.5,gdpr_IV_32.2,</group>
   </rule>
 
 </group>

--- a/rules/0230-ms-se_rules.xml
+++ b/rules/0230-ms-se_rules.xml
@@ -114,13 +114,13 @@
 
   <rule id="7750" level="10" frequency="6" timeframe="240">
     <if_matched_sid>7711</if_matched_sid>
-    <group>gdpr_IV_35.7.d,</group>
+    <group>pci_dss_5.1,pci_dss_5.2,pci_dss_10.6.1,pci_dss_11.4,gdpr_IV_35.7.d,</group>
     <description>Multiple Microsoft Security Essentials AV warnings detected.</description>
   </rule>
 
   <rule id="7751" level="10" frequency="6" timeframe="240">
     <if_matched_sid>7712</if_matched_sid>
-    <group>gdpr_IV_35.7.d,</group>
+    <group>pci_dss_5.1,pci_dss_5.2,pci_dss_10.6.1,pci_dss_11.4,gdpr_IV_35.7.d,</group>
     <description>Multiple Microsoft Security Essentials AV warnings detected.</description>
   </rule>
 </group>

--- a/rules/0240-ids_rules.xml
+++ b/rules/0240-ids_rules.xml
@@ -86,7 +86,7 @@
     <ignore>srcip, id</ignore>
     <description>Multiple IDS events from same source ip </description>
     <description>(ignoring now this srcip and id).</description>
-    <group>gdpr_IV_35.7.d,</group>
+    <group>pci_dss_10.6.1,pci_dss_11.4,gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="20162" level="11" frequency="3" timeframe="3800">
@@ -95,6 +95,6 @@
     <ignore>id</ignore>
     <description>Multiple IDS alerts for same id </description>
     <description>(ignoring now this id).</description>
-    <group>gdpr_IV_35.7.d,</group>
+    <group>pci_dss_10.6.1,pci_dss_11.4,gdpr_IV_35.7.d,</group>
   </rule>
 </group>

--- a/rules/0275-squid_rules.xml
+++ b/rules/0275-squid_rules.xml
@@ -186,7 +186,7 @@
     <same_source_ip />
     <different_url />
     <description>Squid: Multiple 400 error codes (requests failed).</description>
-    <group>gdpr_IV_35.7.d,</group>
+    <group>pci_dss_10.6.1,gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="35058" level="10" frequency="$SQUID_FREQ" timeframe="240">
@@ -194,7 +194,7 @@
     <same_source_ip />
     <different_url />
     <description>Squid: Multiple 500/600 error codes (server error).</description>
-    <group>gdpr_IV_35.7.d,</group>
+    <group>pci_dss_10.6.1,gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="35095" level="0" frequency="2" timeframe="360">

--- a/rules/0340-puppet_rules.xml
+++ b/rules/0340-puppet_rules.xml
@@ -58,7 +58,7 @@
         <if_sid>80000</if_sid>
         <match>^Permission denied </match>
         <description>Puppet Master: Permission denied</description>
-        <group>gpg13_4.14,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
+        <group>pci_dss_10.2.4,pci_dss_10.2.5,gpg13_4.14,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
     </rule>
 
     <!--

--- a/rules/0360-serv-u_rules.xml
+++ b/rules/0360-serv-u_rules.xml
@@ -169,7 +169,7 @@ TypeMessage:
         <action>10</action>
         <match>Sent file</match>
         <description>Serv-U: File downloaded</description>
-        <group>gdpr_II_5.1.f,</group>
+        <group>pci_dss_11.5,gdpr_II_5.1.f,</group>
     </rule>
 
     <rule id="80512" level="0">
@@ -177,7 +177,7 @@ TypeMessage:
         <action>11</action>
         <match>Received file</match>
         <description>Serv-U: File uploaded</description>
-        <group>gdpr_II_5.1.f,</group>
+        <group>pci_dss_11.5,gdpr_II_5.1.f,</group>
     </rule>
 
     <rule id="80513" level="3">
@@ -185,7 +185,7 @@ TypeMessage:
         <action>12</action>
         <match>File deleted</match>
         <description>Serv-U: File deleted</description>
-        <group>gdpr_II_5.1.f,</group>
+        <group>pci_dss_11.5,gdpr_II_5.1.f,</group>
     </rule>
 
     <rule id="80514" level="0">
@@ -193,7 +193,7 @@ TypeMessage:
         <action>13</action>
         <match>Renamed</match>
         <description>Serv-U: File/Directory renamed</description>
-        <group>gdpr_II_5.1.f,</group>
+        <group>pci_dss_11.5,gdpr_II_5.1.f,</group>
     </rule>
 
     <rule id="80515" level="0">
@@ -201,7 +201,7 @@ TypeMessage:
         <action>14</action>
         <match>Directory created</match>
         <description>Serv-U: Directory created</description>
-        <group>gdpr_II_5.1.f,</group>
+        <group>pci_dss_11.5,gdpr_II_5.1.f,</group>
     </rule>
 
     <rule id="80516" level="3">
@@ -209,7 +209,7 @@ TypeMessage:
         <action>15</action>
         <match>Directory deleted</match>
         <description>Serv-U: Directory deleted</description>
-        <group>gdpr_II_5.1.f,</group>
+        <group>pci_dss_11.5,gdpr_II_5.1.f,</group>
     </rule>
 
 

--- a/rules/0425-cisco-estreamer_rules.xml
+++ b/rules/0425-cisco-estreamer_rules.xml
@@ -50,7 +50,7 @@
         <id>APP-DETECT</id>
         <match>DNS request for potential malware</match>
         <description>Cisco eStreamer: APP-DETECT DNS request for potential malware</description>
-        <group>gdpr_IV_35.7.d,</group>
+        <group>pci_dss_10.6.1,gdpr_IV_35.7.d,</group>
     </rule>
 
 </group>

--- a/rules/0430-ms_wdefender_rules.xml
+++ b/rules/0430-ms_wdefender_rules.xml
@@ -21,7 +21,7 @@
         <if_sid>83000</if_sid>
         <id>1116</id>
         <description>Windows Defender: detected potentially unwanted software</description>
-        <group>gdpr_IV_35.7.d,</group>
+        <group>pci_dss_10.6.1,gdpr_IV_35.7.d,</group>
     </rule>
 
     <!--
@@ -31,7 +31,7 @@
         <if_sid>83000</if_sid>
         <id>1117</id>
         <description>Windows Defender: error when taking action on potentially unwanted software</description>
-        <group>gdpr_IV_35.7.d,</group>
+        <group>pci_dss_10.6.1,gdpr_IV_35.7.d,</group>
     </rule>
 
 </group>

--- a/rules/0450-mongodb_rules.xml
+++ b/rules/0450-mongodb_rules.xml
@@ -129,7 +129,7 @@ D	Debug, for All Verbosity Levels > 0
         <field name="mongodb.component">ACCESS</field>
         <regex>Unauthorized not authorized on \S+ to execute command</regex>
         <description>MongoDB: Execute commands without the necessary privileges</description>
-        <group>gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
+        <group>pci_dss_10.2.5,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
     </rule>
 
 </group>

--- a/rules/0455-docker_rules.xml
+++ b/rules/0455-docker_rules.xml
@@ -61,7 +61,7 @@
         <if_sid>86003</if_sid>
         <match>unauthorized</match>
         <description>Docker: Error - unauthorized action</description>
-        <group>docker-error,gdpr_IV_35.7.d,</group>
+        <group>docker-error,pci_dss_10.2.4,pci_dss_10.2.5,gdpr_IV_35.7.d,</group>
     </rule>
 
     <!--
@@ -73,7 +73,7 @@
         <if_sid>86003</if_sid>
         <match>denied: User</match>
         <description>Docker: Error - denied action</description>
-        <group>docker-error,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
+        <group>docker-error,pci_dss_10.2.5,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
     </rule>
 
 </group>

--- a/rules/0470-vshell_rules.xml
+++ b/rules/0470-vshell_rules.xml
@@ -16,21 +16,21 @@
     <if_sid>86800</if_sid>
     <match>Connection accepted from</match>
     <description>VShell connection attempt successful</description>
-    <group>gdpr_IV_32.2,</group>
+    <group>pci_dss_10.2.5,gdpr_IV_32.2,</group>
   </rule>
 
   <rule id="86802" level="5">
     <if_sid>86800</if_sid>
     <regex>Login failed|Authentication for (\w+) failed</regex>
     <description>VShell user failed to login or user does not exist</description>
-    <group>gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
+    <group>pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
   </rule>
 
   <rule id="86803" level="7">
     <if_sid>86802</if_sid>
     <regex>Maximum authentication retries for user (\w+) exceeded</regex>
     <description>VShell user used the maximum number of password attempts.</description>
-    <group>gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
+    <group>pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
   </rule>
 
   <rule id="86804" level="10">
@@ -44,18 +44,18 @@
     <if_sid>86800</if_sid>
     <regex>password for user (\S+) accepted</regex>
     <description>VShell user successfully authenticated.</description>
-    <group>gpg13_7.1,gpg13_7.2,gdpr_IV_32.2,</group>
+    <group>pci_dss_10.2.5,gpg13_7.1,gpg13_7.2,gdpr_IV_32.2,</group>
   </rule>
 
   <rule id="86806" level="12" frequency="5" timeframe="120">
     <if_matched_sid>86804</if_matched_sid>
     <description>VShell multiple connection attempts within 2 minute by a host in the deny file, potential DOS or brute force attempt.</description>
-    <group>gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
+    <group>pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
   </rule>
 
   <rule id="86807" level="12" frequency="5" timeframe="60">
     <if_matched_sid>86802</if_matched_sid>
     <description>VShell host has exceeded the number of failed login attempts and has been added to the Hosts Deny file.</description>
-    <group>gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
+    <group>pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
   </rule>
 </group>

--- a/rules/0480-qualysguard_rules.xml
+++ b/rules/0480-qualysguard_rules.xml
@@ -19,7 +19,7 @@
        <if_sid>86900</if_sid>
        <field name="qualysguard.severity">^Potential Vulnerability - level 3</field>
        <description>Qualysguard: $(qualysguard.vulnerability_title).</description>
-       <group>gdpr_IV_35.7.d,</group>
+       <group>pci_dss_10.6.1,gdpr_IV_35.7.d,</group>
     </rule>
 
     <!-- 
@@ -29,7 +29,7 @@
        <if_sid>86900</if_sid>
        <field name="qualysguard.severity">^Vulnerability - level 3</field>
        <description>Qualysguard: $(qualysguard.vulnerability_title).</description>
-       <group>gdpr_IV_35.7.d,</group>
+       <group>pci_dss_10.6.1,gdpr_IV_35.7.d,</group>
     </rule>
 
     <!-- Level 4 Rules -->
@@ -40,7 +40,7 @@
        <if_sid>86900</if_sid>
        <field name="qualysguard.severity">^Potential Vulnerability - level 4</field>
        <description>Qualysguard: $(qualysguard.vulnerability_title).</description>
-       <group>gdpr_IV_35.7.d,</group>
+       <group>pci_dss_10.6.1,gdpr_IV_35.7.d,</group>
     </rule>
 
     <!-- 
@@ -50,7 +50,7 @@
        <if_sid>86900</if_sid>
        <field name="qualysguard.severity">^Vulnerability - level 4</field>
        <description>Qualysguard: $(qualysguard.vulnerability_title).</description>
-       <group>gdpr_IV_35.7.d,</group>
+       <group>pci_dss_10.6.1,gdpr_IV_35.7.d,</group>
     </rule>
 
     <!-- Level 5 Rules -->
@@ -61,7 +61,7 @@
        <if_sid>86900</if_sid>
        <field name="qualysguard.severity">^Potential Vulnerability - level 5</field>
        <description>Qualysguard: $(qualysguard.vulnerability_title).</description>
-       <group>gdpr_IV_35.7.d,</group>
+       <group>pci_dss_10.6.1,gdpr_IV_35.7.d,</group>
     </rule>
 
     <!-- 
@@ -71,6 +71,6 @@
        <if_sid>86900</if_sid>
        <field name="qualysguard.severity">^Vulnerability - level 5</field>
        <description>Qualysguard: $(qualysguard.vulnerability_title).</description>
-       <group>gdpr_IV_35.7.d,</group>
+       <group>pci_dss_10.6.1,gdpr_IV_35.7.d,</group>
     </rule>
 </group>

--- a/rules/0485-cylance_rules.xml
+++ b/rules/0485-cylance_rules.xml
@@ -21,7 +21,7 @@
         <if_sid>87000</if_sid>
         <field name="cylance_events.eventstatus">unsafe</field>
         <description>Cylance: File $(cylance_events.filepath) is unsafe.</description>
-        <group>gdpr_IV_35.7.d,</group>
+        <group>pci_dss_10.6.1,gdpr_IV_35.7.d,</group>
     </rule>
 
     <!-- 
@@ -102,6 +102,6 @@
     	<if_sid>87050</if_sid>
     	<field name="cylance_threats.file_status">unsafe</field>
     	<description>Cylance Threat: File $(cylance_threats.file_path) is unsafe</description>
-        <group>gdpr_IV_35.7.d,</group>
+        <group>pci_dss_10.6.1,gdpr_IV_35.7.d,</group>
     </rule> 
 </group>

--- a/rules/0490-virustotal_rules.xml
+++ b/rules/0490-virustotal_rules.xml
@@ -44,7 +44,7 @@
         <if_sid>87100</if_sid>
         <field name="virustotal.malicious">1</field>
         <description>VirusTotal: Alert - $(virustotal.source.file) - $(virustotal.positives) engines detected this file</description>
-        <group>gdpr_IV_35.7.d,</group>
+        <group>pci_dss_10.6.1,pci_dss_11.4,gdpr_IV_35.7.d,</group>
     </rule>
  
 </group>

--- a/rules/0505-vuls_rules.xml
+++ b/rules/0505-vuls_rules.xml
@@ -41,28 +41,28 @@
       <if_sid>22403</if_sid>
       <field name="vuls.score">^4|^5|^6</field>
       <description>Medium vulnerability $(vuls.scanned_cve) detected in scanning launched on $(vuls.scan_date) with $(vuls.assurance) reliability ($(vuls.detection_method)). $(vuls.tittle). Score: $(vuls.score) ($(vuls.source)). Affected packages: $(vuls.affected_packages)</description>
-      <group>gdpr_IV_35.7.d,</group>
+      <group>pci_dss_10.6.1,gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="22405" level="10">
       <if_sid>22403</if_sid>
       <field name="vuls.score">^7|^8</field>
       <description>High vulnerability $(vuls.scanned_cve) detected in scanning launched on $(vuls.scan_date) with $(vuls.assurance) reliability ($(vuls.detection_method)). $(vuls.tittle). Score: $(vuls.score) ($(vuls.source)). Affected packages: $(vuls.affected_packages)</description>
-      <group>gdpr_IV_35.7.d,</group>
+      <group>pci_dss_10.6.1,gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="22406" level="13">
       <if_sid>22403</if_sid>
       <field name="vuls.score">^9|^10</field>
       <description>Critical vulnerability $(vuls.scanned_cve) detected in scanning launched on $(vuls.scan_date) with $(vuls.assurance) reliability ($(vuls.detection_method)). $(vuls.tittle). Score: $(vuls.score) ($(vuls.source)). Affected packages: $(vuls.affected_packages)</description>
-      <group>gdpr_IV_35.7.d,</group>
+      <group>pci_dss_10.6.1,gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="22407" level="7">
       <if_sid>22401</if_sid>
       <field name="vuls.affected_packages">kernel</field>
       <description>Vulnerability $(vuls.scanned_cve) affects critical parts of the system.</description>
-      <group>gdpr_IV_35.7.d,</group>
+      <group>pci_dss_10.6.1,gdpr_IV_35.7.d,</group>
   </rule>
 
 </group>

--- a/rules/0510-ciscat_rules.xml
+++ b/rules/0510-ciscat_rules.xml
@@ -179,28 +179,28 @@
     <if_sid>87401</if_sid>
     <field name="cis.score">^4\d|^3\d</field>
     <description>CIS-CAT Report overview: Score less than 50% ($(cis.score))</description>
-    <group>gdpr_IV_35.7.d,</group>
+    <group>pci_dss_10.6.1,gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="87424" level="7">
     <if_sid>87402</if_sid>
     <field name="cis-data.score">^4\d|^3\d</field>
     <description>CIS-CAT Report overview: Score less than 50% ($(cis-data.score) %)</description>
-    <group>gdpr_IV_35.7.d,</group>
+    <group>pci_dss_10.6.1,gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="87425" level="9">
     <if_sid>87401</if_sid>
     <field name="cis.score">^2\d|^1\d|^\d$</field>
     <description>CIS-CAT Report overview: Score less than 30% ($(cis.score))</description>
-    <group>gdpr_IV_35.7.d,</group>
+    <group>pci_dss_10.6.1,gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="87426" level="9">
     <if_sid>87402</if_sid>
     <field name="cis-data.score">^2\d|^1\d|^\d$</field>
     <description>CIS-CAT Report overview: Score less than 30% ($(cis-data.score) %)</description>
-    <group>gdpr_IV_35.7.d,</group>
+    <group>pci_dss_10.6.1,gdpr_IV_35.7.d,</group>
   </rule>
 
 </group>

--- a/rules/0515-exim_rules.xml
+++ b/rules/0515-exim_rules.xml
@@ -23,14 +23,14 @@
       <if_sid>87501</if_sid>
       <match>authenticator failed</match>
       <description>Exim Auth failed</description>
-      <group>invalid_login,authentication_failed,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
+      <group>invalid_login,authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
     </rule>
 
     <rule id="87507" level="10" frequency="6" timeframe="240">
       <if_matched_sid>87506</if_matched_sid>
       <same_source_ip />
       <description>Exim brute force attack (multiple auth failures).</description>
-      <group>authentication_failures,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
+      <group>authentication_failures,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
     </rule>
 
     <rule id="87508" level="0">

--- a/rules/0520-vulnerability-detector.xml
+++ b/rules/0520-vulnerability-detector.xml
@@ -31,7 +31,7 @@
       <options>no_full_log</options>
       <field name="vulnerability.severity">Medium|Moderate</field>
       <description>$(vulnerability.title)</description>
-      <group>gdpr_IV_35.7.d,</group>
+      <group>pci_dss_10.6.1,gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="23505" level="10">
@@ -39,7 +39,7 @@
       <options>no_full_log</options>
       <field name="vulnerability.severity">High|Important </field>
       <description>$(vulnerability.title)</description>
-      <group>gdpr_IV_35.7.d,</group>
+      <group>pci_dss_10.6.1,gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="23506" level="13">
@@ -47,6 +47,6 @@
       <options>no_full_log</options>
       <field name="vulnerability.severity">Critical</field>
       <description>$(vulnerability.title)</description>
-      <group>gdpr_IV_35.7.d,</group>
+      <group>pci_dss_10.6.1,gdpr_IV_35.7.d,</group>
   </rule>
 </group>


### PR DESCRIPTION
We have revised the ruleset with the aim of updating the missing PCI groups in new rules and checking the old ones.

The added groups are as follows:

pci_dss_10.2.4
pci_dss_10.2.5
pci_dss_10.6.1
pci_dss_11.4
pci_dss_11.5