### PR TITLE
Upgraded Cisco IOS decoders

### DIFF
--- a/decoders/0065-cisco-ios_decoders.xml
+++ b/decoders/0065-cisco-ios_decoders.xml
@@ -43,11 +43,11 @@
 </decoder>
 
 <!--
-  - Date and hour (preceded by * or nothing) with ms and timezone, no sequence number
+  - Date and hour (preceded by * or nothing) with ms and optional timezone, no sequence number
   - *Mar  1 18:48:50.483 UTC: %SYS-5-CONFIG_I: Configured from console by vty2 (10.34.195.36)
 -->
 <decoder name="cisco-ios">
-  <prematch>^\p*\w+\s+\d*\s+\d+:\d+:\d+.\d+\s+\w+:\s+%</prematch>
+  <prematch>^\p*\w+\s+\d*\s+\d+:\d+:\d+.\d+\s*\w*:\s+%</prematch>
 </decoder>
 
 


### PR DESCRIPTION
The timezone field is optional: Can be found or not.

With this modification, logs like these will be now decoded correctly:

`*May 24 09:31:58.694: %LINEPROTO-5-UPDOWN: Line protocol on Interface GigabitEthernet1/0/28, changed state to up`


```
**Phase 1: Completed pre-decoding.
       full event: '*May 24 09:31:58.694: %LINEPROTO-5-UPDOWN: Line protocol on Interface GigabitEthernet1/0/28, changed state to up'
       timestamp: '(null)'
       hostname: 'manager1'
       program_name: '(null)'
       log: '*May 24 09:31:58.694: %LINEPROTO-5-UPDOWN: Line protocol on Interface GigabitEthernet1/0/28, changed state to up'

**Phase 2: Completed decoding.
       decoder: 'cisco-ios'
       id: '%LINEPROTO-5-UPDOWN'

**Phase 3: Completed filtering (rules).
       Rule id: '4715'
       Level: '0'
       Description: 'Cisco IOS notification message.'
```

