### PR TITLE
fix false positives on /etc/hosts caused by unescaped . character

### DIFF
--- a/rootchecks/rootkit_trojans.txt
+++ b/rootchecks/rootkit_trojans.txt
@@ -81,23 +81,23 @@ kill        !/dev/[ab,d-k,m-z]|/dev/[F-Z]|/dev/[A-D]|/dev/[0-9]|proc\.h|bash|tmp
 # http://blog.tenablesecurity.com/2006/12/detecting_compr.html
 # http://www.sophos.com/security/analyses/trojbagledll.html
 # http://www.f-secure.com/v-descs/fantibag_b.shtml
-/etc/hosts  !^[^#]*avp.ch!Anti-virus site on the hosts file
-/etc/hosts  !^[^#]*avp.ru!Anti-virus site on the hosts file
-/etc/hosts  !^[^#]*awaps.net! Anti-virus site on the hosts file
-/etc/hosts  !^[^#]*ca.com! Anti-virus site on the hosts file
-/etc/hosts  !^[^#]*mcafee.com! Anti-virus site on the hosts file
-/etc/hosts  !^[^#]*microsoft.com! Anti-virus site on the hosts file
-/etc/hosts  !^[^#]*f-secure.com! Anti-virus site on the hosts file
-/etc/hosts  !^[^#]*sophos.com! Anti-virus site on the hosts file
-/etc/hosts  !^[^#]*symantec.com! Anti-virus site on the hosts file
-/etc/hosts  !^[^#]*my-etrust.com! Anti-virus site on the hosts file
-/etc/hosts  !^[^#]*nai.com! Anti-virus site on the hosts file
-/etc/hosts  !^[^#]*networkassociates.com! Anti-virus site on the hosts file
-/etc/hosts  !^[^#]*viruslist.ru! Anti-virus site on the hosts file
+/etc/hosts  !^[^#]*avp\.ch!Anti-virus site on the hosts file
+/etc/hosts  !^[^#]*avp\.ru!Anti-virus site on the hosts file
+/etc/hosts  !^[^#]*awaps\.net! Anti-virus site on the hosts file
+/etc/hosts  !^[^#]*ca\.com! Anti-virus site on the hosts file
+/etc/hosts  !^[^#]*mcafee\.com! Anti-virus site on the hosts file
+/etc/hosts  !^[^#]*microsoft\.com! Anti-virus site on the hosts file
+/etc/hosts  !^[^#]*f-secure\.com! Anti-virus site on the hosts file
+/etc/hosts  !^[^#]*sophos\.com! Anti-virus site on the hosts file
+/etc/hosts  !^[^#]*symantec\.com! Anti-virus site on the hosts file
+/etc/hosts  !^[^#]*my-etrust\.com! Anti-virus site on the hosts file
+/etc/hosts  !^[^#]*nai\.com! Anti-virus site on the hosts file
+/etc/hosts  !^[^#]*networkassociates\.com! Anti-virus site on the hosts file
+/etc/hosts  !^[^#]*viruslist\.ru! Anti-virus site on the hosts file
 /etc/hosts  !^[^#]*kaspersky! Anti-virus site on the hosts file
-/etc/hosts  !^[^#]*symantecliveupdate.com! Anti-virus site on the hosts file
-/etc/hosts  !^[^#]*grisoft.com! Anti-virus site on the hosts file
-/etc/hosts  !^[^#]*clamav.net! Anti-virus site on the hosts file
-/etc/hosts  !^[^#]*bitdefender.com! Anti-virus site on the hosts file
-/etc/hosts  !^[^#]*antivirus.com! Anti-virus site on the hosts file
-/etc/hosts  !^[^#]*sans.org! Security site on the hosts file
+/etc/hosts  !^[^#]*symantecliveupdate\.com! Anti-virus site on the hosts file
+/etc/hosts  !^[^#]*grisoft\.com! Anti-virus site on the hosts file
+/etc/hosts  !^[^#]*clamav\.net! Anti-virus site on the hosts file
+/etc/hosts  !^[^#]*bitdefender\.com! Anti-virus site on the hosts file
+/etc/hosts  !^[^#]*antivirus\.com! Anti-virus site on the hosts file
+/etc/hosts  !^[^#]*sans\.org! Security site on the hosts file


### PR DESCRIPTION
The dot character in these regular expressions is matching any character instead of a literal dot, causing strings like "camcom" to match ^[^#]*ca.com resulting in a false positive. 

The fix is to escape the dot so it matches literal dot. I've tested this on my own systems and it seems to correctly match on "ca.com" and no longer match any string with a character between ca and com. 