### PR TITLE
Extract dstuser nginx decoders

### DIFF
--- a/decoders/0170-nginx_decoders.xml
+++ b/decoders/0170-nginx_decoders.xml
@@ -20,9 +20,15 @@
 
 <decoder name="nginx-errorlog-user-ip">
   <parent>nginx-errorlog</parent>
-  <prematch offset="after_parent"> user "\.+"\.+, client: \S+, server: \S+, request: "\S+ </prematch>
-  <regex offset="after_parent"> user "(\.+)"\.+, client: (\S+), </regex>
-  <order>dstuser, srcip</order>
+  <prematch offset="after_parent"> user "\.+"</prematch>
+  <regex offset="after_parent"> user "(\.+)"</regex>
+  <order>dstuser</order>
+</decoder>
+
+<decoder name="nginx-errorlog-user-ip">
+  <parent>nginx-errorlog</parent>
+  <regex offset="after_regex">client: (\S+),</regex>
+  <order>srcip</order>
 </decoder>
 
 <decoder name="nginx-errorlog-ip">


### PR DESCRIPTION
Hello team,

Based on #141, we have added two twin decoders in order to get the "dstuser" field when the event contains the user. 

The new decoders: 

```
<decoder name="nginx-errorlog-user-ip">
  <parent>nginx-errorlog</parent>
  <prematch offset="after_parent"> user "\.+"</prematch>
  <regex offset="after_parent"> user "(\.+)"</regex>
  <order>dstuser</order>
</decoder>

<decoder name="nginx-errorlog-user-ip">
  <parent>nginx-errorlog</parent>
  <regex offset="after_regex">client: (\S+),</regex>
  <order>srcip</order>
</decoder>
```

Logtest ouput without user:

```

2009/09/15 20:55:40 [error] 63858#0: *3663 open() "/srv/www/ossec.net/robots.txt" failed (2: No such file or directory), client: 1.2.3.4, server: ossec.net, request: "GET /robots.txt HTTP/1.1", host: "www.ossec.net"


**Phase 1: Completed pre-decoding.
       full event: '2009/09/15 20:55:40 [error] 63858#0: *3663 open() "/srv/www/ossec.net/robots.txt" failed (2: No such file or directory), client: 1.2.3.4, server: ossec.net, request: "GET /robots.txt HTTP/1.1", host: "www.ossec.net"'
       timestamp: '(null)'
       hostname: 'manager'
       program_name: '(null)'
       log: '2009/09/15 20:55:40 [error] 63858#0: *3663 open() "/srv/www/ossec.net/robots.txt" failed (2: No such file or directory), client: 1.2.3.4, server: ossec.net, request: "GET /robots.txt HTTP/1.1", host: "www.ossec.net"'

**Phase 2: Completed decoding.
       decoder: 'nginx-errorlog'
       srcip: '1.2.3.4'

**Phase 3: Completed filtering (rules).
       Rule id: '31310'
       Level: '0'
       Description: 'Nginx: Server returned 404 (reported in the access.log).'

2009/09/15 19:51:07 [error] 37992#0: accept() failed (53: Software caused connection abort)


**Phase 1: Completed pre-decoding.
       full event: '2009/09/15 19:51:07 [error] 37992#0: accept() failed (53: Software caused connection abort)'
       timestamp: '(null)'
       hostname: 'manager'
       program_name: '(null)'
       log: '2009/09/15 19:51:07 [error] 37992#0: accept() failed (53: Software caused connection abort)'

**Phase 2: Completed decoding.
       decoder: 'nginx-errorlog'

**Phase 3: Completed filtering (rules).
       Rule id: '31311'
       Level: '0'
       Description: 'Nginx: Incomplete client request.'

```

Logtest output with user:

```
2018/05/26 06:46:11 [error] 31963#31963: *28769 user "user1" was not found in "/etc/nginx/conf.d/users.htpasswd", client: 1.2.3.4, server: example.com, request: "GET / HTTP/1.1", host: "example.com"


**Phase 1: Completed pre-decoding.
       full event: '2018/05/26 06:46:11 [error] 31963#31963: *28769 user "user1" was not found in "/etc/nginx/conf.d/users.htpasswd", client: 1.2.3.4, server: example.com, request: "GET / HTTP/1.1", host: "example.com"'
       timestamp: '(null)'
       hostname: 'manager'
       program_name: '(null)'
       log: '2018/05/26 06:46:11 [error] 31963#31963: *28769 user "user1" was not found in "/etc/nginx/conf.d/users.htpasswd", client: 1.2.3.4, server: example.com, request: "GET / HTTP/1.1", host: "example.com"'

**Phase 2: Completed decoding.
       decoder: 'nginx-errorlog'
       dstuser: 'user1'
       srcip: '1.2.3.4'

**Phase 3: Completed filtering (rules).
       Rule id: '31315'
       Level: '5'
       Description: 'Nginx: Web authentication failed.'
**Alert to be generated.

2018/05/27 10:22:20 [error] 31972#31972: *52363 user "test user": password mismatch, client: 1.2.3.4, server: example.com, request: "GET / HTTP/2.0", host: "example.com"


**Phase 1: Completed pre-decoding.
       full event: '2018/05/27 10:22:20 [error] 31972#31972: *52363 user "test user": password mismatch, client: 1.2.3.4, server: example.com, request: "GET / HTTP/2.0", host: "example.com"'
       timestamp: '(null)'
       hostname: 'manager'
       program_name: '(null)'
       log: '2018/05/27 10:22:20 [error] 31972#31972: *52363 user "test user": password mismatch, client: 1.2.3.4, server: example.com, request: "GET / HTTP/2.0", host: "example.com"'

**Phase 2: Completed decoding.
       decoder: 'nginx-errorlog'
       dstuser: 'test user'
       srcip: '1.2.3.4'

**Phase 3: Completed filtering (rules).
       Rule id: '31315'
       Level: '5'
       Description: 'Nginx: Web authentication failed.'
**Alert to be generated.
```

Kind regards,

Alfonso Ruiz-Bravo