### PR TITLE
Correct frequency offset in rules

### DIFF
--- a/rules/0020-syslog_rules.xml
+++ b/rules/0020-syslog_rules.xml
@@ -182,7 +182,7 @@
     <group>gdpr_IV_32.2,</group>
   </rule>
 
-  <rule id="2509" level="5" timeframe="10" frequency="0">
+  <rule id="2509" level="5" timeframe="10" frequency="2">
     <if_sid>2507</if_sid>
     <if_matched_sid>2508</if_matched_sid>
     <same_id />

--- a/rules/0025-sendmail_rules.xml
+++ b/rules/0025-sendmail_rules.xml
@@ -78,7 +78,7 @@
     <group>system_error,gdpr_IV_35.7.d,</group>
   </rule>
 
-  <rule id="3151" level="10" frequency="6" timeframe="120">
+  <rule id="3151" level="10" frequency="8" timeframe="120">
     <if_matched_sid>3102</if_matched_sid>
     <same_source_ip />
     <description>sendmail: Sender domain has bogus MX record. </description>
@@ -86,7 +86,7 @@
     <group>multiple_spam,pci_dss_11.4,gdpr_IV_35.7.d,</group>
   </rule>
 
-  <rule id="3152" level="6" frequency="6" timeframe="120">
+  <rule id="3152" level="6" frequency="8" timeframe="120">
     <if_matched_sid>3103</if_matched_sid>
     <same_source_ip />
     <description>sendmail: Multiple attempts to send e-mail from a </description>
@@ -94,14 +94,14 @@
     <group>multiple_spam,pci_dss_11.4,gdpr_IV_35.7.d,</group>
   </rule>
 
-  <rule id="3153" level="6" frequency="6" timeframe="120">
+  <rule id="3153" level="6" frequency="8" timeframe="120">
     <if_matched_sid>3104</if_matched_sid>
     <same_source_ip />
     <description>sendmail: Multiple relaying attempts of spam.</description>
     <group>multiple_spam,pci_dss_11.4,gdpr_IV_35.7.d,</group>
   </rule>
 
-  <rule id="3154" level="10" frequency="6" timeframe="120">
+  <rule id="3154" level="10" frequency="8" timeframe="120">
     <if_matched_sid>3105</if_matched_sid>
     <same_source_ip />
     <description>sendmail: Multiple attempts to send e-mail </description>
@@ -109,7 +109,7 @@
     <group>multiple_spam,pci_dss_11.4,gdpr_IV_35.7.d,</group>
   </rule>
 
-  <rule id="3155" level="10" frequency="6" timeframe="120">
+  <rule id="3155" level="10" frequency="8" timeframe="120">
     <if_matched_sid>3106</if_matched_sid>
     <same_source_ip />
     <description>sendmail: Multiple attempts to send e-mail from </description>
@@ -117,14 +117,14 @@
     <group>multiple_spam,pci_dss_11.4,gdpr_IV_35.7.d,</group>
   </rule>
 
-  <rule id="3156" level="10" frequency="10" timeframe="120">
+  <rule id="3156" level="10" frequency="12" timeframe="120">
     <if_matched_sid>3107</if_matched_sid>
     <same_source_ip />
     <description>sendmail: Multiple rejected e-mails from same source ip.</description>
     <group>multiple_spam,pci_dss_11.4,gdpr_IV_35.7.d,</group>
   </rule>
 
-  <rule id="3158" level="10" frequency="6" timeframe="120">
+  <rule id="3158" level="10" frequency="8" timeframe="120">
     <if_matched_sid>3108</if_matched_sid>
     <same_source_ip />
     <description>sendmail: Multiple pre-greetings rejects.</description>

--- a/rules/0030-postfix_rules.xml
+++ b/rules/0030-postfix_rules.xml
@@ -7,7 +7,7 @@
   -  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2.
 -->
 
-<var name="POSTFIX_FREQ">6</var>
+<var name="POSTFIX_FREQ">8</var>
 
 <group name="syslog,postfix,">
   <rule id="3300" level="0">
@@ -157,7 +157,7 @@
     <group>multiple_spam,pci_dss_10.6.1,pci_dss_11.4,gdpr_IV_35.7.d,</group>
   </rule>
 
-  <rule id="3357" level="10" frequency="6" timeframe="120" ignore="60">
+  <rule id="3357" level="10" frequency="8" timeframe="120" ignore="60">
     <if_matched_sid>3332</if_matched_sid>
     <same_source_ip />
     <description>Postfix: Multiple SASL authentication failures.</description>

--- a/rules/0040-imapd_rules.xml
+++ b/rules/0040-imapd_rules.xml
@@ -6,7 +6,7 @@
   -  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2.
 -->
 
-<var name="IMAPD_FREQ">6</var>
+<var name="IMAPD_FREQ">8</var>
 
 <group name="syslog,imapd,">
   <rule id="3600" level="0" noalert="1">

--- a/rules/0045-mailscanner_rules.xml
+++ b/rules/0045-mailscanner_rules.xml
@@ -25,7 +25,7 @@
     <group>spam,</group>
   </rule>
 
-  <rule id="3751" level="6" frequency="6" timeframe="180">
+  <rule id="3751" level="6" frequency="8" timeframe="180">
     <if_matched_sid>3702</if_matched_sid>
     <same_source_ip />
     <description>mailscanner: Multiple attempts of spam.</description>

--- a/rules/0050-ms-exchange_rules.xml
+++ b/rules/0050-ms-exchange_rules.xml
@@ -27,14 +27,14 @@
     <group>spam,</group>
   </rule>
 
-  <rule id="3851" level="9" frequency="10" timeframe="120" ignore="120">
+  <rule id="3851" level="9" frequency="12" timeframe="120" ignore="120">
     <if_matched_sid>3801</if_matched_sid>
     <same_source_ip />
     <description>ms-exchange: Multiple e-mail attempts to an invalid account.</description>
     <group>multiple_spam,pci_dss_10.6.1,gpg13_4.12,gdpr_IV_35.7.d,</group>
   </rule>
 
-  <rule id="3852" level="9" frequency="12" timeframe="120" ignore="240">
+  <rule id="3852" level="9" frequency="14" timeframe="120" ignore="240">
     <if_matched_sid>3802</if_matched_sid>
     <same_source_ip />
     <description>ms-exchange: Multiple e-mail 500 error code (spam).</description>

--- a/rules/0055-courier_rules.xml
+++ b/rules/0055-courier_rules.xml
@@ -40,14 +40,14 @@
     <group>authentication_success,pci_dss_10.2.5,gpg13_7.1,gpg13_7.2,gdpr_IV_32.2,</group>
   </rule>
 
-  <rule id="3910" level="10" frequency="10" timeframe="30">
+  <rule id="3910" level="10" frequency="12" timeframe="30">
     <if_matched_sid>3902</if_matched_sid>
     <description>Courier brute force (multiple failed logins).</description>
     <group>authentication_failures,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
     <same_source_ip />
   </rule>
 
-  <rule id="3911" level="10" frequency="15" timeframe="30">
+  <rule id="3911" level="10" frequency="17" timeframe="30">
     <if_matched_sid>3901</if_matched_sid>
     <same_source_ip />
     <description>Courier: Multiple connection attempts from same source.</description>

--- a/rules/0060-firewall_rules.xml
+++ b/rules/0060-firewall_rules.xml
@@ -23,7 +23,7 @@
     <group>firewall_drop,pci_dss_1.4,gpg13_4.12,gdpr_IV_35.7.d,</group>
   </rule>
 
-  <rule id="4151" level="10" frequency="16" timeframe="45" ignore="240">
+  <rule id="4151" level="10" frequency="18" timeframe="45" ignore="240">
     <if_matched_sid>4101</if_matched_sid>
     <same_source_ip />
     <description>Multiple Firewall drop events from same source.</description>

--- a/rules/0065-pix_rules.xml
+++ b/rules/0065-pix_rules.xml
@@ -191,38 +191,38 @@
     <group>adduser,account_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_4.13,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
   </rule>
 
-  <rule id="4380" level="10" frequency="6" timeframe="360">
+  <rule id="4380" level="10" frequency="8" timeframe="360">
     <if_matched_sid>4310</if_matched_sid>
     <description>Multiple PIX alert messages.</description>
     <group>pci_dss_10.6.1,pci_dss_11.4,gpg13_4.12,gdpr_IV_35.7.d,</group>
   </rule>
 
-  <rule id="4381" level="10" frequency="6" timeframe="360">
+  <rule id="4381" level="10" frequency="8" timeframe="360">
     <if_matched_sid>4311</if_matched_sid>
     <description>PIX: Multiple critical messages.</description>
     <group>pci_dss_10.6.1,pci_dss_11.4,gpg13_4.1,gdpr_IV_35.7.d,</group>
   </rule>
 
-  <rule id="4382" level="10" frequency="8" timeframe="120">
+  <rule id="4382" level="10" frequency="10" timeframe="120">
     <if_matched_sid>4312</if_matched_sid>
     <description>PIX: Multiple error messages.</description>
     <group>system_error,pci_dss_10.6.1,pci_dss_11.4,gpg13_4.3,gdpr_IV_35.7.d,</group>
   </rule>
 
-  <rule id="4383" level="10" frequency="8" timeframe="120">
+  <rule id="4383" level="10" frequency="10" timeframe="120">
     <if_matched_sid>4313</if_matched_sid>
     <description>PIX: Multiple warning messages.</description>
     <group>pci_dss_10.6.1,gpg13_4.12,gdpr_IV_35.7.d,</group>
   </rule>
 
-  <rule id="4385" level="10" frequency="8" timeframe="240" ignore="90">
+  <rule id="4385" level="10" frequency="10" timeframe="240" ignore="90">
     <if_matched_sid>4333</if_matched_sid>
     <same_source_ip />
     <description>PIX: Multiple attack in progress messages.</description>
     <group>pci_dss_10.6.1,pci_dss_11.4,gpg13_4.12,gdpr_IV_35.7.d,</group>
   </rule>
 
-  <rule id="4386" level="10" frequency="8" timeframe="240">
+  <rule id="4386" level="10" frequency="10" timeframe="240">
     <if_matched_sid>4334</if_matched_sid>
     <description>PIX: Multiple AAA (VPN) authentication failures.</description>
     <group>authentication_failures,pci_dss_11.4,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>

--- a/rules/0070-netscreenfw_rules.xml
+++ b/rules/0070-netscreenfw_rules.xml
@@ -79,7 +79,7 @@
     <group>config_changed,pci_dss_1.1.1,gpg13_4.12,gdpr_IV_35.7.d,</group>
   </rule>
 
-  <rule id="4550" level="10" frequency="4" timeframe="180" ignore="60">
+  <rule id="4550" level="10" frequency="6" timeframe="180" ignore="60">
     <if_matched_sid>4503</if_matched_sid>
     <same_source_ip />
     <description>Netscreen firewall: Multiple critical messages from </description>
@@ -87,12 +87,12 @@
     <group>pci_dss_1.4,pci_dss_10.6.1,pci_dss_11.4,gpg13_4.1,gdpr_IV_35.7.d,</group>
   </rule>
 
-  <rule id="4551" level="10" frequency="6" timeframe="180" ignore="60">
+  <rule id="4551" level="10" frequency="8" timeframe="180" ignore="60">
     <if_matched_sid>4503</if_matched_sid>
     <description>Netscreen firewall: Multiple critical messages.</description>
   </rule>
 
-  <rule id="4552" level="10" frequency="4" timeframe="180" ignore="60">
+  <rule id="4552" level="10" frequency="6" timeframe="180" ignore="60">
     <if_matched_sid>4513</if_matched_sid>
     <same_source_ip />
     <description>Netscreen firewall: Multiple alert messages from </description>
@@ -100,7 +100,7 @@
     <group>pci_dss_1.4,pci_dss_10.6.1,pci_dss_11.4,gpg13_4.12,gdpr_IV_35.7.d,</group>
   </rule>
 
-  <rule id="4553" level="10" frequency="8" timeframe="100" ignore="60">
+  <rule id="4553" level="10" frequency="10" timeframe="100" ignore="60">
     <if_matched_sid>4513</if_matched_sid>
     <description>Netscreen firewall: Multiple alert messages.</description>
   </rule>

--- a/rules/0080-sonicwall_rules.xml
+++ b/rules/0080-sonicwall_rules.xml
@@ -71,13 +71,13 @@
     <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_3.6,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
   </rule>
 
-  <rule id="4850" level="10" frequency="6" timeframe="120" ignore="60">
+  <rule id="4850" level="10" frequency="8" timeframe="120" ignore="60">
     <if_matched_sid>4804</if_matched_sid>
     <description>SonicWall: Multiple firewall warning messages.</description>
     <group>service_availability,pci_dss_10.6.1,gdpr_IV_35.7.d,</group>
   </rule>
 
-  <rule id="4851" level="10" frequency="6" timeframe="120" ignore="60">
+  <rule id="4851" level="10" frequency="8" timeframe="120" ignore="60">
     <if_matched_sid>4803</if_matched_sid>
     <description>SonicWall: Multiple firewall error messages.</description>
     <group>service_availability,pci_dss_10.6.1,gpg13_3.5,gdpr_IV_35.7.d,</group>

--- a/rules/0085-pam_rules.xml
+++ b/rules/0085-pam_rules.xml
@@ -61,7 +61,7 @@
     <description>PAM: Ignoring events with a user or a password.</description>
   </rule>
 
-  <rule id="5551" level="10" frequency="6" timeframe="180">
+  <rule id="5551" level="10" frequency="8" timeframe="180">
     <if_matched_sid>5503</if_matched_sid>
     <same_source_ip />
     <description>PAM: Multiple failed logins in a small period of time.</description>

--- a/rules/0090-telnetd_rules.xml
+++ b/rules/0090-telnetd_rules.xml
@@ -40,7 +40,7 @@
     <group>gdpr_IV_35.7.d,</group>
   </rule>
 
-  <rule id="5631" level="10" frequency="6" timeframe="120">
+  <rule id="5631" level="10" frequency="8" timeframe="120">
     <if_matched_sid>5602</if_matched_sid>
     <same_source_ip />
     <description>telnetd: Multiple connection attempts from same source </description>

--- a/rules/0095-sshd_rules.xml
+++ b/rules/0095-sshd_rules.xml
@@ -28,7 +28,7 @@
     <group>pci_dss_11.4,gpg13_4.12,gdpr_IV_35.7.d,</group>
   </rule>
 
-  <rule id="5703" level="10" frequency="4" timeframe="360">
+  <rule id="5703" level="10" frequency="6" timeframe="360">
     <if_matched_sid>5702</if_matched_sid>
     <description>sshd: Possible breakin attempt </description>
     <description>(high number of reverse lookup errors).</description>
@@ -41,7 +41,7 @@
     <description>sshd: Timeout while logging in.</description>
   </rule>
 
-  <rule id="5705" level="10" frequency="4" timeframe="360">
+  <rule id="5705" level="10" frequency="6" timeframe="360">
     <if_matched_sid>5704</if_matched_sid>
     <description>sshd: Possible scan or breakin attempt </description>
     <description>(high number of login timeouts).</description>
@@ -86,7 +86,7 @@
     <description>sshd: Useless/Duplicated SSHD message without a user/ip.</description>
   </rule>
 
-  <rule id="5712" level="10" frequency="6" timeframe="120" ignore="60">
+  <rule id="5712" level="10" frequency="8" timeframe="120" ignore="60">
     <if_matched_sid>5710</if_matched_sid>
     <description>sshd: brute force trying to get access to </description>
     <description>the system.</description>
@@ -100,7 +100,7 @@
     <description>sshd: Corrupted bytes on SSHD.</description>
   </rule>
 
-  <rule id="5714" level="14" timeframe="120" frequency="1">
+  <rule id="5714" level="14" timeframe="120" frequency="3">
     <if_matched_sid>5713</if_matched_sid>
     <match>Local: crc32 compensation attack</match>
     <description>sshd: SSH CRC-32 Compensation attack</description>
@@ -136,13 +136,13 @@
     <group>invalid_login,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
   </rule>
 
-  <rule id="5719" level="10" frequency="6" timeframe="120" ignore="60">
+  <rule id="5719" level="10" frequency="8" timeframe="120" ignore="60">
     <if_matched_sid>5718</if_matched_sid>
     <description>sshd: Multiple access attempts using a denied user.</description>
     <group>invalid_login,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
   </rule>
 
-  <rule id="5720" level="10" frequency="6">
+  <rule id="5720" level="10" frequency="8">
     <if_matched_sid>5716</if_matched_sid>
     <same_source_ip />
     <description>sshd: Multiple authentication failures.</description>

--- a/rules/0105-asterisk_rules.xml
+++ b/rules/0105-asterisk_rules.xml
@@ -54,21 +54,21 @@
     <group>invalid_login,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
   </rule>
 
-  <rule id="6250" level="10" frequency="6" timeframe="300">
+  <rule id="6250" level="10" frequency="8" timeframe="300">
     <if_matched_sid>6211</if_matched_sid>
     <same_source_ip />
     <description>Asterisk: Multiple failed logins (user enumeration in process).</description>
     <group>pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
   </rule>
 
-  <rule id="6251" level="10" frequency="6" timeframe="300">
+  <rule id="6251" level="10" frequency="8" timeframe="300">
     <if_matched_sid>6210</if_matched_sid>
     <same_source_ip />
     <description>Asterisk: Multiple failed logins.</description>
     <group>pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
   </rule>
 
-  <rule id="6252" level="10" frequency="6" timeframe="300">
+  <rule id="6252" level="10" frequency="8" timeframe="300">
     <if_matched_sid>6212</if_matched_sid>
     <same_source_ip />
     <description>Asterisk: Extension enumeration.</description>
@@ -85,7 +85,7 @@
   </rule>
 
   <!--From Javi Benito jabi.benito@gmail.com-->
-  <rule id="6254" level="10" frequency="3" timeframe="300">
+  <rule id="6254" level="10" frequency="5" timeframe="300">
     <if_matched_sid>6253</if_matched_sid>
     <same_source_ip />
     <description>Asterisk: Extension IAX Enumeration.</description>
@@ -109,7 +109,7 @@
   </rule>
 
   <!--From Javi Benito jabi.benito@gmail.com-->
-  <rule id="6257" level="10" frequency="3" timeframe="300">
+  <rule id="6257" level="10" frequency="5" timeframe="300">
     <if_matched_sid>6256</if_matched_sid>
     <same_source_ip />
     <description>Asterisk: Multiple failed logins.</description>

--- a/rules/0135-hordeimp_rules.xml
+++ b/rules/0135-hordeimp_rules.xml
@@ -52,14 +52,14 @@
     <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
   </rule>
 
-  <rule id="9351" level="10" frequency="6" timeframe="120">
+  <rule id="9351" level="10" frequency="8" timeframe="120">
     <if_matched_sid>9306</if_matched_sid>
     <same_source_ip />
     <description>Horde brute force (multiple failed logins).</description>
     <group>authentication_failures,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
   </rule>
 
-  <rule id="9352" level="10" frequency="4" timeframe="320">
+  <rule id="9352" level="10" frequency="6" timeframe="320">
     <if_matched_sid>9304</if_matched_sid>
     <description>Multiple Horde emergency messages.</description>
     <group>service_availability,pci_dss_10.6.1,gpg13_4.1,gdpr_IV_35.7.d,</group>

--- a/rules/0140-roundcube_rules.xml
+++ b/rules/0140-roundcube_rules.xml
@@ -27,7 +27,7 @@
     <group>authentication_success,pci_dss_10.2.5,gpg13_7.1,gpg13_7.2,gdpr_IV_32.2,</group>
   </rule>
 
-  <rule id="9403" level="10" frequency="6" timeframe="120">
+  <rule id="9403" level="10" frequency="8" timeframe="120">
     <if_matched_sid>9401</if_matched_sid>
     <same_source_ip />
     <description>Roundcube brute force (multiple failed logins).</description>

--- a/rules/0155-dovecot_rules.xml
+++ b/rules/0155-dovecot_rules.xml
@@ -62,14 +62,14 @@
 
 
 <!-- Composite rules -->
-<rule id="9750" level="10" frequency="6" timeframe="120">
+<rule id="9750" level="10" frequency="8" timeframe="120">
   <if_matched_sid>9702</if_matched_sid>
   <same_source_ip />
   <description>Dovecot Multiple Authentication Failures.</description>
   <group>authentication_failures,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
 </rule>
 
-<rule id="9751" level="10" frequency="6" timeframe="240">
+<rule id="9751" level="10" frequency="8" timeframe="240">
   <if_matched_sid>9705</if_matched_sid>
   <same_source_ip />
   <description>Dovecot brute force attack (multiple auth failures).</description>

--- a/rules/0160-vmpop3d_rules.xml
+++ b/rules/0160-vmpop3d_rules.xml
@@ -19,7 +19,7 @@
     <description>vm-pop3d: Login failed accessing the pop3 server.</description>
   </rule>
 
-  <rule id="9820" level="10" frequency="6" timeframe="240">
+  <rule id="9820" level="10" frequency="8" timeframe="240">
     <if_matched_sid>9801</if_matched_sid>
     <same_source_ip />
     <description>vm-pop3d: POP3 brute force (multiple failed logins).</description>

--- a/rules/0165-vpopmail_rules.xml
+++ b/rules/0165-vpopmail_rules.xml
@@ -41,21 +41,21 @@
     <description>vpopmail: successful login.</description>
   </rule>
 
-  <rule id="9951" level="10" frequency="8" timeframe="240">
+  <rule id="9951" level="10" frequency="10" timeframe="240">
     <if_matched_sid>9901</if_matched_sid>
     <same_source_ip />
     <description>vpopmail: brute force (multiple failed logins).</description>
     <group>authentication_failures,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
   </rule>
 
-  <rule id="9952" level="10" frequency="8" timeframe="240">
+  <rule id="9952" level="10" frequency="10" timeframe="240">
     <if_matched_sid>9902</if_matched_sid>
     <same_source_ip />
     <description>vpopmail: brute force (email harvesting).</description>
     <group>authentication_failures,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
   </rule>
 
-  <rule id="9953" level="10" frequency="8" timeframe="240">
+  <rule id="9953" level="10" frequency="10" timeframe="240">
     <if_matched_sid>9903</if_matched_sid>
     <same_source_ip />
     <description>vpopmail: brute force (empty password).</description>

--- a/rules/0175-proftpd_rules.xml
+++ b/rules/0175-proftpd_rules.xml
@@ -165,21 +165,21 @@
     <description>Check log message for reason.</description>
   </rule>
 
-  <rule id="11251" level="10" frequency="6" timeframe="120">
+  <rule id="11251" level="10" frequency="8" timeframe="120">
     <if_matched_sid>11204</if_matched_sid>
     <same_source_ip />
     <description>proftpd: FTP brute force (multiple failed logins).</description>
     <group>authentication_failures,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
   </rule>
 
-  <rule id="11252" level="10" frequency="10" timeframe="60">
+  <rule id="11252" level="10" frequency="12" timeframe="60">
     <if_matched_sid>11201</if_matched_sid>
     <same_source_ip />
     <description>proftpd: Multiple connection attempts from same source.</description>
     <group>recon,pci_dss_11.4,gdpr_IV_35.7.d,</group>
   </rule>
 
-  <rule id="11253" level="10" frequency="10" timeframe="120">
+  <rule id="11253" level="10" frequency="12" timeframe="120">
     <if_matched_sid>11215</if_matched_sid>
     <same_source_ip />
     <description>proftpd: Multiple timed out logins from same source.</description>

--- a/rules/0180-pure-ftpd_rules.xml
+++ b/rules/0180-pure-ftpd_rules.xml
@@ -1,4 +1,4 @@
-<!--
+frequency="8"<!--
   -  Pure-ftpd rules
   -  Author: Daniel Cid.
   -  Author: Peter Ahlert <peter@ifup.de>.
@@ -47,13 +47,13 @@
     <group>pci_dss_10.2.4,gdpr_IV_35.7.d,</group>
   </rule>
 
-  <rule id="11306" level="10" frequency="6" timeframe="120">
+  <rule id="11306" level="10" frequency="8" timeframe="120">
     <if_matched_sid>11302</if_matched_sid>
     <description>pure-ftpd: FTP brute force (multiple failed logins).</description>
     <group>authentication_failures,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
   </rule>
 
-  <rule id="11307" level="10" frequency="6" timeframe="60">
+  <rule id="11307" level="10" frequency="8" timeframe="60">
     <if_matched_sid>11301</if_matched_sid>
     <same_source_ip />
     <description>pure-ftpd: Multiple connection attempts from same source.</description>

--- a/rules/0185-vsftpd_rules.xml
+++ b/rules/0185-vsftpd_rules.xml
@@ -41,14 +41,14 @@
     <description>vsftpd: FTP server file upload.</description>
   </rule>
 
-  <rule id="11451" level="10" frequency="6" timeframe="120">
+  <rule id="11451" level="10" frequency="8" timeframe="120">
     <if_matched_sid>11403</if_matched_sid>
     <same_source_ip />
     <description>vsftpd: FTP brute force (multiple failed logins).</description>
     <group>authentication_failures,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
   </rule>
 
-  <rule id="11452" level="10" frequency="10" timeframe="60">
+  <rule id="11452" level="10" frequency="12" timeframe="60">
     <if_matched_sid>11401</if_matched_sid>
     <same_source_ip />
     <description>vsftpd: Multiple FTP connection attempts from </description>

--- a/rules/0190-ms_ftpd_rules.xml
+++ b/rules/0190-ms_ftpd_rules.xml
@@ -41,20 +41,20 @@
     <description>MS-FTP: FTP client request failed.</description>
   </rule>
 
-  <rule id="11510" level="10" frequency="6" timeframe="120">
+  <rule id="11510" level="10" frequency="8" timeframe="120">
     <if_matched_sid>11502</if_matched_sid>
     <description>MS-FTP: FTP brute force (multiple failed logins).</description>
     <group>authentication_failures,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
   </rule>
 
-  <rule id="11511" level="10" frequency="8" timeframe="30">
+  <rule id="11511" level="10" frequency="10" timeframe="30">
     <if_matched_sid>11501</if_matched_sid>
     <same_source_ip />
     <description>MS-FTP: Multiple connection attempts from same source.</description>
     <group>recon,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
   </rule>
 
-  <rule id="11512" level="10" frequency="6" timeframe="120">
+  <rule id="11512" level="10" frequency="8" timeframe="120">
     <if_matched_sid>11504</if_matched_sid>
     <same_source_ip />
     <description>MS-FTP: Multiple FTP errors from same source.</description>

--- a/rules/0195-named_rules.xml
+++ b/rules/0195-named_rules.xml
@@ -324,7 +324,7 @@
     <description>Parsing of a configuration file has failed.</description>
   </rule>
 
-  <rule id="12149" level="10" frequency="6" timeframe="120">
+  <rule id="12149" level="10" frequency="8" timeframe="120">
     <if_matched_sid>12108</if_matched_sid>
     <same_source_ip />
     <description> Multiple query (cache) failures.</description>

--- a/rules/0205-racoon_rules.xml
+++ b/rules/0205-racoon_rules.xml
@@ -61,7 +61,7 @@
     <description>racoon: Invalid configuration settings (ignored error).</description>
   </rule>
 
-  <rule id="14151" level="9" frequency="3" timeframe="360">
+  <rule id="14151" level="9" frequency="5" timeframe="360">
     <if_matched_sid>14101</if_matched_sid>
     <same_source_ip />
     <description>racoon: Multiple failed VPN logins.</description>

--- a/rules/0210-vpn_concentrator_rules.xml
+++ b/rules/0210-vpn_concentrator_rules.xml
@@ -34,7 +34,7 @@
     <group>authentication_success,pci_dss_10.2.5,gpg13_7.1,gpg13_7.2,gdpr_IV_32.2,</group>
   </rule>
 
-  <rule id="14251" level="10" frequency="8" timeframe="240">
+  <rule id="14251" level="10" frequency="10" timeframe="240">
     <if_matched_sid>14202</if_matched_sid>
     <same_source_ip />
     <description>CiscoVPN: Multiple VPN authentication failures.</description>

--- a/rules/0220-msauth_rules.xml
+++ b/rules/0220-msauth_rules.xml
@@ -6,7 +6,7 @@
   -  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2.
 -->
 
-<var name="MS_FREQ">6</var>
+<var name="MS_FREQ">8</var>
 
 <group name="windows,">
   <rule id="18100" level="0">

--- a/rules/0225-mcafee_av_rules.xml
+++ b/rules/0225-mcafee_av_rules.xml
@@ -11,7 +11,7 @@
 <var name="MCAFEE_INFO">^257$|^5000$|^5026$|^5052$|^5055$</var>
 <var name="MCAFEE_VIRUS_OK">quarantined|moved to quarantine|file was deleted|deleted successfully|has been deleted|message deleted|deleted after|cleaned|successfully deleted</var>
 <var name="MCAFEE_VIRUS">The file \.+ contain|infected with|User defined detection|scan found|error attempting to clean</var>
-<var name="MCAFEE_FREQ">10</var>
+<var name="MCAFEE_FREQ">12</var>
 
 <group name="mcafee,">
   <rule id="7500" level="0">

--- a/rules/0230-ms-se_rules.xml
+++ b/rules/0230-ms-se_rules.xml
@@ -112,13 +112,13 @@
   </rule>
 
 
-  <rule id="7750" level="10" frequency="6" timeframe="240">
+  <rule id="7750" level="10" frequency="8" timeframe="240">
     <if_matched_sid>7711</if_matched_sid>
     <group>gdpr_IV_35.7.d,</group>
     <description>Multiple Microsoft Security Essentials AV warnings detected.</description>
   </rule>
 
-  <rule id="7751" level="10" frequency="6" timeframe="240">
+  <rule id="7751" level="10" frequency="8" timeframe="240">
     <if_matched_sid>7712</if_matched_sid>
     <group>gdpr_IV_35.7.d,</group>
     <description>Multiple Microsoft Security Essentials AV warnings detected.</description>

--- a/rules/0235-vmware_rules.xml
+++ b/rules/0235-vmware_rules.xml
@@ -1,4 +1,4 @@
-<!--
+frequency="8"<!--
   -  VMWare ESX rules
   -  Author: Daniel Cid.
   -  Copyright (C) 2009 Trend Micro Inc.
@@ -124,25 +124,25 @@
 
   <!-- Composite rules. -->
 
-  <rule id="19150" level="10" frequency="6" timeframe="120" ignore="60">
+  <rule id="19150" level="10" frequency="8" timeframe="120" ignore="60">
     <if_matched_sid>19104</if_matched_sid>
     <description>Multiple VMWare ESX warning messages.</description>
     <group>service_availability,pci_dss_10.6.1,gpg13_4.12,gdpr_IV_35.7.d,</group>
   </rule>
 
-  <rule id="19151" level="10" frequency="6" timeframe="120" ignore="60">
+  <rule id="19151" level="10" frequency="8" timeframe="120" ignore="60">
     <if_matched_sid>19103</if_matched_sid>
     <description>Multiple VMWare ESX error messages.</description>
     <group>service_availability,pci_dss_10.6.1,gpg13_4.3,gdpr_IV_35.7.d,</group>
   </rule>
 
-  <rule id="19152" level="10" frequency="6" timeframe="120">
+  <rule id="19152" level="10" frequency="8" timeframe="120">
     <if_matched_sid>19111</if_matched_sid>
     <description>Multiple VMWare ESX authentication failures.</description>
     <group>authentication_failures,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
   </rule>
 
-  <rule id="19153" level="10" frequency="6" timeframe="120">
+  <rule id="19153" level="10" frequency="8" timeframe="120">
     <if_matched_sid>19113</if_matched_sid>
     <description>Multiple VMWare ESX user authentication failures.</description>
     <group>authentication_failures,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>

--- a/rules/0240-ids_rules.xml
+++ b/rules/0240-ids_rules.xml
@@ -6,7 +6,7 @@
   -  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2.
 -->
 
-<var name="IDS_FREQ">8</var>
+<var name="IDS_FREQ">10</var>
 
 <group name="ids,">
   <rule id="20100" level="8">
@@ -79,7 +79,7 @@
      - the same thing all the time. We will skip those events
      - since they became just noise.
      -->
-  <rule id="20161" level="11" frequency="3" timeframe="3800">
+  <rule id="20161" level="11" frequency="5" timeframe="3800">
     <if_matched_sid>20151</if_matched_sid>
     <same_source_ip />
     <same_id />
@@ -89,7 +89,7 @@
     <group>gdpr_IV_35.7.d,</group>
   </rule>
 
-  <rule id="20162" level="11" frequency="3" timeframe="3800">
+  <rule id="20162" level="11" frequency="5" timeframe="3800">
     <if_matched_sid>20152</if_matched_sid>
     <same_id />
     <ignore>id</ignore>

--- a/rules/0245-web_rules.xml
+++ b/rules/0245-web_rules.xml
@@ -148,7 +148,7 @@
   </rule>
 
 
-  <rule id="31151" level="10" frequency="12" timeframe="90">
+  <rule id="31151" level="10" frequency="14" timeframe="90">
     <if_matched_sid>31101</if_matched_sid>
     <same_source_ip />
     <description>Multiple web server 400 error codes </description>
@@ -156,7 +156,7 @@
     <group>web_scan,recon,pci_dss_6.5,pci_dss_11.4,gdpr_IV_35.7.d,</group>
   </rule>
 
-  <rule id="31152" level="10" frequency="6" timeframe="120">
+  <rule id="31152" level="10" frequency="8" timeframe="120">
     <if_matched_sid>31103</if_matched_sid>
     <same_source_ip />
     <description>Multiple SQL injection attempts from same </description>
@@ -164,14 +164,14 @@
     <group>attack,sql_injection,pci_dss_6.5,pci_dss_11.4,pci_dss_6.5.1,gdpr_IV_35.7.d,</group>
   </rule>
 
-  <rule id="31153" level="10" frequency="8" timeframe="120">
+  <rule id="31153" level="10" frequency="10" timeframe="120">
     <if_matched_sid>31104</if_matched_sid>
     <same_source_ip />
     <description>Multiple common web attacks from same source ip.</description>
     <group>attack,pci_dss_6.5,pci_dss_11.4,gdpr_IV_35.7.d,</group>
   </rule>
 
-  <rule id="31154" level="10" frequency="8" timeframe="120">
+  <rule id="31154" level="10" frequency="10" timeframe="120">
     <if_matched_sid>31105</if_matched_sid>
     <same_source_ip />
     <description>Multiple XSS (Cross Site Scripting) attempts </description>
@@ -179,21 +179,21 @@
     <group>attack,pci_dss_6.5,pci_dss_11.4,pci_dss_6.5.7,gdpr_IV_35.7.d,</group>
   </rule>
 
-  <rule id="31161" level="10" frequency="12" timeframe="120">
+  <rule id="31161" level="10" frequency="14" timeframe="120">
     <if_matched_sid>31121</if_matched_sid>
     <same_source_ip />
     <description>Multiple web server 501 error code (Not Implemented).</description>
     <group>web_scan,recon,pci_dss_6.5,pci_dss_11.4,gdpr_IV_35.7.d,</group>
   </rule>
 
-  <rule id="31162" level="10" frequency="12" timeframe="120">
+  <rule id="31162" level="10" frequency="14" timeframe="120">
     <if_matched_sid>31122</if_matched_sid>
     <same_source_ip />
     <description>Multiple web server 500 error code (Internal Error).</description>
     <group>system_error,pci_dss_6.5,pci_dss_10.6.1,gdpr_IV_35.7.d,</group>
   </rule>
 
-  <rule id="31163" level="10" frequency="12" timeframe="120">
+  <rule id="31163" level="10" frequency="14" timeframe="120">
     <if_matched_sid>31123</if_matched_sid>
     <same_source_ip />
     <description>Multiple web server 503 error code (Service unavailable).</description>

--- a/rules/0250-apache_rules.xml
+++ b/rules/0250-apache_rules.xml
@@ -103,7 +103,7 @@
     <group>invalid_request,</group>
   </rule>
 
-  <rule id="30116" level="10" frequency="8" timeframe="120">
+  <rule id="30116" level="10" frequency="10" timeframe="120">
     <if_matched_sid>30115</if_matched_sid>
     <same_source_ip />
     <description>Apache: Multiple Invalid URI requests from same source.</description>
@@ -125,7 +125,7 @@
     <group>modsecurity,access_denied,pci_dss_10.2.4,gdpr_IV_35.7.d,</group>
   </rule>
 
-  <rule id="30119" level="12" frequency="6" timeframe="120">
+  <rule id="30119" level="12" frequency="8" timeframe="120">
     <if_matched_sid>30118</if_matched_sid>
     <same_source_ip />
     <description>ModSecurity: Multiple attempts blocked.</description>
@@ -152,7 +152,7 @@
     <group>modsecurity,access_denied,pci_dss_10.2.4,gdpr_IV_35.7.d,</group>
   </rule>
 
-  <rule id="30202" level="10" frequency="8" timeframe="120">
+  <rule id="30202" level="10" frequency="10" timeframe="120">
     <if_matched_sid>30201</if_matched_sid>
     <description>ModSecurity: Multiple attempts blocked.</description>
     <group>modsecurity,access_denied,pci_dss_10.2.4,pci_dss_11.4,gdpr_IV_35.7.d,</group>
@@ -222,7 +222,7 @@
     <group>invalid_login,pci_dss_11.4,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
   </rule>
 
-  <rule id="30310" level="10" frequency="10" timeframe="160">
+  <rule id="30310" level="10" frequency="12" timeframe="160">
     <if_matched_sid>30309</if_matched_sid>
     <same_source_ip/>
     <description>Apache: Multiple authentication failures with invalid user.</description>
@@ -245,7 +245,7 @@
     <group>invalid_request,pci_dss_10.2.4,gdpr_IV_35.7.d,</group>
   </rule>
 
-  <rule id="30316" level="10" frequency="8" timeframe="120">
+  <rule id="30316" level="10" frequency="10" timeframe="120">
     <if_matched_sid>30315</if_matched_sid>
     <same_source_ip />
     <description>Apache: Multiple Invalid URI requests from same source.</description>

--- a/rules/0255-zeus_rules.xml
+++ b/rules/0255-zeus_rules.xml
@@ -54,7 +54,7 @@
     <group>gpg13_4.12,</group>
   </rule>
 
-  <rule id="31251" level="10" frequency="6" timeframe="120">
+  <rule id="31251" level="10" frequency="8" timeframe="120">
     <if_matched_sid>31202</if_matched_sid>
     <description>Multiple Zeus warnings.</description>
     <group>pci_dss_10.6.1,gpg13_4.12,gdpr_IV_35.7.d,</group>

--- a/rules/0260-nginx_rules.xml
+++ b/rules/0260-nginx_rules.xml
@@ -58,7 +58,7 @@
     <group>pci_dss_10.6.1,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
   </rule>
 
-  <rule id="31316" level="10" frequency="6" timeframe="240">
+  <rule id="31316" level="10" frequency="8" timeframe="240">
     <if_matched_sid>31315</if_matched_sid>
     <same_source_ip />
     <description>Nginx: Multiple web authentication failures.</description>

--- a/rules/0270-web_appsec_rules.xml
+++ b/rules/0270-web_appsec_rules.xml
@@ -99,7 +99,7 @@
   </rule>
 
   <!-- If we see frequent wp-login POST's, it is likely a bot. -->
-  <rule id="31510" level="8" frequency="6" timeframe="30">
+  <rule id="31510" level="8" frequency="8" timeframe="30">
     <if_matched_sid>31509</if_matched_sid>
     <same_source_ip />
     <description>CMS (WordPress or Joomla) brute force attempt.</description>
@@ -178,7 +178,7 @@
     <description>Ignoring often post requests inside /wp-admin and /admin.</description>
    </rule>
 
-   <rule id="31533" level="10" timeframe="20" frequency="6">
+   <rule id="31533" level="10" timeframe="20" frequency="8">
     <if_matched_sid>31530</if_matched_sid>
     <same_source_ip />
     <description>High amount of POST requests in a small period of time (likely bot).</description>

--- a/rules/0275-squid_rules.xml
+++ b/rules/0275-squid_rules.xml
@@ -7,7 +7,7 @@
   -  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2.
 -->
 
-<var name="SQUID_FREQ">8</var>
+<var name="SQUID_FREQ">10</var>
 
 <group name="squid,">
   <rule id="35000" level="0">
@@ -197,7 +197,7 @@
     <group>gdpr_IV_35.7.d,</group>
   </rule>
 
-  <rule id="35095" level="0" frequency="2" timeframe="360">
+  <rule id="35095" level="0" frequency="4" timeframe="360">
     <if_matched_sid>35055</if_matched_sid>
     <same_source_ip />
     <description>Squid: Ignoring multiple attempts from same source ip</description>

--- a/rules/0280-attack_rules.xml
+++ b/rules/0280-attack_rules.xml
@@ -63,7 +63,7 @@
     <group>exploit_attempt,pci_dss_6.2,pci_dss_6.5.2,pci_dss_11.4,gdpr_IV_35.7.d,</group>
   </rule>
 
-  <rule id="40111" level="10" frequency="10" timeframe="160">
+  <rule id="40111" level="10" frequency="12" timeframe="160">
     <if_matched_group>authentication_failed</if_matched_group>
     <description>Multiple authentication failures.</description>
     <group>authentication_failures,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,gpg13_7.8,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
@@ -78,7 +78,7 @@
     <group>pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gpg13_7.1,gpg13_7.8,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
   </rule>
 
-  <rule id="40113" level="12" frequency="6" timeframe="360">
+  <rule id="40113" level="12" frequency="8" timeframe="360">
     <if_matched_group>virus</if_matched_group>
     <description>Multiple viruses detected - Possible outbreak.</description>
     <group>virus,pci_dss_5.1,pci_dss_5.2,pci_dss_11.4,gpg13_4.2,gdpr_IV_35.7.d,</group>
@@ -88,7 +88,7 @@
 
 <!-- Privilege escalation messages -->
 <group name="syslog,elevation_of_privilege,">
-  <rule id="40501" level="15" timeframe="300" frequency="2">
+  <rule id="40501" level="15" timeframe="300" frequency="4">
     <if_group>adduser</if_group>
     <if_matched_group>attacks</if_matched_group>
     <same_location/>
@@ -100,7 +100,7 @@
 
 <!-- Scan signatures -->
 <group name="syslog,recon,">
-  <rule id="40601" level="10" frequency="10" timeframe="90" ignore="90">
+  <rule id="40601" level="10" frequency="12" timeframe="90" ignore="90">
     <if_matched_group>connection_attempt</if_matched_group>
     <description>Network scan from same source ip.</description>
     <same_source_ip />

--- a/rules/0295-mysql_rules.xml
+++ b/rules/0295-mysql_rules.xml
@@ -67,7 +67,7 @@
     <group>service_availability,pci_dss_10.6.1,gpg13_4.1,gdpr_IV_35.7.d,</group>
   </rule>
 
-  <rule id="50180" level="10" frequency="6" timeframe="120" ignore="60">
+  <rule id="50180" level="10" frequency="8" timeframe="120" ignore="60">
     <if_matched_sid>50125</if_matched_sid>
     <description>MySQL: Multiple errors.</description>
     <group>service_availability,pci_dss_10.6.1,gpg13_4.3,gdpr_IV_35.7.d,</group>

--- a/rules/0300-postgresql_rules.xml
+++ b/rules/0300-postgresql_rules.xml
@@ -77,13 +77,13 @@
     <group>service_availability,pci_dss_10.6.1,gpg13_4.14,gdpr_IV_35.7.d,</group>
   </rule>
 
-  <rule id="50580" level="10" frequency="6" timeframe="120" ignore="60">
+  <rule id="50580" level="10" frequency="8" timeframe="120" ignore="60">
     <if_matched_sid>50504</if_matched_sid>
     <description>PostgreSQL: Multiple database errors.</description>
     <group>service_availability,pci_dss_10.6.1,pci_dss_11.4,gpg13_4.3,gdpr_IV_35.7.d,</group>
   </rule>
 
-  <rule id="50581" level="10" frequency="6" timeframe="120" ignore="60">
+  <rule id="50581" level="10" frequency="8" timeframe="120" ignore="60">
     <if_matched_sid>50503</if_matched_sid>
     <description>PostgreSQL: Multiple database errors.</description>
     <group>service_availability,pci_dss_10.6.1,pci_dss_11.4,gpg13_4.3,gdpr_IV_35.7.d,</group>

--- a/rules/0305-dropbear_rules.xml
+++ b/rules/0305-dropbear_rules.xml
@@ -39,7 +39,7 @@
     <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_8.1.5,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
   </rule>
 
-  <rule id="51004" level="10" frequency="6" timeframe="120" ignore="60">
+  <rule id="51004" level="10" frequency="8" timeframe="120" ignore="60">
     <if_matched_group>authentication_failed</if_matched_group>
     <same_source_ip />
     <description>Dropbear: dropbear brute force attempt.</description>
@@ -60,7 +60,7 @@
     <group>recon,pci_dss_10.6.1,pci_dss_11.4,pci_dss_8.1.5,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
   </rule>
 
-  <rule id="51007" level="10" frequency="6" timeframe="120" ignore="60">
+  <rule id="51007" level="10" frequency="8" timeframe="120" ignore="60">
     <if_matched_sid>51000</if_matched_sid>
     <same_source_ip />
     <description>Dropbear: brute force attempt.</description>

--- a/rules/0320-clam_av_rules.xml
+++ b/rules/0320-clam_av_rules.xml
@@ -81,7 +81,7 @@
     <group>virus,pci_dss_5.1,gpg13_4.14,</group>
   </rule>
 
-  <rule id="52511" level="10" frequency="6">
+  <rule id="52511" level="10" frequency="8">
     <if_matched_sid>52502</if_matched_sid>
     <same_id />
     <description>ClamAV: Virus detected multiple times</description>

--- a/rules/0345-netscaler_rules.xml
+++ b/rules/0345-netscaler_rules.xml
@@ -26,7 +26,7 @@ id (Decoder): AAA, UI, API, SSLVPN, EVENT, SSLLOG, APPFW, TCP, ROUTING, SNMP, AC
         <group>authentication_failed,netscaler-aaa,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,gpg13_3.3,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
     </rule>
 
-    <rule id="80102" level="10" frequency="6">
+    <rule id="80102" level="10" frequency="8">
         <if_matched_sid>80101</if_matched_sid>
         <same_source_ip />
         <description>Netscaler: Multiple AAA failed to login the user</description>
@@ -56,7 +56,7 @@ id (Decoder): AAA, UI, API, SSLVPN, EVENT, SSLLOG, APPFW, TCP, ROUTING, SNMP, AC
         <group>netscaler-cmd,gpg13_3.5,gdpr_IV_35.7.d,</group>
     </rule>
 
-    <rule id="80105" level="10" frequency="6">
+    <rule id="80105" level="10" frequency="8">
         <if_matched_sid>80104</if_matched_sid>
         <same_source_ip />
         <description>Netscaler: Multiple commands failed</description>
@@ -124,7 +124,7 @@ id (Decoder): AAA, UI, API, SSLVPN, EVENT, SSLLOG, APPFW, TCP, ROUTING, SNMP, AC
         <group>netscaler-sslvpn,access_denied,pci_dss_10.2.4,gdpr_IV_35.7.d,</group>
     </rule>
 
-    <rule id="80112" level="10" frequency="8" timeframe="120">
+    <rule id="80112" level="10" frequency="10" timeframe="120">
         <if_matched_sid>80111</if_matched_sid>
         <description>Netscaler: Multiple non-http resource access denied</description>
         <group>netscaler-sslvpn,access_denied,pci_dss_10.2.4,pci_dss_11.4,gdpr_IV_35.7.d,</group>
@@ -141,7 +141,7 @@ id (Decoder): AAA, UI, API, SSLVPN, EVENT, SSLLOG, APPFW, TCP, ROUTING, SNMP, AC
         <group>netscaler-sslvpn,access_denied,pci_dss_10.2.4,gdpr_IV_35.7.d,</group>
     </rule>
 
-    <rule id="80114" level="10" frequency="8" timeframe="120">
+    <rule id="80114" level="10" frequency="10" timeframe="120">
         <if_matched_sid>80113</if_matched_sid>
         <description>Netscaler: Multiple http resource access denied</description>
         <group>netscaler-sslvpn,access_denied,pci_dss_10.2.4,pci_dss_11.4,gdpr_IV_35.7.d,</group>
@@ -400,7 +400,7 @@ id (Decoder): AAA, UI, API, SSLVPN, EVENT, SSLLOG, APPFW, TCP, ROUTING, SNMP, AC
         <group>netscaler-aaatm,access_denied,pci_dss_10.2.4,gdpr_IV_35.7.d,</group>
     </rule>
 
-    <rule id="80137" level="10" frequency="8" timeframe="120">
+    <rule id="80137" level="10" frequency="10" timeframe="120">
         <if_matched_sid>80136</if_matched_sid>
         <description>Netscaler: Multiple AAATM http resource access denied</description>
         <group>netscaler-aaatm,access_denied,pci_dss_10.2.4,pci_dss_11.4,gdpr_IV_35.7.d,</group>
@@ -431,7 +431,7 @@ id (Decoder): AAA, UI, API, SSLVPN, EVENT, SSLLOG, APPFW, TCP, ROUTING, SNMP, AC
         <group>authentication_failed,netscaler-cmd,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_3.3,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
     </rule>
 
-    <rule id="80140" level="10" frequency="6">
+    <rule id="80140" level="10" frequency="8">
         <if_matched_sid>80139</if_matched_sid>
         <same_source_ip />
         <description>Netscaler: Multiple UI/API login failed</description>

--- a/rules/0350-amazon_rules.xml
+++ b/rules/0350-amazon_rules.xml
@@ -59,7 +59,7 @@ ID: 80200 - 80499
         <group>pci_dss_10.6.1,gdpr_IV_35.7.d,</group>
     </rule>
 
-    <rule id="80252" level="10" frequency="20" timeframe="600">
+    <rule id="80252" level="10" frequency="22" timeframe="600">
         <if_matched_sid>80251</if_matched_sid>
         <description>Amazon: $(aws.eventSource) - $(aws.eventName) - high number of deleted object.</description>
         <group>pci_dss_10.6.1,gdpr_IV_35.7.d,</group>
@@ -80,7 +80,7 @@ ID: 80200 - 80499
         <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
     </rule>
 
-    <rule id="80255" level="10" frequency="4" timeframe="360">
+    <rule id="80255" level="10" frequency="6" timeframe="360">
         <if_matched_sid>80254</if_matched_sid>
         <description>Amazon: $(aws.eventSource) - $(aws.eventName) - Possible breaking attempt (high number of login attempts).</description>
         <group>authentication_failures,pci_dss_11.4,pci_dss_10.2.4,pci_dss_10.2.5,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>

--- a/rules/0360-serv-u_rules.xml
+++ b/rules/0360-serv-u_rules.xml
@@ -95,7 +95,7 @@ TypeMessage:
         <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
     </rule>
 
-    <rule id="80506" level="10" frequency="6">
+    <rule id="80506" level="10" frequency="8">
         <if_matched_sid>80505</if_matched_sid>
         <same_user />
         <description>Serv-U: Multiple authentication failures.</description>
@@ -123,7 +123,7 @@ TypeMessage:
         <action>02</action>
         <match>Closed session</match>
         <description>Serv-U: Closed session</description>
-        <group>gpg13_7.1,gdpr_IV_32.2,</group>   
+        <group>gpg13_7.1,gdpr_IV_32.2,</group>
     </rule>
 
     <!--

--- a/rules/0390-fortigate_rules.xml
+++ b/rules/0390-fortigate_rules.xml
@@ -40,7 +40,7 @@ ID: 81600 - 80799
         <group>firewall_drop,pci_dss_1.4,gdpr_IV_35.7.d,</group>
     </rule>
 
-    <rule id="81605" level="7" frequency="16" timeframe="45" ignore="240">
+    <rule id="81605" level="7" frequency="18" timeframe="45" ignore="240">
         <if_matched_sid>81604</if_matched_sid>
         <same_source_ip />
         <description>Fortigate: Multiple Firewall drop events from same source.</description>
@@ -59,7 +59,7 @@ ID: 81600 - 80799
         <group>authentication_failed,invalid_login,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
     </rule>
 
-    <rule id="81607" level="7" frequency="16" timeframe="45" ignore="240">
+    <rule id="81607" level="7" frequency="18" timeframe="45" ignore="240">
         <if_matched_sid>81606</if_matched_sid>
         <same_source_ip />
         <options>alert_by_email</options>
@@ -79,7 +79,7 @@ ID: 81600 - 80799
         <group>gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
     </rule>
 
-    <rule id="81609" level="8" frequency="16" timeframe="45" ignore="240">
+    <rule id="81609" level="8" frequency="18" timeframe="45" ignore="240">
         <if_matched_sid>81608</if_matched_sid>
         <same_source_ip />
         <description>Fortigate: Multiple changed configuration events from same source.</description>
@@ -96,7 +96,7 @@ ID: 81600 - 80799
         <group>pci_dss_10.6.1,gdpr_IV_35.7.d,</group>
     </rule>
 
-    <rule id="81611" level="7" frequency="16" timeframe="45" ignore="240">
+    <rule id="81611" level="7" frequency="18" timeframe="45" ignore="240">
         <if_matched_sid>81610</if_matched_sid>
         <same_source_ip />
         <options>alert_by_email</options>
@@ -114,7 +114,7 @@ ID: 81600 - 80799
         <group>pci_dss_10.6.1,gpg13_4.13,gdpr_IV_35.7.d,</group>
     </rule>
 
-    <rule id="81613" level="4" frequency="16" timeframe="45" ignore="240">
+    <rule id="81613" level="4" frequency="18" timeframe="45" ignore="240">
         <if_matched_sid>81612</if_matched_sid>
         <same_source_ip />
         <description>Fortigate: Multiple Firewall edit events from same source.</description>
@@ -132,7 +132,7 @@ ID: 81600 - 80799
         <group>authentication_failed,invalid_login,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
     </rule>
 
-    <rule id="81615" level="7" frequency="16" timeframe="45" ignore="240">
+    <rule id="81615" level="7" frequency="18" timeframe="45" ignore="240">
         <if_matched_sid>81614</if_matched_sid>
         <same_source_ip />
         <options>alert_by_email</options>
@@ -151,7 +151,7 @@ ID: 81600 - 80799
         <group>pci_dss_10.2.5,gpg13_7.1,gpg13_7.2,gdpr_IV_32.2,</group>
     </rule>
 
-    <rule id="81617" level="7" frequency="16" timeframe="45" ignore="240">
+    <rule id="81617" level="7" frequency="18" timeframe="45" ignore="240">
         <if_matched_sid>81616</if_matched_sid>
         <same_source_ip />
         <description>Fortigate: Multiple Firewall logout events from same source.</description>
@@ -169,7 +169,7 @@ ID: 81600 - 80799
         <group>pci_dss_10.6.1,gdpr_IV_35.7.d,</group>
     </rule>
 
-    <rule id="81619" level="3" frequency="16" timeframe="45" ignore="240">
+    <rule id="81619" level="3" frequency="18" timeframe="45" ignore="240">
         <if_matched_sid>81618</if_matched_sid>
         <same_source_ip />
         <options>alert_by_email</options>
@@ -188,7 +188,7 @@ ID: 81600 - 80799
         <group>firewall_drop,pci_dss_10.6.1,gdpr_IV_35.7.d,</group>
     </rule>
 
-    <rule id="81621" level="3" frequency="16" timeframe="45" ignore="240">
+    <rule id="81621" level="3" frequency="18" timeframe="45" ignore="240">
         <if_matched_sid>81620</if_matched_sid>
         <same_source_ip />
         <description>Fortigate: Multiple URL blocked from same source.</description>
@@ -206,7 +206,7 @@ ID: 81600 - 80799
         <group>authentication_success,pci_dss_10.2.5,gpg13_7.1,gdpr_IV_32.2,</group>
     </rule>
 
-    <rule id="81623" level="4" frequency="16" timeframe="45" ignore="240">
+    <rule id="81623" level="4" frequency="18" timeframe="45" ignore="240">
         <if_matched_sid>81622</if_matched_sid>
         <same_source_ip />
         <description>Fortigate: Multiple vpn user connected from same source.</description>
@@ -224,7 +224,7 @@ ID: 81600 - 80799
         <group>pci_dss_10.2.5,gpg13_7.1,gdpr_IV_32.2,</group>
     </rule>
 
-    <rule id="81625" level="4" frequency="16" timeframe="45" ignore="240">
+    <rule id="81625" level="4" frequency="18" timeframe="45" ignore="240">
         <if_matched_sid>81624</if_matched_sid>
         <same_source_ip />
         <description>Fortigate: Multiple user disconnected events from same source.</description>
@@ -243,7 +243,7 @@ ID: 81600 - 80799
         <group>pci_dss_10.6.1,gpg13_7.1,gpg13_7.2,gdpr_IV_32.2,</group>
     </rule>
 
-    <rule id="81627" level="4" frequency="16" timeframe="45" ignore="240">
+    <rule id="81627" level="4" frequency="18" timeframe="45" ignore="240">
         <if_matched_sid>81626</if_matched_sid>
         <same_source_ip />
         <description>Fortigate: Multiple Firewall login events from same source.</description>

--- a/rules/0395-hp_rules.xml
+++ b/rules/0395-hp_rules.xml
@@ -100,7 +100,7 @@ Jun  8 11:54:52 HP-5500EI-HO %%10SHELL/4/LOGINAUTHFAIL(t): Trap 1.1.1.1.1.1.2550
         <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
     </rule>
 
-    <rule id="81710" level="10" frequency="6">
+    <rule id="81710" level="10" frequency="8">
       <if_matched_sid>81709</if_matched_sid>
       <same_source_ip />
       <description>HP 5500 EI: Multiple authentication failures.</description>

--- a/rules/0400-openvpn_rules.xml
+++ b/rules/0400-openvpn_rules.xml
@@ -23,7 +23,7 @@
         <group>authentication_success,pci_dss_10.2.5,gpg13_7.1,gpg13_7.2,gdpr_IV_32.2,</group>
     </rule>
 
-    <rule id="81802" level="3" frequency="1" timeframe="60">
+    <rule id="81802" level="3" frequency="3" timeframe="60">
         <if_matched_sid>81801</if_matched_sid>
         <user />
         <options>alert_by_email</options>
@@ -42,7 +42,7 @@
         <group>openvpn-error,gdpr_IV_35.7.d,</group>
     </rule>
 
-    <rule id="81804" level="4" frequency="1" timeframe="60">
+    <rule id="81804" level="4" frequency="3" timeframe="60">
         <if_matched_sid>81803</if_matched_sid>
         <options>alert_by_email</options>
         <description>OpenVPN: Certificate failed - Possible revoked user</description>

--- a/rules/0405-rsa-auth-manager_rules.xml
+++ b/rules/0405-rsa-auth-manager_rules.xml
@@ -35,7 +35,7 @@
         <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
     </rule>
 
-    <rule id="81904" level="10" frequency="6" timeframe="120">
+    <rule id="81904" level="10" frequency="8" timeframe="120">
         <if_matched_sid>81903</if_matched_sid>
         <same_user />
         <description>RSA Authentication Manager: Multiple authentication failures.</description>

--- a/rules/0440-ms_sqlserver_rules.xml
+++ b/rules/0440-ms_sqlserver_rules.xml
@@ -12,10 +12,10 @@
     <decoded_as>sqlserver</decoded_as>
     <description>SQL Server messages.</description>
   </rule>
-  
+
 <!--
 2017-04-03 15:53:08.63 nameserv     Starting up database 'mustest'.
--->  
+-->
 
     <rule id="85001" level="3">
         <if_sid>85000</if_sid>
@@ -23,10 +23,10 @@
         <description>Starting up database.</description>
         <group></group>
     </rule>
-  
+
 <!--
 2017-04-03 15:53:26.47 nameserv      Attempting to load library 'libexample.dll' into memory. This is an informational message only. No user action is required.
--->   
+-->
 
     <rule id="85002" level="3">
         <if_sid>85000</if_sid>
@@ -34,17 +34,17 @@
         <description>Attempting to load library.</description>
         <group>sqlserverlibraries,</group>
     </rule>
-  
+
 <!--
 2017-04-03 15:53:00.66 Server      Server process ID is 3832.
--->  
+-->
     <rule id="85003" level="3">
         <if_sid>85000</if_sid>
         <match>Server process ID is</match>
         <description>SQL Server process ID.</description>
         <group>sqlserver_process_id,</group>
-    </rule>  
-  
+    </rule>
+
 <!--
 2017-04-03 15:55:24.37 Logon       Login succeeded for user 'DOMAIN\user'. Connection made using Windows authentication. [CLIENT: 10.10.10.10]
 -->
@@ -53,11 +53,11 @@
         <match>Login succeeded for user</match>
         <description>SQL Server login success.</description>
         <group>sqlserver_login,pci_dss_10.2.5,gpg13_7.1,gpg13_7.2,gdpr_IV_32.2,</group>
-    </rule>  
-  
+    </rule>
+
 <!--
 2017-04-03 15:53:08.22 Logon       Login failed for user 'DOMAIN\sqluser'. Reason: Failed to open the explicitly specified database. [CLIENT: fe20::53e4:4653:bcef:34d6%62]
--->  
+-->
 
     <rule id="85005" level="7">
         <if_sid>85000</if_sid>
@@ -66,12 +66,12 @@
         <group>sqlserver_login, authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
     </rule>
 
-    <rule id="85006" level="10" frequency="6">
+    <rule id="85006" level="10" frequency="8">
         <if_matched_sid>85005</if_matched_sid>
         <same_source_ip />
         <description>SQL Server: Multiple authentication failures.</description>
         <group>identityguard_login,authentication_failures,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
-    </rule>  
+    </rule>
 
 <!--
 2017-04-03 15:53:26.11 spid51      Using 'xpstar.dll' version '2007.100.6000' to execute extended stored procedure 'xp_instance_regread'. This is an informational message only; no user action is required.
@@ -82,30 +82,30 @@
         <match>Using </match>
         <description>SQL Server library use.</description>
         <group>sqlserverlibraries,</group>
-    </rule> 
-  
+    </rule>
+
 <!--
 2017-04-03 15:53:07.73 Server      The SQL Server Network Interface library could not register the Service Principal Name (SPN) for the SQL Server service. Error: 0x2098, state: 15. Failure to register an SPN may cause integrated authentication to fall back to NTLM instead of Kerberos. This is an informational message. Further action is only required if Kerberos authentication is required by authentication policies.
  -->
- 
+
     <rule id="85008" level="6">
         <if_sid>85000</if_sid>
         <match>The SQL Server Network Interface library could not register the Service Principal Name</match>
         <description>SQL Server Network Interface library unregistered </description>
         <group>sqlservererror, sqlserverlibraries,gdpr_IV_35.7.d,</group>
-    </rule> 
-  
+    </rule>
+
 <!--
 2017-04-03 15:53:12.59 Logon       Error: 18456, Severity: 14, State: 38.
--->  
+-->
 
     <rule id="85009" level="3">
         <if_sid>85000</if_sid>
         <match>Error: </match>
         <description>SQL Server error.</description>
         <group>sqlservererror,gdpr_IV_35.7.d,</group>
-    </rule> 
-    
+    </rule>
+
 <!--
 2017-04-03 15:53:03.64 user      FILESTREAM: effective level = 0, configured level = 0, file system access share name = 'MSSQLSERVER'.
 -->
@@ -115,6 +115,6 @@
          <match>FILESTREAM: </match>
          <description>SQL Server filestream information.</description>
          <group>sqlservererror,</group>
-    </rule> 
-	
+    </rule>
+
 </group>

--- a/rules/0445-identity_guard_rules.xml
+++ b/rules/0445-identity_guard_rules.xml
@@ -13,10 +13,10 @@
         <decoded_as>identity_guard</decoded_as>
         <description>Identity Guard Log.</description>
     </rule>
-  
+
 <!--
 [2017-04-10 10:23:20,361] [IG Audit Writer] [INFO ] [IG.AUDIT] [AUD6001] [web/test] User web/test failed authentication. Authentication Type: PASSWORD, Default Password: true, Remote Address: 10.10.10.10
--->  
+-->
 
     <rule id="85501" level="7">
         <if_sid>85500</if_sid>
@@ -26,11 +26,11 @@
     </rule>
 
 
-    <rule id="85502" level="10" frequency="6">
+    <rule id="85502" level="10" frequency="8">
         <if_matched_sid>85501</if_matched_sid>
         <same_source_ip />
         <description>Identity Guard: Multiple authentication failures.</description>
         <group>identityguard_login,authentication_failures,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
-    </rule>	
-	
+    </rule>
+
 </group>

--- a/rules/0450-mongodb_rules.xml
+++ b/rules/0450-mongodb_rules.xml
@@ -114,7 +114,7 @@ D	Debug, for All Verbosity Levels > 0
         <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
     </rule>
 
-    <rule id="85760" level="10" frequency="6">
+    <rule id="85760" level="10" frequency="8">
       <if_matched_sid>85759</if_matched_sid>
       <same_source_ip />
       <description>MongoDB: Multiple authentication failures.</description>

--- a/rules/0470-vshell_rules.xml
+++ b/rules/0470-vshell_rules.xml
@@ -47,13 +47,13 @@
     <group>gpg13_7.1,gpg13_7.2,gdpr_IV_32.2,</group>
   </rule>
 
-  <rule id="86806" level="12" frequency="5" timeframe="120">
+  <rule id="86806" level="12" frequency="7" timeframe="120">
     <if_matched_sid>86804</if_matched_sid>
     <description>VShell multiple connection attempts within 2 minute by a host in the deny file, potential DOS or brute force attempt.</description>
     <group>gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
   </rule>
 
-  <rule id="86807" level="12" frequency="5" timeframe="60">
+  <rule id="86807" level="12" frequency="7" timeframe="60">
     <if_matched_sid>86802</if_matched_sid>
     <description>VShell host has exceeded the number of failed login attempts and has been added to the Hosts Deny file.</description>
     <group>gdpr_IV_35.7.d,gdpr_IV_32.2,</group>

--- a/rules/0495-proxmox-ve_rules.xml
+++ b/rules/0495-proxmox-ve_rules.xml
@@ -17,7 +17,7 @@
     <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
   </rule>
 
-  <rule id="87202" level="10" frequency="6" timeframe="120">
+  <rule id="87202" level="10" frequency="8" timeframe="120">
     <if_matched_sid>87201</if_matched_sid>
     <same_source_ip />
     <description>Proxmox VE brute force (multiple failed logins).</description>

--- a/rules/0500-owncloud_rules.xml
+++ b/rules/0500-owncloud_rules.xml
@@ -1,4 +1,4 @@
-<!--
+frequency="8"<!--
   - OwnCloud ruleset
   - Created by Wazuh, Inc. <support@wazuh.com>.
   -  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2.
@@ -6,7 +6,7 @@
 
 <!-- ID: 87300 - 87400 -->
 
-<!-- 
+<!--
   - It's needed to paste the following in /var/ossec/etc/ossec.conf for the decoder to work properly:
 
     <localfile>
@@ -33,9 +33,9 @@
   - {"reqId":"BaW6nfA5rHBoihjDtQVm","remoteAddr":"127.0.0.1","app":"core-preview","message":"Passed filename is not valid, might be malicious (file:\"test\";ip:\"127.0.0.1\")","level":2,"time":"2017-09-01T22:11:25+02:00","method":"POST","url":"\/login","user":"--","@source":"ownCloud"}
   - {"reqId":"4ETnKW0UyDBNmL4z\/umV","remoteAddr":"127.0.0.1","app":"PHP","message":"Redis::connect(): connect() failed: No such file or directory at \/var\/www\/owncloud\/lib\/private\/RedisFactory.php#60","level":3,"time":"2017-08-21T16:00:34+02:00","method":"PROPFIND","url":"\/remote.php\/dav\/addressbooks\/users\/admin\/example\/","user":"admin","@source":"ownCloud"}
   - {"reqId":"4j2DKpvOh0OezXVwfuLO","remoteAddr":"127.0.0.1","app":"PHP","message":"fopen(\/var\/www\/owncloud\/data\/user 1\/thumbnails\/1234\/32-32.png): failed to open stream: No such file or directory at \/var\/www\/owncloud\/lib\/private\/Files\/Storage\/Local.php#278","level":3,"time":"2017-07-15T23:59:20+02:00","method":"GET","url":"\/core\/preview.png?file=%2Fexample.txt&c=123&x=32&y=32&forceIcon=0","user":"user 1","@source":"ownCloud"}
-  
+
   - Examples syslog:
-  
+
   - Sep  1 20:16:09 foo ownCloud[15463]: {core} Login failed: 'test' (Remote IP: '127.0.0.1')
   - Sep  1 22:16:33 foo ownCloud[15467]: {core-preview} Passed filename is not valid, might be malicious (file:"test";ip:"127.0.0.1","@source":"ownCloud")
 -->
@@ -60,7 +60,7 @@
     <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
   </rule>
 
-  <rule id="87302" level="10" frequency="6" timeframe="120">
+  <rule id="87302" level="10" frequency="8" timeframe="120">
     <if_matched_sid>87301</if_matched_sid>
     <same_source_ip />
     <description>ownCloud brute force (multiple failed logins).</description>

--- a/rules/0515-exim_rules.xml
+++ b/rules/0515-exim_rules.xml
@@ -1,4 +1,4 @@
-<!-- 
+<!--
   -  Exim rules
   -  Author: Alexandr Garaga.
   -  Copyright (C) 2009 Trend Micro Inc.
@@ -26,7 +26,7 @@
       <group>invalid_login,authentication_failed,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
     </rule>
 
-    <rule id="87507" level="10" frequency="6" timeframe="240">
+    <rule id="87507" level="10" frequency="8" timeframe="240">
       <if_matched_sid>87506</if_matched_sid>
       <same_source_ip />
       <description>Exim brute force attack (multiple auth failures).</description>
@@ -51,4 +51,3 @@
       <description>Exim syntax or protocol errors</description>
     </rule>
 </group>
-

--- a/rules/0525-openvas_rules.xml
+++ b/rules/0525-openvas_rules.xml
@@ -1,4 +1,4 @@
-<!--
+frequency="8"<!--
   -  OpenVAS rules
   -  Author: Christian Fischer.
   -  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2.
@@ -18,7 +18,7 @@
     <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
   </rule>
 
-  <rule id="87602" level="10" frequency="6" timeframe="120">
+  <rule id="87602" level="10" frequency="8" timeframe="120">
     <if_matched_sid>87601</if_matched_sid>
     <same_source_ip />
     <description>OpenVAS (gsad) brute force (multiple failed logins).</description>
@@ -71,7 +71,7 @@
     <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
   </rule>
 
-  <rule id="87610" level="10" frequency="6" timeframe="120">
+  <rule id="87610" level="10" frequency="8" timeframe="120">
     <if_matched_sid>87609</if_matched_sid>
     <same_source_ip />
     <description>OpenVAS (openvasmd) brute force (multiple failed logins).</description>

--- a/rules/0540-pfsense_rules.xml
+++ b/rules/0540-pfsense_rules.xml
@@ -23,11 +23,10 @@
     <group>firewall_block,pci_dss_1.4,gpg13_4.12,</group>
   </rule>
 
-  <rule id="87702" level="10" frequency="16" timeframe="45" ignore="240">
+  <rule id="87702" level="10" frequency="18" timeframe="45" ignore="240">
     <if_matched_sid>87701</if_matched_sid>
     <same_source_ip />
     <description>Multiple pfSense firewall blocks events from same source.</description>
     <group>multiple_blocks,pci_dss_1.4,pci_dss_10.6.1,gpg13_4.12,</group>
   </rule>
 </group>
-

--- a/rules/translated/pure_ftpd/pure-ftpd_rules_da.xml
+++ b/rules/translated/pure_ftpd/pure-ftpd_rules_da.xml
@@ -45,13 +45,13 @@
     <description>Attempt to access invalid directory</description>
   </rule>
 
-  <rule id="11306" level="10" frequency="6" timeframe="3600">
+  <rule id="11306" level="10" frequency="8" timeframe="3600">
     <if_matched_sid>11302</if_matched_sid>
     <description>FTP brute force (multiple failed logins).</description>
     <group>authentication_failures,</group>
   </rule>
 
-  <rule id="11307" level="10" frequency="6" timeframe="60">
+  <rule id="11307" level="10" frequency="8" timeframe="60">
     <if_matched_sid>11301</if_matched_sid>
     <same_source_ip />
     <description>Multiple connection attempts from same source.</description>

--- a/rules/translated/pure_ftpd/pure-ftpd_rules_de.xml
+++ b/rules/translated/pure_ftpd/pure-ftpd_rules_de.xml
@@ -46,13 +46,13 @@
     <description>Attempt to access invalid directory</description>
   </rule>
 
-  <rule id="11306" level="10" frequency="6" timeframe="3600">
+  <rule id="11306" level="10" frequency="8" timeframe="3600">
     <if_matched_sid>11302</if_matched_sid>
     <description>FTP brute force (multiple failed logins).</description>
     <group>authentication_failures,</group>
   </rule>
 
-  <rule id="11307" level="10" frequency="6" timeframe="60">
+  <rule id="11307" level="10" frequency="8" timeframe="60">
     <if_matched_sid>11301</if_matched_sid>
     <same_source_ip />
     <description>Multiple connection attempts from same source.</description>

--- a/rules/translated/pure_ftpd/pure-ftpd_rules_en.xml
+++ b/rules/translated/pure_ftpd/pure-ftpd_rules_en.xml
@@ -45,13 +45,13 @@
     <description>Attempt to access invalid directory</description>
   </rule>
 
-  <rule id="11306" level="10" frequency="6" timeframe="120">
+  <rule id="11306" level="10" frequency="8" timeframe="120">
     <if_matched_sid>11302</if_matched_sid>
     <description>FTP brute force (multiple failed logins).</description>
     <group>authentication_failures,</group>
   </rule>
 
-  <rule id="11307" level="10" frequency="6" timeframe="60">
+  <rule id="11307" level="10" frequency="8" timeframe="60">
     <if_matched_sid>11301</if_matched_sid>
     <same_source_ip />
     <description>Multiple connection attempts from same source.</description>

--- a/rules/translated/pure_ftpd/pure-ftpd_rules_es.xml
+++ b/rules/translated/pure_ftpd/pure-ftpd_rules_es.xml
@@ -45,13 +45,13 @@
     <description>Attempt to access invalid directory</description>
   </rule>
 
-  <rule id="11306" level="10" frequency="6" timeframe="3600">
+  <rule id="11306" level="10" frequency="8" timeframe="3600">
     <if_matched_sid>11302</if_matched_sid>
     <description>FTP brute force (multiple failed logins).</description>
     <group>authentication_failures,</group>
   </rule>
 
-  <rule id="11307" level="10" frequency="6" timeframe="60">
+  <rule id="11307" level="10" frequency="8" timeframe="60">
     <if_matched_sid>11301</if_matched_sid>
     <same_source_ip />
     <description>Multiple connection attempts from same source.</description>

--- a/rules/translated/pure_ftpd/pure-ftpd_rules_fr.xml
+++ b/rules/translated/pure_ftpd/pure-ftpd_rules_fr.xml
@@ -46,13 +46,13 @@
     <description>Attempt to access invalid directory</description>
   </rule>
 
-  <rule id="11306" level="10" frequency="6" timeframe="3600">
+  <rule id="11306" level="10" frequency="8" timeframe="3600">
     <if_matched_sid>11302</if_matched_sid>
     <description>FTP brute force (multiple failed logins).</description>
     <group>authentication_failures,</group>
   </rule>
 
-  <rule id="11307" level="10" frequency="6" timeframe="60">
+  <rule id="11307" level="10" frequency="8" timeframe="60">
     <if_matched_sid>11301</if_matched_sid>
     <same_source_ip />
     <description>Multiple connection attempts from same source.</description>

--- a/rules/translated/pure_ftpd/pure-ftpd_rules_fr_funny.xml
+++ b/rules/translated/pure_ftpd/pure-ftpd_rules_fr_funny.xml
@@ -45,13 +45,13 @@
     <description>Attempt to access invalid directory</description>
   </rule>
 
-  <rule id="11306" level="10" frequency="6" timeframe="3600">
+  <rule id="11306" level="10" frequency="8" timeframe="3600">
     <if_matched_sid>11302</if_matched_sid>
     <description>FTP brute force (multiple failed logins).</description>
     <group>authentication_failures,</group>
   </rule>
 
-  <rule id="11307" level="10" frequency="6" timeframe="60">
+  <rule id="11307" level="10" frequency="8" timeframe="60">
     <if_matched_sid>11301</if_matched_sid>
     <same_source_ip />
     <description>Multiple connection attempts from same source.</description>

--- a/rules/translated/pure_ftpd/pure-ftpd_rules_it.xml
+++ b/rules/translated/pure_ftpd/pure-ftpd_rules_it.xml
@@ -45,13 +45,13 @@
     <description>Attempt to access invalid directory</description>
   </rule>
 
-  <rule id="11306" level="10" frequency="6" timeframe="3600">
+  <rule id="11306" level="10" frequency="8" timeframe="3600">
     <if_matched_sid>11302</if_matched_sid>
     <description>FTP brute force (multiple failed logins).</description>
     <group>authentication_failures,</group>
   </rule>
 
-  <rule id="11307" level="10" frequency="6" timeframe="60">
+  <rule id="11307" level="10" frequency="8" timeframe="60">
     <if_matched_sid>11301</if_matched_sid>
     <same_source_ip />
     <description>Multiple connection attempts from same source.</description>

--- a/rules/translated/pure_ftpd/pure-ftpd_rules_nl.xml
+++ b/rules/translated/pure_ftpd/pure-ftpd_rules_nl.xml
@@ -45,13 +45,13 @@
     <description>Attempt to access invalid directory</description>
   </rule>
 
-  <rule id="11306" level="10" frequency="6" timeframe="3600">
+  <rule id="11306" level="10" frequency="8" timeframe="3600">
     <if_matched_sid>11302</if_matched_sid>
     <description>FTP brute force (multiple failed logins).</description>
     <group>authentication_failures,</group>
   </rule>
 
-  <rule id="11307" level="10" frequency="6" timeframe="60">
+  <rule id="11307" level="10" frequency="8" timeframe="60">
     <if_matched_sid>11301</if_matched_sid>
     <same_source_ip />
     <description>Multiple connection attempts from same source.</description>

--- a/rules/translated/pure_ftpd/pure-ftpd_rules_no.xml
+++ b/rules/translated/pure_ftpd/pure-ftpd_rules_no.xml
@@ -45,13 +45,13 @@
     <description>Attempt to access invalid directory</description>
   </rule>
 
-  <rule id="11306" level="10" frequency="6" timeframe="3600">
+  <rule id="11306" level="10" frequency="8" timeframe="3600">
     <if_matched_sid>11302</if_matched_sid>
     <description>FTP brute force (multiple failed logins).</description>
     <group>authentication_failures,</group>
   </rule>
 
-  <rule id="11307" level="10" frequency="6" timeframe="60">
+  <rule id="11307" level="10" frequency="8" timeframe="60">
     <if_matched_sid>11301</if_matched_sid>
     <same_source_ip />
     <description>Multiple connection attempts from same source.</description>

--- a/rules/translated/pure_ftpd/pure-ftpd_rules_pt_br.xml
+++ b/rules/translated/pure_ftpd/pure-ftpd_rules_pt_br.xml
@@ -46,13 +46,13 @@
     <description>Attempt to access invalid directory</description>
   </rule>
 
-  <rule id="11306" level="10" frequency="6" timeframe="3600">
+  <rule id="11306" level="10" frequency="8" timeframe="3600">
     <if_matched_sid>11302</if_matched_sid>
     <description>FTP brute force (multiple failed logins).</description>
     <group>authentication_failures,</group>
   </rule>
 
-  <rule id="11307" level="10" frequency="6" timeframe="60">
+  <rule id="11307" level="10" frequency="8" timeframe="60">
     <if_matched_sid>11301</if_matched_sid>
     <same_source_ip />
     <description>Multiple connection attempts from same source.</description>

--- a/rules/translated/pure_ftpd/pure-ftpd_rules_ro.xml
+++ b/rules/translated/pure_ftpd/pure-ftpd_rules_ro.xml
@@ -46,13 +46,13 @@
     <description>Attempt to access invalid directory</description>
   </rule>
 
-  <rule id="11306" level="10" frequency="6" timeframe="3600">
+  <rule id="11306" level="10" frequency="8" timeframe="3600">
     <if_matched_sid>11302</if_matched_sid>
     <description>FTP brute force (multiple failed logins).</description>
     <group>authentication_failures,</group>
   </rule>
 
-  <rule id="11307" level="10" frequency="6" timeframe="60">
+  <rule id="11307" level="10" frequency="8" timeframe="60">
     <if_matched_sid>11301</if_matched_sid>
     <same_source_ip />
     <description>Multiple connection attempts from same source.</description>

--- a/rules/translated/pure_ftpd/pure-ftpd_rules_sk.xml
+++ b/rules/translated/pure_ftpd/pure-ftpd_rules_sk.xml
@@ -46,13 +46,13 @@
     <description>Attempt to access invalid directory</description>
   </rule>
 
-  <rule id="11306" level="10" frequency="6" timeframe="3600">
+  <rule id="11306" level="10" frequency="8" timeframe="3600">
     <if_matched_sid>11302</if_matched_sid>
     <description>FTP brute force (multiple failed logins).</description>
     <group>authentication_failures,</group>
   </rule>
 
-  <rule id="11307" level="10" frequency="6" timeframe="60">
+  <rule id="11307" level="10" frequency="8" timeframe="60">
     <if_matched_sid>11301</if_matched_sid>
     <same_source_ip />
     <description>Multiple connection attempts from same source.</description>

--- a/rules/translated/pure_ftpd/pure-ftpd_rules_sv.xml
+++ b/rules/translated/pure_ftpd/pure-ftpd_rules_sv.xml
@@ -46,13 +46,13 @@
     <description>Attempt to access invalid directory</description>
   </rule>
 
-  <rule id="11306" level="10" frequency="6" timeframe="3600">
+  <rule id="11306" level="10" frequency="8" timeframe="3600">
     <if_matched_sid>11302</if_matched_sid>
     <description>FTP brute force (multiple failed logins).</description>
     <group>authentication_failures,</group>
   </rule>
 
-  <rule id="11307" level="10" frequency="6" timeframe="60">
+  <rule id="11307" level="10" frequency="8" timeframe="60">
     <if_matched_sid>11301</if_matched_sid>
     <same_source_ip />
     <description>Multiple connection attempts from same source.</description>

--- a/rules/translated/pure_ftpd/pure-ftpd_rules_tr.xml
+++ b/rules/translated/pure_ftpd/pure-ftpd_rules_tr.xml
@@ -46,13 +46,13 @@
     <description>Attempt to access invalid directory</description>
   </rule>
 
-  <rule id="11306" level="10" frequency="6" timeframe="3600">
+  <rule id="11306" level="10" frequency="8" timeframe="3600">
     <if_matched_sid>11302</if_matched_sid>
     <description>FTP brute force (multiple failed logins).</description>
     <group>authentication_failures,</group>
   </rule>
 
-  <rule id="11307" level="10" frequency="6" timeframe="60">
+  <rule id="11307" level="10" frequency="8" timeframe="60">
     <if_matched_sid>11301</if_matched_sid>
     <same_source_ip />
     <description>Multiple connection attempts from same source.</description>


### PR DESCRIPTION
Related to the PR: [#827](https://github.com/wazuh/wazuh/pull/827)

It has been removed the +2 offset of the frequency option. This PR adapts existing rules frequency to the new equivalent values.