### PR TITLE
0050-checkpoint_decoders.xml updated

### DIFF
--- a/decoders/0050-checkpoint_decoders.xml
+++ b/decoders/0050-checkpoint_decoders.xml
@@ -48,12 +48,15 @@ FireWall-1;
   - Checkpoint:  3Apr2008 15:02:15 monitor 10.10.10.3 >eth2 Attack Info: Line
 in HTTP request too long; attack: Malformed HTTP; src: 10.10.10.4; dst:
 10.10.10.5; proto: tcp; product: SmartDefense; service: 111; s_port: 222;
+  -
+  - Apr 10 20:43:34 ngman Checkpoint: 10Apr2018 20:43:33 monitor 10.10.1.12  <bond0 Protection Name:Header Rejection;Severity:4;Confidence Level:4;protection_id:HttpHeaderRejection;SmartDefense Profile:SU2_Protection;Performance Impact:2;Industry Reference:CVE-2002-0032, CAN-2003-0237, CAN-2002-0254, CVE-2002-0155, CAN-2003-0397, CAN-2002-0314;Protection Type:protection;Signature Info:^User-Agent[^I ]*:[^I ]*.*esb|ESB;Update Version:634182243;rule:26;rule_uid:{405CB782-3274-4D7F-8AAA-4FB24CE726A0};resource:http://dnl-02.geo.kaspersky.com/bases/av/kdb/i386/kdb-i386-1211g.xml.klz;reject_id:5accf7c4-10053-c00080a-c0000003;web_client_type:Other: *BcfBAAAAgCCAAEFBAAwQfKXVzrzGvyfPESboPxow0mHhxRLAXAQAAIAAKAA=;Attack Info:WSE0100001 header rejection pattern found in request;attack:Header Rejection;src:10.36.52.125;dst:94.75.236.122;proto:6;proxy_src_ip:10.36.52.125;product:SmartDefense;service:80;s_port:51642;FollowUp:Not Followed;product_family:Network
   -->
+
 
 <!-- \s+\S+ \d\d:\d\d:\d\d (\w+) \d+.\d+.\d+.\d+ \p\S+ rule: -->
 <decoder name="checkpoint-syslog">
   <program_name>^Checkpoint</program_name>
-  <prematch>^\s+\S+ \d\d:\d\d:\d\d </prematch>
+  <prematch>^\s*\S+ \d\d:\d\d:\d\d </prematch>
 </decoder>
 
 <decoder name="checkpoint-syslog-fw">
@@ -76,9 +79,9 @@ in HTTP request too long; attack: Malformed HTTP; src: 10.10.10.4; dst:
   <parent>checkpoint-syslog</parent>
   <type>ids</type>
   <prematch offset="after_parent">^monitor|^drop</prematch>
-  <regex offset="after_prematch">attack: (\.+); </regex>
-  <regex>src: (\S+); dst: (\S+); </regex>
-  <regex>proto: (\S+);</regex>
+  <regex offset="after_prematch">attack:\s*(\.+);\s*</regex>
+  <regex>src:\s*(\S+);\s*dst:\s*(\S+);\s*</regex>
+  <regex>proto:\s*(\S+);</regex>
   <order>extra_data, srcip, dstip, protocol</order>
   <fts>name, extra_data, srcip, dstip</fts>
   <ftscomment>First time Checkpoint rule fired.</ftscomment>


### PR DESCRIPTION
We have fixed two decoders because they do not read well the formats of certain events depending on the blank spaces that could exist.

If we received an event with the following format: 

`Feb 17 00:01:02 HostWazuh Checkpoint: 21Aug2007 14:49:26 drop   10.10.10.1 >eth4 rule: 102; rule_uid: {00000000-0000-0000-0000-000000000000}; ICMP: Echo Request; src: 10.10.10.2; dst: 10.10.10.3; proto: icmp; ICMP Type: 8; ICMP Code: 0; product: VPN-1 & FireWall-1;`

Specifically in this section: 

`Checkpoint: 21Aug2007`

In the pre-decoding phase, the blank space after the "program_name" (Checkpoint:) was deleted but the decoder was forced to read it. 

```
<decoder name="checkpoint-syslog">
  <program_name>^Checkpoint</program_name>
  <prematch>^\s+\S+ \d\d:\d\d:\d\d </prematch>
</decoder>
```

```
Feb 17 00:01:02 HostWazuh Checkpoint: 21Aug2007 14:49:26 drop   10.10.10.1 >eth4 rule: 102; rule_uid: {00000000-0000-0000-0000-000000000000}; ICMP: Echo Request; src: 10.10.10.2; dst: 10.10.10.3; proto: icmp; ICMP Type: 8; ICMP Code: 0; product: VPN-1 & FireWall-1;


**Phase 1: Completed pre-decoding.
       full event: 'Feb 17 00:01:02 HostWazuh Checkpoint: 21Aug2007 14:49:26 drop   10.10.10.1 >eth4 rule: 102; rule_uid: {00000000-0000-0000-0000-000000000000}; ICMP: Echo Request; src: 10.10.10.2; dst: 10.10.10.3; proto: icmp; ICMP Type: 8; ICMP Code: 0; product: VPN-1 & FireWall-1;'
       timestamp: 'Feb 17 00:01:02'
       hostname: 'HostWazuh'
       program_name: 'Checkpoint'
       log: '21Aug2007 14:49:26 drop   10.10.10.1 >eth4 rule: 102; rule_uid: {00000000-0000-0000-0000-000000000000}; ICMP: Echo Request; src: 10.10.10.2; dst: 10.10.10.3; proto: icmp; ICMP Type: 8; ICMP Code: 0; product: VPN-1 & FireWall-1;'

**Phase 2: Completed decoding.
       No decoder matched.
```

We have changed the decoder so it doesn't have to read the blank space: 

```
<decoder name="checkpoint-syslog">
  <program_name>^Checkpoint</program_name>
  <prematch>^\s*\S+ \d\d:\d\d:\d\d </prematch>
</decoder>
```

```
Feb 17 00:01:02 HostWazuh Checkpoint: 21Aug2007 14:49:26 drop   10.10.10.1 >eth4 rule: 102; rule_uid: {00000000-0000-0000-0000-000000000000}; ICMP: Echo Request; src: 10.10.10.2; dst: 10.10.10.3; proto: icmp; ICMP Type: 8; ICMP Code: 0; product: VPN-1 & FireWall-1


**Phase 1: Completed pre-decoding.
       full event: 'Feb 17 00:01:02 HostWazuh Checkpoint: 21Aug2007 14:49:26 drop   10.10.10.1 >eth4 rule: 102; rule_uid: {00000000-0000-0000-0000-000000000000}; ICMP: Echo Request; src: 10.10.10.2; dst: 10.10.10.3; proto: icmp; ICMP Type: 8; ICMP Code: 0; product: VPN-1 & FireWall-1'
       timestamp: 'Feb 17 00:01:02'
       hostname: 'HostWazuh'
       program_name: 'Checkpoint'
       log: '21Aug2007 14:49:26 drop   10.10.10.1 >eth4 rule: 102; rule_uid: {00000000-0000-0000-0000-000000000000}; ICMP: Echo Request; src: 10.10.10.2; dst: 10.10.10.3; proto: icmp; ICMP Type: 8; ICMP Code: 0; product: VPN-1 & FireWall-1'

**Phase 2: Completed decoding.
       decoder: 'checkpoint-syslog'
       action: 'drop'
       srcip: '10.10.10.2'
       dstip: '10.10.10.3'
       protocol: 'icmp'

**Phase 3: Completed filtering (rules).
       Rule id: '4100'
       Level: '0'
       Description: 'Firewall rules grouped.'
```

Additionally, we have adapted a second decoder so that it can read events with a different format, where there may be blank spaces in the body of the event. 

For example:

`Apr 10 20:43:34 ngman Checkpoint: 10Apr2018 20:43:33 monitor 10.10.1.12  <bond0 Protection Name:Header Rejection;Severity:4;Confidence Level:4;protection_id:HttpHeaderRejection;SmartDefense Profile:SU2_Protection;Performance Impact:2;Industry Reference:CVE-2002-0032, CAN-2003-0237, CAN-2002-0254, CVE-2002-0155, CAN-2003-0397, CAN-2002-0314;Protection Type:protection;Signature Info:^User-Agent[^I ]*:[^I ]*.*esb|ESB;Update Version:634182243;rule:26;rule_uid:{405CB782-3274-4D7F-8AAA-4FB24CE726A0};resource:http://dnl-02.geo.kaspersky.com/bases/av/kdb/i386/kdb-i386-1211g.xml.klz;reject_id:5accf7c4-10053-c00080a-c0000003;web_client_type:Other: *BcfBAAAAgCCAAEFBAAwQfKXVzrzGvyfPESboPxow0mHhxRLAXAQAAIAAKAA=;Attack Info:WSE0100001 header rejection pattern found in request;attack:Header Rejection;src:10.36.52.125;dst:94.75.236.122;proto:6;proxy_src_ip:10.36.52.125;product:SmartDefense;service:80;s_port:51642;FollowUp:Not Followed;product_family:Network
`
In this case, the resulting decoder is: 

```
<decoder name="checkpoint-syslog-ids">
  <parent>checkpoint-syslog</parent>
  <type>ids</type>
  <prematch offset="after_parent">^monitor|^drop</prematch>
  <regex offset="after_prematch">attack:\s*(\.+);\s*</regex>
  <regex>src:\s*(\S+);\s*dst:\s*(\S+);\s*</regex>
  <regex>proto:\s*(\S+);</regex>
  <order>extra_data, srcip, dstip, protocol</order>
  <fts>name, extra_data, srcip, dstip</fts>
  <ftscomment>First time Checkpoint rule fired.</ftscomment>
</decoder>

```
```
Apr 10 20:43:34 ngman Checkpoint: 10Apr2018 20:43:33 monitor 10.10.1.12  <bond0 Protection Name:Header Rejection;Severity:4;Confidence Level:4;protection_id:HttpHeaderRejection;SmartDefense Profile:SU2_Protection;Performance Impact:2;Industry Reference:CVE-2002-0032, CAN-2003-0237, CAN-2002-0254, CVE-2002-0155, CAN-2003-0397, CAN-2002-0314;Protection Type:protection;Signature Info:^User-Agent[^I ]*:[^I ]*.*esb|ESB;Update Version:634182243;rule:26;rule_uid:{405CB782-3274-4D7F-8AAA-4FB24CE726A0};resource:http://dnl-02.geo.kaspersky.com/bases/av/kdb/i386/kdb-i386-1211g.xml.klz;reject_id:5accf7c4-10053-c00080a-c0000003;web_client_type:Other: *BcfBAAAAgCCAAEFBAAwQfKXVzrzGvyfPESboPxow0mHhxRLAXAQAAIAAKAA=;Attack Info:WSE0100001 header rejection pattern found in request;attack:Header Rejection;src:10.36.52.125;dst:94.75.236.122;proto:6;proxy_src_ip:10.36.52.125;product:SmartDefense;service:80;s_port:51642;FollowUp:Not Followed;product_family:Network


**Phase 1: Completed pre-decoding.
       full event: 'Apr 10 20:43:34 ngman Checkpoint: 10Apr2018 20:43:33 monitor 10.10.1.12  <bond0 Protection Name:Header Rejection;Severity:4;Confidence Level:4;protection_id:HttpHeaderRejection;SmartDefense Profile:SU2_Protection;Performance Impact:2;Industry Reference:CVE-2002-0032, CAN-2003-0237, CAN-2002-0254, CVE-2002-0155, CAN-2003-0397, CAN-2002-0314;Protection Type:protection;Signature Info:^User-Agent[^I ]*:[^I ]*.*esb|ESB;Update Version:634182243;rule:26;rule_uid:{405CB782-3274-4D7F-8AAA-4FB24CE726A0};resource:http://dnl-02.geo.kaspersky.com/bases/av/kdb/i386/kdb-i386-1211g.xml.klz;reject_id:5accf7c4-10053-c00080a-c0000003;web_client_type:Other: *BcfBAAAAgCCAAEFBAAwQfKXVzrzGvyfPESboPxow0mHhxRLAXAQAAIAAKAA=;Attack Info:WSE0100001 header rejection pattern found in request;attack:Header Rejection;src:10.36.52.125;dst:94.75.236.122;proto:6;proxy_src_ip:10.36.52.125;product:SmartDefense;service:80;s_port:51642;FollowUp:Not Followed;product_family:Network'
       timestamp: 'Apr 10 20:43:34'
       hostname: 'ngman'
       program_name: 'Checkpoint'
       log: '10Apr2018 20:43:33 monitor 10.10.1.12  <bond0 Protection Name:Header Rejection;Severity:4;Confidence Level:4;protection_id:HttpHeaderRejection;SmartDefense Profile:SU2_Protection;Performance Impact:2;Industry Reference:CVE-2002-0032, CAN-2003-0237, CAN-2002-0254, CVE-2002-0155, CAN-2003-0397, CAN-2002-0314;Protection Type:protection;Signature Info:^User-Agent[^I ]*:[^I ]*.*esb|ESB;Update Version:634182243;rule:26;rule_uid:{405CB782-3274-4D7F-8AAA-4FB24CE726A0};resource:http://dnl-02.geo.kaspersky.com/bases/av/kdb/i386/kdb-i386-1211g.xml.klz;reject_id:5accf7c4-10053-c00080a-c0000003;web_client_type:Other: *BcfBAAAAgCCAAEFBAAwQfKXVzrzGvyfPESboPxow0mHhxRLAXAQAAIAAKAA=;Attack Info:WSE0100001 header rejection pattern found in request;attack:Header Rejection;src:10.36.52.125;dst:94.75.236.122;proto:6;proxy_src_ip:10.36.52.125;product:SmartDefense;service:80;s_port:51642;FollowUp:Not Followed;product_family:Network'

**Phase 2: Completed decoding.
       decoder: 'checkpoint-syslog'
       extra_data: 'Header Rejection'
       srcip: '10.36.52.125'
       dstip: '94.75.236.122'
       protocol: '6'

**Phase 3: Completed filtering (rules).
       Rule id: '20100'
       Level: '8'
       Description: 'First time this IDS alert is generated.'
**Alert to be generated.

```

Kind regards,

Alfonso Ruiz-Bravo
