### PR TITLE
Fortigate issue 137

### DIFF
--- a/decoders/0100-fortigate_decoders.xml
+++ b/decoders/0100-fortigate_decoders.xml
@@ -54,31 +54,106 @@ Feb 20 12:31:11 date=2011-02-20 time=12: 31:09 devname=Name_of_Device device_id=
 
 <!-- FortiOS 5.0 via syslog -->
 <decoder name="fortigate-firewall-v5">
-    <prematch>date=\S+ time=\.+ devname=\S+ devid=FG\w+ logid=\d+ |date=\S+ time=\.+ devname="\S+" devid="FG\w+" logid="\d+" </prematch>
+    <prematch>date=\S+\.+time=\.+devname=\S+\.+devid=\p*FG\S+\.+logid=</prematch>
     <type>syslog</type>
 </decoder>
 
 <!--
 date=2016-06-15 time=09:41:35 devname=Device_Name devid=FGTXXXX9999999999 logid=9999999999 type=utm subtype=ips eventtype=signature level=alert vd="root" severity=info srcip=192.168.10.8 dstip=157.55.235.162 srcintf="internal2" dstintf="wan2" policyid=2 sessionid=1473454 action=dropped proto=6 service=tcp/20480 attack="HTTP.Unknown.Tunnelling" srcport=62216 dstport=80 direction=outgoing attackid=107347981 profile="default" ref="http://www.fortinet.com/ids/VID107347981" incidentserialno=1999871775 msg="http_decoder: HTTP.Unknown.Tunnelling,"
+
 -->
+
 <decoder name="fortigate-firewall-v5-utm-ips">
     <parent>fortigate-firewall-v5</parent>
-    <prematch offset="after_parent">type=utm subtype=ips</prematch>
-    <regex offset="after_prematch">severity=(\S+) srcip=(\S+) dstip=(\S+) \.*action=(\S+) proto\.+srcport=(\d+) dstport=(\d+) \.*msg=(\.*)</regex>
-    <order>status,srcip,dstip,action,srcport,dstport,extra_data</order>
+    <prematch offset="after_parent">type=utm,subtype=ips|type=utm subtype=ips|type="utm" subtype="ips"</prematch>
+    <regex offset="after_prematch">\.*severity="(\S+)"|\.*severity=(\S+),|\.*severity=(\S+) </regex>
+    <order>status</order>
 </decoder>
+
+<decoder name="fortigate-firewall-v5-utm-ips">
+    <parent>fortigate-firewall-v5</parent>
+    <regex offset="after_regex">\.*srcip="(\S+)"|\.*srcip=(\S+),|\.*srcip=(\S+) </regex>
+    <order>srcip</order>
+</decoder>
+
+<decoder name="fortigate-firewall-v5-utm-ips">
+    <parent>fortigate-firewall-v5</parent>
+    <regex offset="after_regex">\.*dstip="(\S+)"|\.*dstip=(\S+),|\.*dstip=(\S+) </regex>
+    <order>dstip</order>
+</decoder>
+
+<decoder name="fortigate-firewall-v5-utm-ips">
+    <parent>fortigate-firewall-v5</parent>
+    <regex offset="after_regex">\.*action="(\S+)"|\.*action=(\S+),|\.*action=(\S+) </regex>
+    <order>action</order>
+</decoder>
+
+<decoder name="fortigate-firewall-v5-utm-ips">
+    <parent>fortigate-firewall-v5</parent>
+    <regex offset="after_regex">\.*srcport="(\d+)"|\.*srcport=(\d+),|\.*srcport=(\d+) </regex>
+    <order>srcport</order>
+</decoder>
+
+<decoder name="fortigate-firewall-v5-utm-ips">
+    <parent>fortigate-firewall-v5</parent>
+    <regex offset="after_regex">\.*dstport="(\d+)"|\.*dstport=(\d+),|\.*dstport=(\d+) </regex>
+    <order>dstport</order>
+</decoder>
+
+<decoder name="fortigate-firewall-v5-utm-ips">
+    <parent>fortigate-firewall-v5</parent>
+    <regex offset="after_regex">\.*msg="(\.+)"|\.*dstport=(\.+),|\.*dstport=(\.+) </regex>
+    <order>extra_data</order>
+</decoder>
+
+
+
+
 
 <!--
 Mar 22 19:21:00 10.10.10.10 date=2016-03-22 time=19:20:46 devname=Text devid=FGT3HD0000000000 logid=0000018000 type=anomaly subtype=anomaly level=alert vd="root" severity=critical srcip=10.10.10.35 dstip=10.10.10.84 srcintf="port2" sessionid=0 action=detected proto=6 service=tcp/36875 count=1903 attack="tcp_syn_flood" srcport=32835 dstport=2960 attackid=100663396 profile="DoS-policy1" ref="http://www.fortinet.com/ids/VID100663396" msg="anomaly: tcp_syn_flood, 2001 > threshold 2000, repeats 1903 times" crscore=50 crlevel=critical
 
 Mar 22 19:21:00 10.10.10.10 date=2016-03-22 time=19:20:46 devname=Text devid=FGT3HD0000000000 logid=0000018000 type=anomaly subtype=anomaly level=alert vd="root" severity=critical srcip=10.10.10.61 dstip=10.10.10.84 srcintf="port2" sessionid=0 action=dropped proto=6 service=NONE count=9 attack="IP.Bad.Header" attackid=127 profile="N/A" ref="http://www.fortinet.com/ids/VID127" msg="anomaly: IP.Bad.Header, repeats 9 times" crscore=50 crlevel=critical
 -->
+
+
 <decoder name="fortigate-firewall-v5-anomaly">
     <parent>fortigate-firewall-v5</parent>
-    <prematch offset="after_parent">type=anomaly</prematch>
-    <regex offset="after_parent">severity=(\w+) srcip=(\S+) dstip=(\S+) srcintf=\S+ sessionid=\S+ action=(\w+) proto=\d+ service=(\S+) count=\d+ (attack)="(\.+)"</regex>
-    <order>status, srcip, dstip, action, protocol, id, extra_data</order>
+    <prematch offset="after_parent">type="anomaly"|type=anomaly</prematch>
+    <regex offset="after_parent">\.*severity="(\S+)"|\.*severity=(\S+),|\.*severity=(\S+) </regex>
+    <order>status</order>
 </decoder>
+
+<decoder name="fortigate-firewall-v5-anomaly">
+    <parent>fortigate-firewall-v5</parent>
+    <regex offset="after_regex">\.*srcip="(\S+)"|\.*srcip=(\S+),|\.*srcip=(\S+) </regex>
+    <order>srcip</order>
+</decoder>
+
+<decoder name="fortigate-firewall-v5-anomaly">
+    <parent>fortigate-firewall-v5</parent>
+    <regex offset="after_regex">\.*dstip="(\S+)"|\.*dstip=(\S+),|\.*dstip=(\S+) </regex>
+    <order>dstip</order>
+</decoder>
+
+<decoder name="fortigate-firewall-v5-anomaly">
+    <parent>fortigate-firewall-v5</parent>
+    <regex offset="after_regex">\.*action="(\S+)"|\.*action=(\S+),|\.*action=(\S+) </regex>
+    <order>action</order>
+</decoder>
+
+<decoder name="fortigate-firewall-v5-anomaly">
+    <parent>fortigate-firewall-v5</parent>
+    <regex offset="after_regex">\.*service="(\S+)"|\.*service=(\S+),|\.*service=(\S+) </regex>
+    <order>service</order>
+</decoder>
+
+<decoder name="fortigate-firewall-v5-anomaly">
+    <parent>fortigate-firewall-v5</parent>
+    <regex offset="after_regex">\.*(attack)="(\S+)"|\.*(attack)=(\S+),|\.*(attack)=(\S+) </regex>
+    <order>id, extra_data</order>
+</decoder>
+
 
 <!--
 date=2016-06-15 time=11:44:46 devname=Device_Name devid=FGTXXXX9999999999 logid=9999999999 type=utm subtype=webfilter eventtype=urlfilter level=warning vd="root" urlfilteridx=3 urlfilterlist="default" policyid=2 sessionid=1563645 user="" srcip=1.2.3.11 srcport=52414 srcintf="internal2" dstip=1.5.5.92 dstport=443 dstintf="wan2" proto=6 service=HTTPS hostname="4-edge-chat.facebook.com" profile="default" action=blocked reqtype=referral url="/p?partition=-2&cb=lz1k&failure=5&sticky_token=274&sticky_pool=atn2c06_chat-proxy" sentbyte=932 rcvdbyte=0 direction=outgoing msg="URL was blocked because it is in the URL filter list" crscore=30 crlevel=high
@@ -88,10 +163,106 @@ date=2016-06-15 time=11:44:46 devname=Device_Name devid=FGTXXXX9999999999 logid=
 -->
 <decoder name="fortigate-firewall-v5-utm-webfilter">
     <parent>fortigate-firewall-v5</parent>
-    <prematch offset="after_parent">type=utm subtype=webfilter</prematch>
-    <regex offset="after_parent">level=(\S+) \.+ user="(\.*)" srcip=(\S+) srcport=(\d+) \.+ dstip=(\S+) dstport=(\d+) \.+ hostname="(\.+)" \.+ action=(\w+)</regex>
-    <order>status,srcuser,srcip,srcport,dstip,dstport,url,action</order>
+    <prematch offset="after_parent">type=utm subtype=webfilter|type=utm,subtype=webfilter|type="utm" subtype="webfilter"</prematch>
+    <regex offset="after_prematch">\.*level="(\S+)"|\.*level=(\S+),|\.*level=(\S+) </regex>
+    <order>status</order>
 </decoder>
+
+<decoder name="fortigate-firewall-v5-utm-webfilter">
+    <parent>fortigate-firewall-v5</parent>
+    <regex offset="after_regex">\.*user="(\.*)"|\.*user=(\.*),|\.*user=(\.*) </regex>
+    <order>srcuser</order>
+</decoder>
+
+<decoder name="fortigate-firewall-v5-utm-webfilter">
+    <parent>fortigate-firewall-v5</parent>
+    <regex offset="after_regex">\.*srcip="(\S+)"|\.*srcip=(\S+),|\.*srcip=(\S+) </regex>
+    <order>srcip</order>
+</decoder>
+
+<decoder name="fortigate-firewall-v5-utm-webfilter">
+    <parent>fortigate-firewall-v5</parent>
+    <regex offset="after_regex">\.*srcport="(\d+)"|\.*srcport=(\d+),|\.*srcport=(\d+) </regex>
+    <order>srcport</order>
+</decoder>
+
+<decoder name="fortigate-firewall-v5-utm-webfilter">
+    <parent>fortigate-firewall-v5</parent>
+    <regex offset="after_regex">\.*dstip="(\S+)"|\.*dstip=(\S+),|\.*dstip=(\S+) </regex>
+    <order>dstip</order>
+</decoder>
+
+<decoder name="fortigate-firewall-v5-utm-webfilter">
+    <parent>fortigate-firewall-v5</parent>
+    <regex offset="after_regex">\.*dstport="(\d+)"|\.*dstport=(\d+),|\.*dstport=(\d+) </regex>
+    <order>dstport</order>
+</decoder>
+
+<decoder name="fortigate-firewall-v5-utm-webfilter">
+    <parent>fortigate-firewall-v5</parent>
+    <regex offset="after_regex">\.*hostname="(\.+)"|\.*hostname=(\.+),|\.*hostname=(\.+) </regex>
+    <order>url</order>
+</decoder>
+
+<decoder name="fortigate-firewall-v5-utm-webfilter">
+    <parent>fortigate-firewall-v5</parent>
+    <regex offset="after_regex">\.*action="(\S+)"|\.*action=(\S+),|\.*action=(\S+) </regex>
+    <order>action</order>
+</decoder>
+
+<!--
+2018 Apr 09 16:03:37 inwazuhmgr->172.24.0.253 date=2018-04-09 time=16:03:37 devname=BA-RSYS-FW devid=FG600C3912803212 logid="1059028704" type="utm" subtype="app-ctrl" eventtype="app-ctrl-all" level="information" vd="BA-EXORA" logtime=1523270017 appid=16009 srcip=172.24.42.175 dstip=111.221.29.254 srcport=55139 dstport=443 srcintf="port3" srcintfrole="wan" dstintf="port5" dstintfrole="undefined" proto=6 service="HTTPS" policyid=107 sessionid=3454887534 applist="block-high-risk" appcat="Update" app="MS.Windows.Update" action="pass" hostname="*.vortex-win.data.microsoft.com" incidentserialno=1405558813 url="/" msg="Update: MS.Windows.Update," apprisk="elevated" scertcname="*.vortex-win.data.microsoft.com"
+-->
+
+<decoder name="fortigate-firewall-v5-utm-app-ctrl">
+    <parent>fortigate-firewall-v5</parent>
+    <prematch offset="after_parent">type=utm subtype=app-ctrl|type=utm,subtype=app-ctrl|type="utm" subtype="app-ctrl"</prematch>
+    <regex offset="after_prematch">\.*level="(\S+)"|\.*level=(\S+),|\.*level=(\S+) </regex>
+    <order>status</order>
+</decoder>
+
+<decoder name="fortigate-firewall-v5-utm-app-ctrl">
+    <parent>fortigate-firewall-v5</parent>
+    <regex offset="after_regex">\.*user="(\.*)"|\.*user=(\.*),|\.*user=(\.*) </regex>
+    <order>srcuser</order>
+</decoder>
+
+<decoder name="fortigate-firewall-v5-utm-app-ctrl">
+    <parent>fortigate-firewall-v5</parent>
+    <regex offset="after_regex">\.*srcip="(\S+)"|\.*srcip=(\S+),|\.*srcip=(\S+) </regex>
+    <order>srcip</order>
+</decoder>
+
+<decoder name="fortigate-firewall-v5-utm-app-ctrl">
+    <parent>fortigate-firewall-v5</parent>
+    <regex offset="after_regex">\.*srcport="(\d+)"|\.*srcport=(\d+),|\.*srcport=(\d+) </regex>
+    <order>srcport</order>
+</decoder>
+
+<decoder name="fortigate-firewall-v5-utm-app-ctrl">
+    <parent>fortigate-firewall-v5</parent>
+    <regex offset="after_regex">\.*dstip="(\S+)"|\.*dstip=(\S+),|\.*dstip=(\S+) </regex>
+    <order>dstip</order>
+</decoder>
+
+<decoder name="fortigate-firewall-v5-utm-app-ctrl">
+    <parent>fortigate-firewall-v5</parent>
+    <regex offset="after_regex">\.*dstport="(\d+)"|\.*dstport=(\d+),|\.*dstport=(\d+) </regex>
+    <order>dstport</order>
+</decoder>
+
+<decoder name="fortigate-firewall-v5-utm-app-ctrl">
+    <parent>fortigate-firewall-v5</parent>
+    <regex offset="after_regex">\.*action="(\S+)"|\.*action=(\S+),|\.*action=(\S+) </regex>
+    <order>action</order>
+</decoder>
+
+<decoder name="fortigate-firewall-v5-utm-app-ctrl">
+    <parent>fortigate-firewall-v5</parent>
+    <regex offset="after_regex">\.*hostname="(\.+)"|\.*hostname=(\.+),|\.*hostname=(\.+) </regex>
+    <order>url</order>
+</decoder>
+
 
 <!--
 date=2016-06-16 time=09:03:03 devname=Device_Name devid=FGTXXXX9999999999 logid=9999999999 type=event subtype=system level=information vd="root" logdesc="Object attribute configured" user="admin" ui="GUI(4.3.5.8)" action=Edit cfgtid=2162752 cfgpath="firewall.service.custom" cfgobj="Custom-TCP_10443" cfgattr="tcp-portrange[->10443]udp-portrange[->]sctp-portrange[->]" msg="Edit firewall.service.custom Custom-TCP_10443"
@@ -106,57 +277,100 @@ date=2016-06-16 time=08:48:28 devname=Device_Name devid=FGTXXXX9999999999 logid=
 
 date=2016-06-16 time=16:22:34 devname=Mobipay_Firewall devid=FGTXXXX9999999999 logid=0100032001 type=event subtype=system level=information vd="root" logdesc="Admin login successful" sn=1466090554 user="a@b.com.na" ui=https(10.42.8.253) action=login status=success reason=none profile="super_admin" msg="Administrator a@b.com.na logged in successfully from https(10.42.8.253)"
 -->
+
 <decoder name="fortigate-firewall-v5-event-system-information">
     <parent>fortigate-firewall-v5</parent>
-    <prematch offset="after_parent">type=event subtype=system level=information|type="event" subtype="system" level="information"</prematch>
-    <regex offset="after_parent">user="(\S+)" ui=\p*\w+\((\S+)\)\p* action=(\S+) |user="(\S+)" ui=\p*\w+\((\S+)\)\p* \.*action="(\S+)" </regex>
-    <order>srcuser,srcip,action</order>
+    <prematch offset="after_parent">type=event subtype=system level=information|type=event,subtype=system,level=information|type="event" subtype="system" level="information"</prematch>
+    <regex offset="after_prematch">\.*user="(\S+)"|\.*user(\S+)</regex>
+    <order>srcuser</order>
 </decoder>
 
 <decoder name="fortigate-firewall-v5-event-system-information">
     <parent>fortigate-firewall-v5</parent>
-    <regex offset="after_regex">cfgtid=(\d+) \.*cfgattr=(\.*) msg=(\.*)</regex>
-    <order>id,url,extra_data</order>
+    <regex offset="after_regex">ui=\p*\w+\((\S+)\)\p*</regex>
+    <order>srcip</order>
 </decoder>
 
 <decoder name="fortigate-firewall-v5-event-system-information">
     <parent>fortigate-firewall-v5</parent>
-    <regex offset="after_regex">status=(\S+) \.*msg=(\.*)|status="(\S+)" \.*msg=(\.*)</regex>
-    <order>status,extra_data</order>
+    <regex offset="after_regex">\.*action="(\S+)"|\.*action=(\S+)</regex>
+    <order>action</order>
 </decoder>
+
+<decoder name="fortigate-firewall-v5-event-system-information">
+    <parent>fortigate-firewall-v5</parent>
+    <regex offset="after_regex">\.*cfgtid="(\d+)"|\.*cfgtid=(\d+)</regex>
+    <order>id</order>
+</decoder>
+
+<decoder name="fortigate-firewall-v5-event-system-information">
+    <parent>fortigate-firewall-v5</parent>
+    <regex offset="after_regex">\.*cfgattr="(\.*)"|\.*cfgattr=(\.*)</regex>
+    <order>url</order>
+</decoder>
+
+<decoder name="fortigate-firewall-v5-event-system-information">
+    <parent>fortigate-firewall-v5</parent>
+    <regex offset="after_regex">\.*ip="(\S+)"|\.*ip=(\S+)</regex>
+    <order>src_ip</order>
+</decoder>
+
+<decoder name="fortigate-firewall-v5-event-system-information">
+    <parent>fortigate-firewall-v5</parent>
+    <regex offset="after_regex">\.*srcip="(\S+)"|\.*srcip=(\S+)</regex>
+    <order>src_ip</order>
+</decoder>
+
+<decoder name="fortigate-firewall-v5-event-system-information">
+    <parent>fortigate-firewall-v5</parent>
+    <regex offset="after_regex">\.*status="(\S+)"|\.*status=(\S+)</regex>
+    <order>status</order>
+</decoder>
+
+<decoder name="fortigate-firewall-v5-event-system-information">
+    <parent>fortigate-firewall-v5</parent>
+    <regex offset="after_regex"> msg="(\.*)"|,msg=(\.*)</regex>
+    <order>extra_data</order>
+</decoder>
+
+
+
 
 <!--
 date=2016-06-14 time=12:22:01 devname=Device_Name devid=FGTXXXX9999999999 logid=9999999999 type=event subtype=system level=alert vd="root" logdesc="Admin login failed" sn=0 user="gfedhf" ui=https(4.3.5.253) action=login status=failed reason="name_invalid" msg="Administrator gfedhf login failed from https(4.3.5.253) because of invalid user name"
 
 date=2016-06-17 time=02:37:41 devname=Mobipay_Firewall devid=FGTXXXX9999999999 logid=0100032002 type=event subtype=system level=alert vd="root" logdesc="Admin login failed" sn=0 user="root" ui=ssh(222.186.130.227) action=login status=failed reason="name_invalid" msg="Administrator root login failed from ssh(222.186.130.227) because of invalid user name"
 -->
+
 <decoder name="fortigate-firewall-v5-event-system-alert-fields1">
     <parent>fortigate-firewall-v5</parent>
-    <prematch offset="after_parent">type=event subtype=system level=alert vd="\S+" logdesc="\.+" sn=\S+ </prematch>
-    <regex offset="after_prematch">user="(\S+)" ui=\w+\((\S+)\) action=(\S+) status=(\S+) reason="\.+" msg="(\.+)"$</regex>
-    <order>user,srcip,action,status,extra_data</order>
+    <prematch offset="after_parent">type=event subtype=system level=alert|type=event,subtype=system,level=alert|type="event" subtype="system" level="alert"</prematch>
+    <regex offset="after_prematch">\.*user="(\S+)"|\.*user=(\S+),|\.*user=(\S+) </regex>
+    <order>srcuser</order>
 </decoder>
 
-<!--
-date=2016-06-14 time=10:47:23 devname=Device_Name devid=FGTXXXX9999999999 logid=9999999999 type=event subtype=system level=alert vd="root" logdesc="Configuration changed" user="admin" ui=https(105.232.255.15) msg="Configuration is changed in the admin session"
-
-date=2016-06-16 time=08:48:28 devname=Mobipay_Firewall devid=FGTXXXX9999999999 logid=0100032400 type=event subtype=system level=alert vd="root" logdesc="Configuration changed" user="a@b.com.na" ui=https(10.42.8.253) msg="Configuration is changed in the admin session"
--->
-<decoder name="fortigate-firewall-v5-event-system-alert-fields2">
+<decoder name="fortigate-firewall-v5-event-system-alert-fields1">
     <parent>fortigate-firewall-v5</parent>
-    <prematch offset="after_parent">type=event subtype=system level=alert vd="\S+" logdesc="\.+" user=</prematch>
-    <regex offset="after_prematch">"(\.+)" ui=\w+\((\S+)\) msg="(\.+)"</regex>
-    <order>user,srcip,extra_data</order>
+    <regex offset="after_regex">ui=\p*(\w+)\((\S+)\)\p*</regex>
+    <order>protocol,srcip</order>
 </decoder>
 
-<!--
-date=2016-06-14 time=12:22:03 devname=Device_Name devid=FGTXXXX9999999999 logid=9999999999 type=event subtype=system level=alert vd="root" logdesc="Admin login disabled" ui=4.3.5.253 action=login status=failed reason=exceed_limit msg="Login disabled from IP 4.3.5.253 for 60 seconds because of 3 bad attempts"
--->
-<decoder name="fortigate-firewall-v5-event-system-alert-fields3">
+<decoder name="fortigate-firewall-v5-event-system-alert-fields1">
     <parent>fortigate-firewall-v5</parent>
-    <prematch offset="after_parent">type=event subtype=system level=alert vd="\S+" logdesc="\.+" ui=</prematch>
-    <regex offset="after_prematch">(\S+) action=(\S+) status=(\S+) reason=\S+ msg="(\.+)"</regex>
-    <order>srcip,action,status,extra_data</order>
+    <regex offset="after_regex">\.*action="(\S+)"|\.*action=(\S+),|\.*action=(\S+) </regex>
+    <order>action</order>
+</decoder>
+
+<decoder name="fortigate-firewall-v5-event-system-alert-fields1">
+    <parent>fortigate-firewall-v5</parent>
+    <regex offset="after_regex">\.*status="(\S+)"|\.*status=(\S+),|\.*status=(\S+) </regex>
+    <order>status</order>
+</decoder>
+
+<decoder name="fortigate-firewall-v5-event-system-alert-fields1">
+    <parent>fortigate-firewall-v5</parent>
+    <regex offset="after_regex">\.*msg="(\.+)"|\.*msg=(\.+),|\.*msg=(\.+) </regex>
+    <order>extra_data</order>
 </decoder>
 
 <!--
@@ -167,12 +381,46 @@ date=2016-06-15 time=21:35:09 devname=Device_Name devid=FGTXXXX9999999999 logid=
 date=2016-06-16 time=08:47:00 devname=Device_Name devid=FGTXXXX9999999999 logid=0101039947 type=event subtype=vpn level=information vd="root" logdesc="SSL VPN tunnel up" action="tunnel-up" tunneltype="ssl-tunnel" tunnelid=1050355638 remip=9.8.7.7 tunnelip=1.2.4.6 user="my_user_name" group="SSL_VPN" dst_host="N/A" reason="N/A" msg="SSL tunnel established"
 
 date=2016-06-16 time=08:49:26 devname=Device_Name devid=FGTXXXX9999999999 logid=0101039948 type=event subtype=vpn level=information vd="root" logdesc="SSL VPN tunnel down" action="tunnel-down" tunneltype="ssl-tunnel" tunnelid=1050355638 remip=5.7.8.9 tunnelip=8.4.2.1 user="my_user_name" group="SSL_VPN" dst_host="N/A" reason="N/A" duration=147 sentbyte=2284 rcvdbyte=2630 msg="SSL tunnel shutdown"
--->
+
 <decoder name="fortigate-firewall-v5-event-vpn-fields1">
     <parent>fortigate-firewall-v5</parent>
     <prematch offset="after_parent">type=event subtype=vpn level=\S+ vd="\.+" logdesc="\.+" msg="\.+" action=</prematch>
     <regex>logdesc="(\.+)" msg=\.+ action=(\.*) remip=(\S+) locip=(\S+) \.+ status=(\S+)</regex>
     <order>extra_data,action,dstip,srcip,status</order>
+</decoder>
+-->
+
+
+
+<decoder name="fortigate-firewall-v5-event-vpn-fields1">
+    <parent>fortigate-firewall-v5</parent>
+    <prematch offset="after_parent">type=event subtype=vpn|type="event" subtype="vpn"|type=event,subtype=vpn</prematch>
+    <regex offset="after_prematch">\.*logdesc="(\.+)"</regex>
+    <order>extra_data</order>
+</decoder>
+
+<decoder name="fortigate-firewall-v5-event-vpn-fields1">
+    <parent>fortigate-firewall-v5</parent>
+    <regex offset="after_regex">\.*action="(\S+)"|\.*action=(\S+),|\.*action=(\S+) </regex>
+    <order>action</order>
+</decoder>
+
+<decoder name="fortigate-firewall-v5-event-vpn-fields1">
+    <parent>fortigate-firewall-v5</parent>
+    <regex offset="after_regex">\.*remip="(\S+)"|\.*remip=(\S+),|\.*remip=(\S+) </regex>
+    <order>dstip</order>
+</decoder>
+
+<decoder name="fortigate-firewall-v5-event-vpn-fields1">
+    <parent>fortigate-firewall-v5</parent>
+    <regex offset="after_regex">\.*locip="(\S+)"|\.*locip=(\S+),|\.*locip=(\S+) </regex>
+    <order>srcip</order>
+</decoder>
+
+<decoder name="fortigate-firewall-v5-event-vpn-fields1">
+    <parent>fortigate-firewall-v5</parent>
+    <regex offset="after_regex">\.*status="(\S+)"|\.*status=(\S+),|\.*status=(\S+) </regex>
+    <order>status</order>
 </decoder>
 
 <decoder name="fortigate-firewall-v5-event-vpn-fields2">
@@ -189,7 +437,107 @@ date=2016-06-16 time=10:49:08 devname=Device_Name devid=FGTXXXX9999999999 logid=
 -->
 <decoder name="fortigate-firewall-v5-traffic">
     <parent>fortigate-firewall-v5</parent>
-    <prematch offset="after_parent">type=traffic</prematch>
-    <regex>srcip=(\S+) srcport=(\d+) \.+ dstip=(\S+) dstport=(\d+) \.+ appcat="(\.+)" apprisk=(\w+) applist=</regex>
-    <order>srcip,srcport,dstip,dstport,protocol,status</order>
+    <prematch offset="after_parent">type=traffic|type="traffic"</prematch>
+    <regex offset="after_prematch">\.*srcip="(\S+)"|\.*srcip=(\S+),|\.*srcip=(\S+) </regex>
+    <order>srcip</order>
+</decoder>
+
+<decoder name="fortigate-firewall-v5-traffic">
+    <parent>fortigate-firewall-v5</parent>
+    <regex offset="after_regex">\.*srcport="(\d+)"|\.*srcport=(\d+),|\.*srcport=(\d+) </regex>
+    <order>srcport</order>
+</decoder>
+
+<decoder name="fortigate-firewall-v5-traffic">
+    <parent>fortigate-firewall-v5</parent>
+    <regex offset="after_regex">\.*dstip="(\S+)"|\.*dstip=(\S+),|\.*dstip=(\S+) </regex>
+    <order>dstip</order>
+</decoder>
+
+<decoder name="fortigate-firewall-v5-traffic">
+    <parent>fortigate-firewall-v5</parent>
+    <regex offset="after_regex">\.*dstport="(\d+)"|\.*dstport=(\d+),|\.*dstport=(\d+) </regex>
+    <order>dstport</order>
+</decoder>
+
+<decoder name="fortigate-firewall-v5-traffic">
+    <parent>fortigate-firewall-v5</parent>
+    <regex offset="after_regex">\.*appcat="(\.+)"|\.*appcat=(\.+),|\.*appcat=(\.+) </regex>
+    <order>protocol</order>
+</decoder>
+
+<decoder name="fortigate-firewall-v5-traffic">
+    <parent>fortigate-firewall-v5</parent>
+    <regex offset="after_regex">\.*apprisk="(\S+)"|\.*apprisk=(\S+),|\.*apprisk=(\S+) </regex>
+    <order>status</order>
+</decoder>
+
+<!--
+date=2018-05-31 time=08:58:56 devname="BA-RSYS-FW" devid="FG600C3912803212" logid="0211008192" type="utm" subtype="virus" eventtype="infected" level="warning" vd="BA-EXORA" eventtime=1527737336 msg="File is infected." action="blocked" service="HTTP" sessionid=377413095 srcip=172.24.12.52 dstip=164.100.80.203 srcport=64982 dstport=80 srcintf="port5" srcintfrole="undefined" dstintf="port3" dstintfrole="wan" policyid=108 proto=6 direction="incoming" filename="FrontPageImgHandler.ashx" quarskip="File-was-not-quarantined." virus="Malware_Generic.P0" dtype="Virus" ref="http://www.fortinet.com/ve?vn=Malware_Generic.P0" virusid=7024603 url="http://www.karsec.gov.in/FrontPageImgHandler.ashx?id=12" profile="Web-Browsing" agent="Chrome/66.0.3359.181" analyticscksum="a9165dbae34e6e2952270536e95a2bb154dff0cfcdf41315f0796ee14b36123b" analyticssubmit="false" crscore=50 crlevel="critical"
+-->
+<decoder name="fortigate-firewall-v5-utm-virus">
+    <parent>fortigate-firewall-v5</parent>
+    <prematch offset="after_parent">type=utm subtype=virus|type=utm,subtype=virus|type="utm" subtype="virus"</prematch>
+    <regex offset="after_prematch">\.*eventtype="(\S+)"|\.*eventtype=(\S+),|\.*eventtype=(\S+) </regex>
+    <order>protocol</order>
+</decoder>
+
+<decoder name="fortigate-firewall-v5-utm-virus">
+    <parent>fortigate-firewall-v5</parent>
+    <regex offset="after_regex">\.*level="(\S+)"|\.*level=(\S+),|\.*level=(\S+) </regex>
+    <order>status</order>
+</decoder>
+
+<decoder name="fortigate-firewall-v5-utm-virus">
+    <parent>fortigate-firewall-v5</parent>
+    <regex offset="after_regex">\.*action="(\S+)"|\.*action=(\S+),|\.*action=(\S+) </regex>
+    <order>action</order>
+</decoder>
+
+<decoder name="fortigate-firewall-v5-utm-virus">
+    <parent>fortigate-firewall-v5</parent>
+    <regex offset="after_regex">\.*user="(\.*)"|\.*user=(\.*),|\.*user=(\.*) </regex>
+    <order>srcuser</order>
+</decoder>
+
+<decoder name="fortigate-firewall-v5-utm-virus">
+    <parent>fortigate-firewall-v5</parent>
+    <regex offset="after_regex">\.*srcip="(\S+)"|\.*srcip=(\S+),|\.*srcip=(\S+) </regex>
+    <order>srcip</order>
+</decoder>
+
+<decoder name="fortigate-firewall-v5-utm-virus">
+    <parent>fortigate-firewall-v5</parent>
+    <regex offset="after_regex">\.*dstip="(\S+)"|\.*dstip=(\S+),|\.*dstip=(\S+) </regex>
+    <order>dstip</order>
+</decoder>
+
+<decoder name="fortigate-firewall-v5-utm-virus">
+    <parent>fortigate-firewall-v5</parent>
+    <regex offset="after_regex">\.*srcport="(\d+)"|\.*srcport=(\d+),|\.*srcport=(\d+) </regex>
+    <order>srcport</order>
+</decoder>
+
+<decoder name="fortigate-firewall-v5-utm-virus">
+    <parent>fortigate-firewall-v5</parent>
+    <regex offset="after_regex">\.*dstport="(\d+)"|\.*dstport=(\d+),|\.*dstport=(\d+) </regex>
+    <order>dstport</order>
+</decoder>
+
+<decoder name="fortigate-firewall-v5-utm-virus">
+    <parent>fortigate-firewall-v5</parent>
+    <regex offset="after_regex">\.*filename="(\.+)"|\.*filename=(\.+),|\.*filename=(\.+) </regex>
+    <order>fortigate.file_infected</order>
+</decoder>
+
+<decoder name="fortigate-firewall-v5-utm-virus">
+    <parent>fortigate-firewall-v5</parent>
+    <regex offset="after_regex">\.*virus="(\.+)"|\.*virus=(\.+),|\.*virus=(\.+) </regex>
+    <order>fortigate.virus_found</order>
+</decoder>
+
+<decoder name="fortigate-firewall-v5-utm-virus">
+    <parent>fortigate-firewall-v5</parent>
+    <regex offset="after_regex">\.*url="(\.+)"|\.*url=(\.+),|\.*url=(\.+) </regex>
+    <order>url</order>
 </decoder>

--- a/decoders/0100-fortigate_decoders.xml
+++ b/decoders/0100-fortigate_decoders.xml
@@ -54,7 +54,7 @@ Feb 20 12:31:11 date=2011-02-20 time=12: 31:09 devname=Name_of_Device device_id=
 
 <!-- FortiOS 5.0 via syslog -->
 <decoder name="fortigate-firewall-v5">
-    <prematch>date=\S+ time=\.+ devname=\S+ devid=FG\w+ logid=\d+ </prematch>
+    <prematch>date=\S+ time=\.+ devname=\S+ devid=FG\w+ logid=\d+ |date=\S+ time=\.+ devname="\S+" devid="FG\w+" logid="\d+" </prematch>
     <type>syslog</type>
 </decoder>
 
@@ -108,8 +108,8 @@ date=2016-06-16 time=16:22:34 devname=Mobipay_Firewall devid=FGTXXXX9999999999 l
 -->
 <decoder name="fortigate-firewall-v5-event-system-information">
     <parent>fortigate-firewall-v5</parent>
-    <prematch offset="after_parent">type=event subtype=system level=information</prematch>
-    <regex offset="after_parent">user="(\S+)" ui=\p*\w+\((\S+)\)\p* action=(\S+) </regex>
+    <prematch offset="after_parent">type=event subtype=system level=information|type="event" subtype="system" level="information"</prematch>
+    <regex offset="after_parent">user="(\S+)" ui=\p*\w+\((\S+)\)\p* action=(\S+) |user="(\S+)" ui=\p*\w+\((\S+)\)\p* \.*action="(\S+)" </regex>
     <order>srcuser,srcip,action</order>
 </decoder>
 
@@ -121,7 +121,7 @@ date=2016-06-16 time=16:22:34 devname=Mobipay_Firewall devid=FGTXXXX9999999999 l
 
 <decoder name="fortigate-firewall-v5-event-system-information">
     <parent>fortigate-firewall-v5</parent>
-    <regex offset="after_regex">status=(\S+) \.*msg=(\.*)</regex>
+    <regex offset="after_regex">status=(\S+) \.*msg=(\.*)|status="(\S+)" \.*msg=(\.*)</regex>
     <order>status,extra_data</order>
 </decoder>
 

--- a/rules/0390-fortigate_rules.xml
+++ b/rules/0390-fortigate_rules.xml
@@ -37,14 +37,14 @@ ID: 81600 - 80799
         <if_sid>81603</if_sid>
         <status>dpd_failure</status>
         <description>Fortigate: IP Sec DPD Failed.</description>
-        <group>firewall_drop,pci_dss_1.4,gdpr_IV_35.7.d,</group>
+        <group>firewall_drop,pci_dss_1.4,</group>
     </rule>
 
     <rule id="81605" level="7" frequency="16" timeframe="45" ignore="240">
         <if_matched_sid>81604</if_matched_sid>
         <same_source_ip />
         <description>Fortigate: Multiple Firewall drop events from same source.</description>
-        <group>multiple_drops,pci_dss_1.4,pci_dss_10.6.1,gdpr_IV_35.7.d,</group>
+        <group>multiple_drops,pci_dss_1.4,pci_dss_10.6.1,</group>
     </rule>
 
 
@@ -56,7 +56,7 @@ ID: 81600 - 80799
         <action>login</action>
         <status>failed</status>
         <description>Fortigate: Login failed.</description>
-        <group>authentication_failed,invalid_login,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
+        <group>authentication_failed,invalid_login,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,</group>
     </rule>
 
     <rule id="81607" level="7" frequency="16" timeframe="45" ignore="240">
@@ -64,7 +64,7 @@ ID: 81600 - 80799
         <same_source_ip />
         <options>alert_by_email</options>
         <description>Fortigate: Multiple failed login events from same source.</description>
-        <group>authentication_failures,pci_dss_10.6.1,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
+        <group>authentication_failures,pci_dss_10.6.1,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,</group>
     </rule>
 
 
@@ -76,14 +76,12 @@ ID: 81600 - 80799
         <match>Configuration is changed in the admin session</match>
         <options>alert_by_email</options>
         <description>Fortigate: Configuration changed.</description>
-        <group>gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
     </rule>
 
     <rule id="81609" level="8" frequency="16" timeframe="45" ignore="240">
         <if_matched_sid>81608</if_matched_sid>
         <same_source_ip />
         <description>Fortigate: Multiple changed configuration events from same source.</description>
-        <group>gdpr_IV_35.7.d,</group>
     </rule>
 
     <!--
@@ -93,7 +91,7 @@ ID: 81600 - 80799
         <if_sid>81603</if_sid>
         <match>http_decoder: HTTP.Unknown.Tunnelling</match>
         <description>Fortigate: Default tunneling setting. Could be IPS.</description>
-        <group>pci_dss_10.6.1,gdpr_IV_35.7.d,</group>
+        <group>pci_dss_10.6.1,</group>
     </rule>
 
     <rule id="81611" level="7" frequency="16" timeframe="45" ignore="240">
@@ -101,7 +99,7 @@ ID: 81600 - 80799
         <same_source_ip />
         <options>alert_by_email</options>
         <description>Fortigate: Multiple default tunneling setting events from same source.</description>
-        <group>pci_dss_10.6.1,gdpr_IV_35.7.d,</group>
+        <group>pci_dss_10.6.1,</group>
     </rule>
 
     <!--
@@ -111,14 +109,31 @@ ID: 81600 - 80799
         <if_sid>81603</if_sid>
         <action>Edit</action>
         <description>Fortigate: Firewall configuration changes</description>
-        <group>pci_dss_10.6.1,gpg13_4.13,gdpr_IV_35.7.d,</group>
+        <group>pci_dss_10.6.1,gpg13_4.13,</group>
     </rule>
 
     <rule id="81613" level="4" frequency="16" timeframe="45" ignore="240">
         <if_matched_sid>81612</if_matched_sid>
         <same_source_ip />
         <description>Fortigate: Multiple Firewall edit events from same source.</description>
-        <group>pci_dss_10.6.1,gpg13_4.13,gdpr_IV_35.7.d,</group>
+        <group>pci_dss_10.6.1,gpg13_4.13,</group>
+    </rule>
+
+    <!--
+    date=2016-06-16 time=09:03:03 devname=Device_Name devid=FGTXXXX9999999999 logid=9999999999 type=event subtype=system level=information vd="root" logdesc="Object attribute configured" user="admin" ui="GUI(4.3.5.8)" action=Add cfgtid=2162750 cfgpath="firewall.service.custom" cfgobj="Custom-TCP_10443" cfgattr="" msg="Add firewall.service.custom Custom-TCP_10443"
+    -->
+        <rule id="81631" level="3">
+        <if_sid>81603</if_sid>
+        <action>Add</action>
+        <description>Fortigate: Firewall configuration changes</description>
+        <group>pci_dss_1.4,gpg13_4.13,</group>
+    </rule>
+
+    <rule id="81632" level="4" frequency="16" timeframe="45" ignore="240">
+        <if_matched_sid>81631</if_matched_sid>
+        <same_source_ip />
+        <description>Fortigate: Multiple Firewall edit events from same source.</description>
+        <group>pci_dss_1.4,ci_dss_10.6.1,gpg13_4.13,gdpr_2.3,</group>
     </rule>
 
 
@@ -129,7 +144,7 @@ ID: 81600 - 80799
         <if_sid>81603</if_sid>
         <match>ssl-login-fail</match>
         <description>Fortigate: SSL VPN User failed login attempt</description>
-        <group>authentication_failed,invalid_login,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
+        <group>authentication_failed,invalid_login,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,</group>
     </rule>
 
     <rule id="81615" level="7" frequency="16" timeframe="45" ignore="240">
@@ -137,7 +152,7 @@ ID: 81600 - 80799
         <same_source_ip />
         <options>alert_by_email</options>
         <description>Fortigate: Multiple Firewall SSL VPN failed login events from same source.</description>
-        <group>authentication_failures,pci_dss_10.6.1,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
+        <group>authentication_failures,pci_dss_10.6.1,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,</group>
     </rule>
 
     <!--
@@ -148,25 +163,24 @@ ID: 81600 - 80799
         <action>logout</action>
         <status>success</status>
         <description>Fortigate: User logout successful</description>
-        <group>pci_dss_10.2.5,gpg13_7.1,gpg13_7.2,gdpr_IV_32.2,</group>
+        <group>pci_dss_10.2.5,gpg13_7.1,gpg13_7.2,</group>
     </rule>
 
     <rule id="81617" level="7" frequency="16" timeframe="45" ignore="240">
         <if_matched_sid>81616</if_matched_sid>
         <same_source_ip />
         <description>Fortigate: Multiple Firewall logout events from same source.</description>
-        <group>pci_dss_10.2.5,gpg13_7.1,gdpr_IV_32.2,</group>
+        <group>pci_dss_10.2.5,gpg13_7.1,</group>
     </rule>
 
     <!--
     date=2016-06-16 time=10:49:08 devname=Device_Name devid=FGTXXXX9999999999 logid=0000000013 type=traffic subtype=forward level=notice vd=root srcip=4.3.5.161 srcport=51082 srcintf="internal1" dstip=54.192.197.185 dstport=80 dstintf="wan1" poluuid=d6217c58-8c42-51e5-c3a6-c7766895cbfd sessionid=199618 proto=6 action=deny policyid=8 dstcountry="United States" srccountry="Reserved" trandisp=snat transip=160.242.8.82 transport=51082 service="HTTP" appid=6 app="BitTorrent" appcat="P2P" apprisk=high applist="default" appact=drop-session duration=3 sentbyte=60 rcvdbyte=3050 sentpkt=1 utmaction=block countapp=1 crscore=5 craction=1048576
     -->
-    <rule id="81618" level="1">
+    <rule id="81618" level="3">
         <if_sid>81603</if_sid>
-        <match>type=traffic</match>
-        <status>high</status>
+        <match>type=traffic|type="traffic"</match>
         <description>Fortigate: Traffic to be aware of.</description>
-        <group>pci_dss_10.6.1,gdpr_IV_35.7.d,</group>
+        <group>pci_dss_10.6.1,</group>
     </rule>
 
     <rule id="81619" level="3" frequency="16" timeframe="45" ignore="240">
@@ -174,25 +188,25 @@ ID: 81600 - 80799
         <same_source_ip />
         <options>alert_by_email</options>
         <description>Fortigate: Multiple high traffic events from same source.</description>
-        <group>pci_dss_10.6.1,gdpr_IV_35.7.d,</group>
+        <group>pci_dss_10.6.1,</group>
     </rule>
 
     <!--
     date=2016-06-15 time=11:44:46 devname=Device_Name devid=FGTXXXX9999999999 logid=9999999999 type=utm subtype=webfilter eventtype=urlfilter level=warning vd="root" urlfilteridx=3 urlfilterlist="default" policyid=2 sessionid=1563645 user="" srcip=1.2.3.11 srcport=52414 srcintf="internal2" dstip=1.5.5.92 dstport=443 dstintf="wan2" proto=6 service=HTTPS hostname="4-edge-chat.facebook.com" profile="default" action=blocked reqtype=referral url="/p?partition=-2&cb=lz1k&failure=5&sticky_token=274&sticky_pool=atn2c06_chat-proxy" sentbyte=932 rcvdbyte=0 direction=outgoing msg="URL was blocked because it is in the URL filter list" crscore=30 crlevel=high
     -->
-    <rule id="81620" level="0">
+    <rule id="81620" level="3">
         <if_sid>81603</if_sid>
         <status>warning</status>
         <action>blocked</action>
         <description>Fortigate: URL Blocked by Firewall.</description>
-        <group>firewall_drop,pci_dss_10.6.1,gdpr_IV_35.7.d,</group>
+        <group>firewall_drop,pci_dss_10.6.1,</group>
     </rule>
 
     <rule id="81621" level="3" frequency="16" timeframe="45" ignore="240">
         <if_matched_sid>81620</if_matched_sid>
         <same_source_ip />
         <description>Fortigate: Multiple URL blocked from same source.</description>
-        <group>multiple_drops,pci_dss_10.6.1,gdpr_IV_35.7.d,</group>
+        <group>multiple_drops,pci_dss_10.6.1,</group>
     </rule>
 
     <!--
@@ -200,17 +214,17 @@ ID: 81600 - 80799
     -->
     <rule id="81622" level="3">
         <if_sid>81603</if_sid>
-        <match>level=information</match>
+        <match>level=information|level="information"</match>
         <action>tunnel-up</action>
         <description>Fortigate: VPN User connected.</description>
-        <group>authentication_success,pci_dss_10.2.5,gpg13_7.1,gdpr_IV_32.2,</group>
+        4.13<group>authentication_success,pci_dss_10.2.5,gpg13_7.1,</group>
     </rule>
 
     <rule id="81623" level="4" frequency="16" timeframe="45" ignore="240">
         <if_matched_sid>81622</if_matched_sid>
         <same_source_ip />
         <description>Fortigate: Multiple vpn user connected from same source.</description>
-        <group>authentication_success,pci_dss_10.2.5,gpg13_7.1,gdpr_IV_32.2,</group>
+        <group>authentication_success,pci_dss_10.2.5,gpg13_7.1,</group>
     </rule>
 
     <!--
@@ -218,17 +232,17 @@ ID: 81600 - 80799
     -->
     <rule id="81624" level="3">
         <if_sid>81603</if_sid>
-        <match>level=information</match>
+        <match>level=information|level="information"</match>
         <action>tunnel-down</action>
         <description>Fortigate: VPN User disconnected.</description>
-        <group>pci_dss_10.2.5,gpg13_7.1,gdpr_IV_32.2,</group>
+        <group>pci_dss_10.2.5,gpg13_7.1,</group>
     </rule>
 
     <rule id="81625" level="4" frequency="16" timeframe="45" ignore="240">
         <if_matched_sid>81624</if_matched_sid>
         <same_source_ip />
         <description>Fortigate: Multiple user disconnected events from same source.</description>
-        <group>pci_dss_10.2.5,gpg13_7.1,gdpr_IV_32.2,</group>
+        <group>pci_dss_10.2.5,gpg13_7.1,</group>
     </rule>
 
     <!--
@@ -240,14 +254,14 @@ ID: 81600 - 80799
         <status>success</status>
         <action>login</action>
         <description>Fortigate: User successfully logged into firewall interface.</description>
-        <group>pci_dss_10.6.1,gpg13_7.1,gpg13_7.2,gdpr_IV_32.2,</group>
+        <group>pci_dss_10.6.1,gpg13_7.1,gpg13_7.2,</group>
     </rule>
 
     <rule id="81627" level="4" frequency="16" timeframe="45" ignore="240">
         <if_matched_sid>81626</if_matched_sid>
         <same_source_ip />
         <description>Fortigate: Multiple Firewall login events from same source.</description>
-        <group>pci_dss_10.6.1,gpg13_7.1,gpg13_7.2,gdpr_IV_35.7.d,</group>
+        <group>pci_dss_10.6.1,gpg13_7.1,gpg13_7.2,</group>
     </rule>
 
 
@@ -261,7 +275,7 @@ ID: 81600 - 80799
         <match>attack</match>
         <action>detected</action>
         <description>Fortigate Attack Detected</description>
-        <group>attack,gdpr_IV_35.7.d,</group>
+        <group>attack,</group>
     </rule>
 
     <rule id="81629" level="3">
@@ -269,7 +283,77 @@ ID: 81600 - 80799
         <match>attack</match>
         <action>dropped</action>
         <description>Fortigate Attack Dropped</description>
-        <group>attack,gdpr_IV_35.7.d,</group>
+        <group>attack,</group>
     </rule>
+
+    <rule id="81630" level="3">
+        <if_sid>81603</if_sid>
+        <match>attack</match>
+        <action>clear_session</action>
+        <description>Fortigate Attack: Session cleared.</description>
+        <group>attack,gdpr_2.4</group>
+    </rule>
+
+    <!--
+    2018 Apr 09 16:05:06 inwazuhmgr->172.24.0.253 date=2018-04-09 time=16:05:06 devname=BA-RSYS-FW devid=FG600C3912803212 logid="1059028705" type="utm" subtype="app-ctrl" eventtype="app-ctrl-all" level="warning" vd="BA-EXORA" logtime=1523270106 appid=17244 srcip=172.24.150.115 dstip=139.59.35.216 srcport=62159 dstport=443 srcintf="port5" srcintfrole="undefined" dstintf="port4" dstintfrole="wan" proto=6 service="HTTPS" policyid=107 sessionid=3454918141 applist="block-high-risk" appcat="Proxy" app="OpenVPN" action="block" incidentserialno=798746654 msg="Proxy: OpenVPN," apprisk="elevated"
+    -->
+    <rule id="81633" level="3">
+        <if_sid>81603</if_sid>
+        <match>subtype="app-ctrl"|subtype=app-ctrl</match>
+        <action>pass</action>
+        <description>Fortigate: App passed by firewall.</description>
+        <group>pci_dss_10.6.1,gdpr_2.3,</group>
+    </rule>
+
+    <rule id="81634" level="3">
+        <if_sid>81603</if_sid>
+        <match>subtype="app-ctrl"|subtype=app-ctrl</match>
+        <action>block</action>
+        <description>Fortigate: App blocked by firewall.</description>
+        <group>firewall_drop,pci_dss_10.6.1,gdpr_2.3,</group>
+    </rule>
+
+    <rule id="81635" level="3" frequency="16" timeframe="45" ignore="240">
+        <if_matched_sid>81620</if_matched_sid>
+        <same_source_ip />
+        <description>Fortigate: Multiple URL blocked from same source.</description>
+        <group>multiple_drops,pci_dss_10.6.1,gdpr_2.3,</group>
+    </rule>
+
+    <!--
+    2018 Apr 09 16:03:11 inwazuhmgr->172.0.0.1 date=2018-04-09 time=16:03:11 devname=BA-BE-BI devid=FG600C1234567890 logid="0101037141" type="event" subtype="vpn" level="notice" vd="BA-BEBI" logtime=1523269991 logdesc="IPsec tunnel statistics" msg="IPsec tunnel statistics" action="tunnel-stats" remip=1.1.1.1 locip=1.1.1.1 remport=500 locport=500 outintf="port3" cookies="c95409asssss4d44/b8a16eeeeebe269a" user="N/A" group="N/A" xauthuser="N/A" xauthgroup="N/A" assignip=N/A vpntunnel="AWS-VPN-B" tunnelip=N/A tunnelid=2490314698 tunneltype="ipsec" duration=243565 sentbyte=116502517 rcvdbyte=347903642 nextstat=600
+    -->
+
+    <rule id="81636" level="1">
+        <if_sid>81603</if_sid>
+        <match>type="event" subtype="vpn" level="notice"|type=event subtype=vpn level=notice|type=event,subtype=vpn,level=notice</match>
+        <description>Fortigate: VPN related information</description>
+    </rule>
+
+    <rule id="81637" level="1">
+        <if_sid>81603</if_sid>
+        <match>type="event" subtype="vpn" level="error"|type=event subtype=vpn level=error|type=event,subtype=vpn,level=error</match>
+        <description>Fortigate: VPN related error</description>
+    </rule>
+
+<!--
+May 31 08:58:56 172.0.0.1 date=2018-05-31 time=08:58:56 devname="BA-BEBI" devid="FG600C1234567890" logid="0211008192" type="utm" subtype="virus" eventtype="infected" level="warning" vd="BA-BIBO" eventtime=1527737336 msg="File is infected." action="blocked" service="HTTP" sessionid=377413095 srcip=11.22.33.44 dstip=55.66.77.88 srcport=64982 dstport=80 srcintf="port5" srcintfrole="undefined" dstintf="port3" dstintfrole="wan" policyid=108 proto=6 direction="incoming" filename="FrontPageImgHandler.ashx" quarskip="File-was-not-quarantined." virus="Malware_Generic.P0" dtype="Virus" ref="http://www.fortinet.com/ve?vn=Malware_Generic.P0" virusid=7024603 url="http://www.badguys.web/FrontPageImgHandler.ashx?id=12" profile="Web-Browsing" agent="Chrome/66.0.3359.181" analyticscksum="a9165dbae34e6e2952270536e95a2bb154df61h6d95hfh6ee14b36123b" analyticssubmit="false" crscore=50 crlevel="critical"
+-->
+
+    <rule id="81638" level="5">
+        <if_sid>81603</if_sid>
+        <match>subtype=virus|subtype="virus"</match>
+        <description>Fortigate: Virus detected.</description>
+        <group>pci_dss_10.6.1,gdpr_IV_35.7.d,</group>
+    </rule>
+
+    <rule id="81639" level="5">
+        <if_sid>81638</if_sid>
+        <action>blocked</action>
+        <description>Fortigate: Blocked URL because a virus was detected.</description>
+        <group>firewall_drop,pci_dss_10.6.1,gdpr_IV_35.7.d,</group>
+    </rule>
+
+
 
 </group>

--- a/rules/0390-fortigate_rules.xml
+++ b/rules/0390-fortigate_rules.xml
@@ -354,6 +354,20 @@ May 31 08:58:56 172.0.0.1 date=2018-05-31 time=08:58:56 devname="BA-BEBI" devid=
         <group>firewall_drop,pci_dss_10.6.1,gdpr_IV_35.7.d,</group>
     </rule>
 
+<!--
+2018 Jun 21 00:00:35 XXX->127.0.0.1 date=2018-06-21 time=03:00:35 devname="xxx" devid="FG123341414414" logid="111111111" type="utm" subtype="webfilter" eventtype="ftgd_allow" level="notice" vd="xxx" eventtime=111111111 policyid=111 sessionid=111111111 srcip=127.0.0.1 srcport=11111 srcintf="port1" srcintfrole="undefined" dstip=127.0.0.1 dstport=111 dstintf="port111" dstintfrole="undefined" proto=1 service="XXX" hostname="xxxxx.com" profile="xx" action="passthrough" reqtype="direct" url="/xxxxxxxxxxxx" sentbyte=11 rcvdbyte=111 direction="outgoing" msg="URL belongs to an allowed category in policy" method="domain" cat=50 catdesc="Information and Computer Security"
+
+NOTE: Since this rule can be noisy is set to level 0 by default.
+-->
+
+    <rule id="81640" level="1">
+        <if_sid>81603</if_sid>
+        <status>notice</status>
+        <action>passthrough</action>
+        <description>Fortigate: URL belongs to an allowed category.</description>
+        <group>pci_dss_10.6.1,</group>
+    </rule>
+
 
 
 </group>


### PR DESCRIPTION
Fortigate decoders and rules are fixed and improved to fit Fortigate's new logging format, maintaining backward compatibility with previous versions. Also, new kind of logs (like UTM-Virus) has been added.

`2018 Jun 21 00:00:35 XXX->127.0.0.1 date=2018-06-21 time=03:00:35 devname="xxx" devid="FG123341414414" logid="111111111" type="traffic" subtype="forward" level="notice" vd="xxx" eventtime=111111111 srcip=127.0.0.1 srcport=11111 srcintf="port111" srcintfrole="undefined" dstip=127.0.0.1 dstport=1111 dstintf="xxxxx" dstintfrole="undefined" sessionid=122111221 proto=6 action="deny" policyid=1 policytype="policy" service="tcp/11111" dstcountry="xxxxx" srccountry="xxxx" trandisp="noop" duration=0 sentbyte=0 rcvdbyte=0 sentpkt=0 appcat="unscanned" crscore=111 craction=11111 crlevel="high"`


```
**Phase 1: Completed pre-decoding.
       full event: '2018 Jun 21 00:00:35 XXX->127.0.0.1 date=2018-06-21 time=03:00:35 devname="xxx" devid="FG123341414414" logid="111111111" type="traffic" subtype="forward" level="notice" vd="xxx" eventtime=111111111 srcip=127.0.0.1 srcport=11111 srcintf="port111" srcintfrole="undefined" dstip=127.0.0.1 dstport=1111 dstintf="xxxxx" dstintfrole="undefined" sessionid=122111221 proto=6 action="deny" policyid=1 policytype="policy" service="tcp/11111" dstcountry="xxxxx" srccountry="xxxx" trandisp="noop" duration=0 sentbyte=0 rcvdbyte=0 sentpkt=0 appcat="unscanned" crscore=111 craction=11111 crlevel="high"'
       timestamp: '2018 Jun 21 00:00:35'
       hostname: 'manager1'
       program_name: '(null)'
       log: 'XXX->127.0.0.1 date=2018-06-21 time=03:00:35 devname="xxx" devid="FG123341414414" logid="111111111" type="traffic" subtype="forward" level="notice" vd="xxx" eventtime=111111111 srcip=127.0.0.1 srcport=11111 srcintf="port111" srcintfrole="undefined" dstip=127.0.0.1 dstport=1111 dstintf="xxxxx" dstintfrole="undefined" sessionid=122111221 proto=6 action="deny" policyid=1 policytype="policy" service="tcp/11111" dstcountry="xxxxx" srccountry="xxxx" trandisp="noop" duration=0 sentbyte=0 rcvdbyte=0 sentpkt=0 appcat="unscanned" crscore=111 craction=11111 crlevel="high"'

**Phase 2: Completed decoding.
       decoder: 'fortigate-firewall-v5'
       srcip: '127.0.0.1'
       srcport: '11111'
       dstip: '127.0.0.1'
       dstport: '1111'
       protocol: 'unscanned'

**Phase 3: Completed filtering (rules).
       Rule id: '81618'
       Level: '3'
       Description: 'Fortigate: Traffic to be aware of.'
**Alert to be generated.
```

`2018 Jun 21 00:11:50 XXX->127.0.0.1 date=2018-06-21 time=03:11:49 devname="xxx" devid="FG123341414414" logid="111111111" type="utm" subtype="virus" eventtype="analytics" level="information" vd="xxx" eventtime=111111111 msg="File submitted to Sandbox." action="analytics" service="XXX" sessionid=11111111 srcip=127.0.0.1 dstip=127.0.0.1 srcport=111111 dstport=111 srcintf="port1" srcintfrole="undefined" dstintf="port1" dstintfrole="undefined" policyid=111 proto=1 direction="incoming" filename="xxx.xx" url="wwww.test.com/xxx.xx" profile="XXXX" agent="XXXX" analyticscksum="12k3jljfi1ljfo1jokfjko1ofk1jf" analyticssubmit="true"`

```
**Phase 1: Completed pre-decoding.
       full event: '2018 Jun 21 00:11:50 XXX->127.0.0.1 date=2018-06-21 time=03:11:49 devname="xxx" devid="FG123341414414" logid="111111111" type="utm" subtype="virus" eventtype="analytics" level="information" vd="xxx" eventtime=111111111 msg="File submitted to Sandbox." action="analytics" service="XXX" sessionid=11111111 srcip=127.0.0.1 dstip=127.0.0.1 srcport=111111 dstport=111 srcintf="port1" srcintfrole="undefined" dstintf="port1" dstintfrole="undefined" policyid=111 proto=1 direction="incoming" filename="xxx.xx" url="wwww.test.com/xxx.xx" profile="XXXX" agent="XXXX" analyticscksum="12k3jljfi1ljfo1jokfjko1ofk1jf" analyticssubmit="true"'
       timestamp: '2018 Jun 21 00:11:50'
       hostname: 'manager1'
       program_name: '(null)'
       log: 'XXX->127.0.0.1 date=2018-06-21 time=03:11:49 devname="xxx" devid="FG123341414414" logid="111111111" type="utm" subtype="virus" eventtype="analytics" level="information" vd="xxx" eventtime=111111111 msg="File submitted to Sandbox." action="analytics" service="XXX" sessionid=11111111 srcip=127.0.0.1 dstip=127.0.0.1 srcport=111111 dstport=111 srcintf="port1" srcintfrole="undefined" dstintf="port1" dstintfrole="undefined" policyid=111 proto=1 direction="incoming" filename="xxx.xx" url="wwww.test.com/xxx.xx" profile="XXXX" agent="XXXX" analyticscksum="12k3jljfi1ljfo1jokfjko1ofk1jf" analyticssubmit="true"'

**Phase 2: Completed decoding.
       decoder: 'fortigate-firewall-v5'
       protocol: 'analytics'
       status: 'information'
       action: 'analytics'
       srcip: '127.0.0.1'
       dstip: '127.0.0.1'
       srcport: '111111'
       dstport: '111'
       fortigate.file_infected: 'xxx.xx'
       url: 'wwww.test.com/xxx.xx'

**Phase 3: Completed filtering (rules).
       Rule id: '81638'
       Level: '5'
       Description: 'Fortigate: Virus detected.'
**Alert to be generated.
```

`2018 Jun 21 00:00:35 XXX->127.0.0.1 date=2018-06-21 time=03:00:35 devname="xxx" devid="FG123341414414" logid="111111111" type="utm" subtype="webfilter" eventtype="ftgd_allow" level="notice" vd="xxx" eventtime=111111111 policyid=111 sessionid=111111111 srcip=127.0.0.1 srcport=11111 srcintf="port1" srcintfrole="undefined" dstip=127.0.0.1 dstport=111 dstintf="port111" dstintfrole="undefined" proto=1 service="XXX" hostname="xxxxx.com" profile="xx" action="passthrough" reqtype="direct" url="/xxxxxxxxxxxx" sentbyte=11 rcvdbyte=111 direction="outgoing" msg="URL belongs to an allowed category in policy" method="domain" cat=50 catdesc="Information and Computer Security"`

```
**Phase 1: Completed pre-decoding.
       full event: '2018 Jun 21 00:00:35 XXX->127.0.0.1 date=2018-06-21 time=03:00:35 devname="xxx" devid="FG123341414414" logid="111111111" type="utm" subtype="webfilter" eventtype="ftgd_allow" level="notice" vd="xxx" eventtime=111111111 policyid=111 sessionid=111111111 srcip=127.0.0.1 srcport=11111 srcintf="port1" srcintfrole="undefined" dstip=127.0.0.1 dstport=111 dstintf="port111" dstintfrole="undefined" proto=1 service="XXX" hostname="xxxxx.com" profile="xx" action="passthrough" reqtype="direct" url="/xxxxxxxxxxxx" sentbyte=11 rcvdbyte=111 direction="outgoing" msg="URL belongs to an allowed category in policy" method="domain" cat=50 catdesc="Information and Computer Security"'
       timestamp: '2018 Jun 21 00:00:35'
       hostname: 'manager1'
       program_name: '(null)'
       log: 'XXX->127.0.0.1 date=2018-06-21 time=03:00:35 devname="xxx" devid="FG123341414414" logid="111111111" type="utm" subtype="webfilter" eventtype="ftgd_allow" level="notice" vd="xxx" eventtime=111111111 policyid=111 sessionid=111111111 srcip=127.0.0.1 srcport=11111 srcintf="port1" srcintfrole="undefined" dstip=127.0.0.1 dstport=111 dstintf="port111" dstintfrole="undefined" proto=1 service="XXX" hostname="xxxxx.com" profile="xx" action="passthrough" reqtype="direct" url="/xxxxxxxxxxxx" sentbyte=11 rcvdbyte=111 direction="outgoing" msg="URL belongs to an allowed category in policy" method="domain" cat=50 catdesc="Information and Computer Security"'

**Phase 2: Completed decoding.
       decoder: 'fortigate-firewall-v5'
       status: 'notice'
       srcip: '127.0.0.1'
       srcport: '11111'
       dstip: '127.0.0.1'
       dstport: '111'
       url: 'xxxxx.com'
       action: 'passthrough'

**Phase 3: Completed filtering (rules).
       Rule id: '81640'
       Level: '1'
       Description: 'Fortigate: URL belongs to an allowed category.'
```