### PR TITLE
0375-web-accesslog_decoders.xml updated

### DIFF
--- a/decoders/0375-web-accesslog_decoders.xml
+++ b/decoders/0375-web-accesslog_decoders.xml
@@ -24,7 +24,20 @@
 
   2 IPs:
   10.10.10.11 10.10.10.12 - - [10/Apr/2017:13:18:05 -0700] "GET /injection/%0d%0aSet-Cookie HTTP/1.1" 404 271 "-" "Mozilla/5.0 (Windows NT 6.1; WOW64; rv:22.0) Gecko/20100101 Firefox/22.0"
+
+  With rsyslog:
+  - Jan 11 10:13:05 web01 nginx: 192.168.212.1 - - [11/Jan/2018:10:13:05 +0100] "HEAD / HTTP/1.1" 200 0 random.domain.com "-" "curl/7.47.0" - 3e8756565a738d5333c10462c1bf3913 192.168.212.51:80 /data/www/random.domain.com/php/web
+  - Jan 11 10:13:05 web01 nginx: ::ffff:202.194.15.192 190.7.138.180 - [18/Oct/2010:10:48:55 -0500] "GET //php-my-admin/config/config.inc.php?p=phpinfo(); HTTP/1.1" 404 345 "-"  "Mozilla/4.0 (compatible; MSIE 6.0; Windows 98)"
+  - Jan 11 10:13:05 web01 apache: 10.11.12.13 - - - [27/Mar/2017:13:40:40 -0700] "GET /modules.php?name=Search&type=stories&query=qualys&category=-1%20&categ=%20and%201=2%20UNION%20SELECT%200,0,aid,pwd,0,0,0,0,0,0%20from%20nuke_authors/* HTTP/1.0" 404 982 "-" "-"
+  - Jan 11 10:13:05 web01 nginx: domain.com 10.11.12.13 - - [12/Sep/2016:15:24:41 +0000] "GET /url/errors.php?mode=js HTTP/1.1" 200 0 "https://domain.com/tt-rss/" "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/53.0.2785.101 Safari/537.36"
+  - Jan 11 10:13:05 web01 nginx: 10.10.10.11 10.10.10.12 - - [10/Apr/2017:13:18:05 -0700] "GET /injection/%0d%0aSet-Cookie HTTP/1.1" 404 271 "-" "Mozilla/5.0 (Windows NT 6.1; WOW64; rv:22.0) Gecko/20100101 Firefox/22.0"
+  - Jan 11 10:13:05 web01 apache: 10.10.10.11 10.10.10.12 - - [10/Apr/2017:13:18:05 -0700] "GET /injection/%0d%0aSet-Cookie HTTP/1.1" 404 271 "-" "Mozilla/5.0 (Windows NT 6.1; WOW64; rv:22.0) Gecko/20100101 Firefox/22.0"
   -->
+
+<decoder name="web-accesslog">
+    <type>web-log</type>
+    <program_name>nginx|apache</program_name>
+</decoder>
 
 <decoder name="web-accesslog">
     <type>web-log</type>


### PR DESCRIPTION
We have added a decoder to recognize if the event comes in rsyslog format, recognizing if the program name is nginx or apache.

In response to the issue: [#352](https://github.com/wazuh/wazuh/issues/352) 

We have added the following decoder:

```
<decoder name="web-accesslog">
    <type>web-log</type>
    <program_name>nginx|apache</program_name>
</decoder>
```

It gives us the ability to recognize web access events that come in rsyslog format. 

For example:

 - Withouth rsyslog format:

```
10.11.12.13 - - - [27/Mar/2017:13:40:40 -0700] "GET /modules.php?name=Search&type=stories&query=qualys&category=-1%20&categ=%20and%201=2%20UNION%20SELECT%200,0,aid,pwd,0,0,0,0,0,0%20from%20nuke_authors/* HTTP/1.0" 404 982 "-" "-"


**Phase 1: Completed pre-decoding.

       full event: '10.11.12.13 - - - [27/Mar/2017:13:40:40 -0700] "GET /modules.php?name=Search&type=stories&query=qualys&category=-1%20&categ=%20and%201=2%20UNION%20SELECT%200,0,aid,pwd,0,0,0,0,0,0%20from%20nuke_authors/* HTTP/1.0" 404 982 "-" "-"'
       timestamp: '(null)'
       hostname: 'manager'
       program_name: '(null)'
       log: '10.11.12.13 - - - [27/Mar/2017:13:40:40 -0700] "GET /modules.php?name=Search&type=stories&query=qualys&category=-1%20&categ=%20and%201=2%20UNION%20SELECT%200,0,aid,pwd,0,0,0,0,0,0%20from%20nuke_authors/* HTTP/1.0" 404 982 "-" "-"'

**Phase 2: Completed decoding.
       decoder: 'web-accesslog'
       srcip: '10.11.12.13'
       protocol: 'GET'
       url: '/modules.php?name=Search&type=stories&query=qualys&category=-1%20&categ=%20and%201=2%20UNION%20SELECT%200,0,aid,pwd,0,0,0,0,0,0%20from%20nuke_authors/*'
       id: '404'

**Phase 3: Completed filtering (rules).
       Rule id: '31103'
       Level: '6'
       Description: 'SQL injection attempt.'
**Alert to be generated.
```

 - With rsyslog format: 

```
Jan 11 10:13:05 web01 apache: 10.11.12.13 - - - [27/Mar/2017:13:40:40 -0700] "GET /modules.php?name=Search&type=stories&query=qualys&category=-1%20&categ=%20and%201=2%20UNION%20SELECT%200,0,aid,pwd,0,0,0,0,0,0%20from%20nuke_authors/* HTTP/1.0" 404 982 "-" "-"


**Phase 1: Completed pre-decoding.
       full event: 'Jan 11 10:13:05 web01 apache: 10.11.12.13 - - - [27/Mar/2017:13:40:40 -0700] "GET /modules.php?name=Search&type=stories&query=qualys&category=-1%20&categ=%20and%201=2%20UNION%20SELECT%200,0,aid,pwd,0,0,0,0,0,0%20from%20nuke_authors/* HTTP/1.0" 404 982 "-" "-"'
       timestamp: 'Jan 11 10:13:05'
       hostname: 'web01'
       program_name: 'apache'
       log: '10.11.12.13 - - - [27/Mar/2017:13:40:40 -0700] "GET /modules.php?name=Search&type=stories&query=qualys&category=-1%20&categ=%20and%201=2%20UNION%20SELECT%200,0,aid,pwd,0,0,0,0,0,0%20from%20nuke_authors/* HTTP/1.0" 404 982 "-" "-"'

**Phase 2: Completed decoding.
       decoder: 'web-accesslog'
       srcip: '10.11.12.13'
       protocol: 'GET'
       url: '/modules.php?name=Search&type=stories&query=qualys&category=-1%20&categ=%20and%201=2%20UNION%20SELECT%200,0,aid,pwd,0,0,0,0,0,0%20from%20nuke_authors/*'
       id: '404'

**Phase 3: Completed filtering (rules).
       Rule id: '31103'
       Level: '6'
       Description: 'SQL injection attempt.'
**Alert to be generated.

```

Regards,

Alfonso Ruiz-Bravo
