### PR TITLE
Fixed rules to warn about installed/removed deb packages

### DIFF
--- a/rules/0020-syslog_rules.xml
+++ b/rules/0020-syslog_rules.xml
@@ -606,7 +606,7 @@
 <group name="syslog,dpkg,">
   <rule id="2900" level="0">
     <decoded_as>windows-date-format</decoded_as>
-    <regex offet="after_parent">^startup |^status |^remove |^configure |^install |^purge |^trigproc </regex>
+    <regex offet="after_parent">startup |status |remove |configure |install |purge |trigproc </regex>
     <description>Dpkg (Debian Package) log.</description>
   </rule>
 


### PR DESCRIPTION
This PR fixes the rules 2900-2903 related to Debian packages installation.

The `ossec-logtest` output is the following one for an installed package:

```
root@localhost » ossec-logtest
2018/08/20 12:53:25 ossec-testrule: INFO: Started (pid: 125973).
ossec-testrule: Type one log per line.

2018-08-02 00:03:36 status installed nano:amd64 2.5.3-2ubuntu2

**Phase 1: Completed pre-decoding.
       full event: '2018-08-02 00:03:36 status installed nano:amd64 2.5.3-2ubuntu2'
       timestamp: '(null)'
       hostname: 'localhost'
       program_name: '(null)'
       log: '2018-08-02 00:03:36 status installed nano:amd64 2.5.3-2ubuntu2'

**Phase 2: Completed decoding.
       decoder: 'windows-date-format'

**Phase 3: Completed filtering (rules).
       Rule id: '2902'
       Level: '7'
       Description: 'New dpkg (Debian Package) installed.'
**Alert to be generated. 
```