### PR TITLE
Add rule to detect errors when unmerging files

### DIFF
--- a/rules/0016-wazuh_rules.xml
+++ b/rules/0016-wazuh_rules.xml
@@ -127,4 +127,11 @@
     <group>agent_restarting,configuration_failure,</group>
   </rule>
 
+  <rule id="222" level="7">
+    <if_sid>200</if_sid>
+    <match>^wazuh: Could not unmerge shared file.</match>
+    <description>The agent could not restart due to a error while unmerging files.</description>
+    <group>agent_restarting,configuration_failure,</group>
+  </rule>
+
 </group>


### PR DESCRIPTION
This PR adds the rule necessary for detecting when the agent is unable to unmerge the files received from the manager. It is related to the PR [#804](https://github.com/wazuh/wazuh/pull/804).