### PR TITLE
Allow for srccountry in FortiGate UTM IPS events

### DIFF
--- a/decoders/0100-fortigate_decoders.xml
+++ b/decoders/0100-fortigate_decoders.xml
@@ -64,7 +64,7 @@ date=2016-06-15 time=09:41:35 devname=Device_Name devid=FGTXXXX9999999999 logid=
 <decoder name="fortigate-firewall-v5-utm-ips">
     <parent>fortigate-firewall-v5</parent>
     <prematch offset="after_parent">type=utm subtype=ips</prematch>
-    <regex offset="after_prematch">severity=(\S+) srcip=(\S+) dstip=(\S+) \.*action=(\S+) proto\.+srcport=(\d+) dstport=(\d+) \.*msg=(\.*)</regex>
+    <regex offset="after_prematch">severity=(\S+) srcip=(\S+) \.*dstip=(\S+) \.*action=(\S+) proto\.+srcport=(\d+) dstport=(\d+) \.*msg=(\.*)</regex>
     <order>status,srcip,dstip,action,srcport,dstport,extra_data</order>
 </decoder>
 


### PR DESCRIPTION
Never versions of FortiGate's now log srccountry after srcip. Example log:

date=2018-05-21 time=09:15:21 devname=fw1 devid=FG200D1112223334 logid=000000001 type=utm subtype=ips eventtype=signature level=alert vd=root severity=critical srcip=10.0.0.1 dstip=10.0.0.2 srcintf="in" dstintf="out" policyid=100 sessionid=100000001 action=dropped proto=6 service="SMB" attack="MS.WinVerifyTrust.Signature.Validation.Remote.Code.Execution" srcport=445 dstport=52726 direction=incoming attackid=31536 profile="Windows-Server" ref="http://www.fortinet.com/ids/VID31536" incidentserialno=000000001 msg="applications3: MS.WinVerifyTrust.Signature.Validation.Remote.Code.Execution," crscore=50 crlevel=critical