### PR TITLE
New junos rules and decoders

### DIFF
--- a/decoders/0485-junos_decoders.xml
+++ b/decoders/0485-junos_decoders.xml
@@ -1,0 +1,272 @@
+<!--
+wazuh
+-->
+
+<!-- ======= Junos IDS decoders ======= -->
+
+<decoder name="junos-ids">
+    <program_name>junos-ids</program_name>
+</decoder>
+
+<!--
+Aug 24 04:58:58 192.168.1.1 junos-ids: 2017-08-24T04:58:58.724Z sis-srx-EUH-03 RT_IDS - RT_SCREEN_IP [junos@2636.1.1.1.2.35 attack-name="IP spoofing!" source-address="192.168.1.1" destination-address="192.168.1.2" protocol-id="17" source-zone-name="mpls-untrust" interface-name="intf2.210" action="drop"]
+-->
+<decoder name="junos-ids-ip-spoofing">
+    <parent>junos-ids</parent>
+    <prematch>IP spoofing</prematch>
+    <regex offset="after_parent"> (\.+) (\S+) - (\S+) [\S+ attack-name="(\.+)" source-address="(\S+)" destination-address="(\S+)" protocol-id="(\S+)" source-zone-name="(\S+)" interface-name="(\S+)" action="(\S+)"]</regex>
+    <order>firewall_name, cat, sub_cat, attack.name, srcip, dstip, protocol_id, source_zone, interface, action</order>
+</decoder>
+
+<!--
+Sep 15 00:56:32 192.168.1.1 junos-ids: 2017-09-15T00:56:31.626Z sis-srx-nah-03 RT_IDS - RT_SCREEN_TCP [junos@2636.1.1.1.2.35 attack-name="No TCP flag!" source-address="192.168.1.1" source-port="1080" destination-address="192.168.1.2" destination-port="8010" source-zone-name="azure-untrust" interface-name="intf2.225" action="drop"]
+-->
+<decoder name="junos-ids-no-tcp-flags">
+    <parent>junos-ids</parent>
+    <prematch>No TCP flag</prematch>
+    <regex offset="after_parent"> (\.+) (\S+) - (\S+) [\S+ attack-name="(\.+)" source-address="(\S+)" source-port="(\S+)" destination-address="(\S+)" destination-port="(\S+)" source-zone-name="(\S+)" interface-name="(\S+)" action="(\S+)"]</regex>
+    <order>firewall_name,cat, sub_cat, attack.name, srcip, srcport, dstip, dstport, source_zone, interface, action</order>
+</decoder>
+
+<!--
+Generic
+Sep 15 00:56:32 192.168.1.1 junos-ids: 2017-09-15T00:56:31.626Z sis-srx-nah-03 RT_IDS - RT_SCREEN_TCP [junos@2636.1.1.1.2.35 attack-name="text" source-address="192.168.1.1" source-port="1080" destination-address="192.168.1.2" destination-port="8010" source-zone-name="azure-untrust" interface-name="intf2.225" action="drop"]
+-->
+<decoder name="junos-ids-fields">
+    <parent>junos-ids</parent>
+    <regex offset="after_parent"> (\.+) (\S+) - (\S+) [\S+ attack-name="(\.+)" source-address="(\S+)"</regex>
+    <order>firewall_name,cat, sub_cat, attack.name, srcip</order>
+</decoder>
+
+<decoder name="junos-ids-fields">
+    <parent>junos-ids</parent>
+    <regex offset="after_regex">destination-address="(\S+)"</regex>
+    <order>dstip</order>
+</decoder>
+
+
+<!-- ======= Junos IDS decoders ======= -->
+<!--
+wazuh
+-RT_FLOW_SESSION_DENY  -RT_FLOW_SESSION_CREATE -RT_FLOW_SESSION_CLOSE -FLOW_REASSEMBLE_FAIL -FLOW_REASSEMBLE_SUCCEED -FLOW_MCAST_RPF_FAIL
+    <prematch>RT_FLOW</prematch>
+-->
+
+<decoder name="junos-rt-flow">
+    <program_name>junos-flow</program_name>
+</decoder>
+
+
+<!--
+Sep 23 18:17:09 192.168.1.1 junos-flow: 2017-09-23T18:17:08.717Z sis-srx-ABN-01 RT_FLOW - RT_FLOW_SESSION_CREATE [junos@2636.1.1.1.2.39 source-address="192.168.1.1" source-port="1080" destination-address="192.168.1.2" destination-port="8010" service-name="icmp" nat-source-address="192.168.0.1" nat-source-port="1008" nat-destination-address="192.168.0.2" nat-destination-port="8001" src-nat-rule-name="None" dst-nat-rule-name="None" protocol-id="1" policy-name="Templ-Firewall-monitoring" source-zone-name="untrust" destination-zone-name="trust" session-id-32="8xxx1" username="unauthenticated-user" roles="N/A" packet-incoming-interface="intf0.0" application="UNKNOWN"
+-->
+
+<decoder name="junos-rt-flow-session-create">
+    <parent>junos-rt-flow</parent>
+    <prematch>RT_FLOW_SESSION_CREATE</prematch>
+    <regex offset="after_parent"> (\.+) (\S+) - (\S+) \S+ source-address="(\S+)"</regex>
+        <order>firewall_name,cat, subcat,srcip</order>
+</decoder>
+
+<decoder name="junos-rt-flow-session-create">
+    <parent>junos-rt-flow</parent>
+    <regex offset="after_parent">source-port="(\S+)"</regex>
+        <order>srcport</order>
+</decoder>
+
+<decoder name="junos-rt-flow-session-create">
+    <parent>junos-rt-flow</parent>
+    <regex offset="after_parent">destination-address="(\S+)"</regex>
+        <order>dstip</order>
+</decoder>
+
+<decoder name="junos-rt-flow-session-create">
+    <parent>junos-rt-flow</parent>
+    <regex offset="after_parent">destination-port="(\S+)"</regex>
+        <order>dstport</order>
+</decoder>
+
+<decoder name="junos-rt-flow-session-create">
+    <parent>junos-rt-flow</parent>
+    <regex offset="after_parent">service-name="(\S+)"</regex>
+    <order>service_name</order>
+</decoder>
+
+<decoder name="junos-rt-flow-session-create">
+    <parent>junos-rt-flow</parent>
+    <regex offset="after_parent">nat-source-address="(\S+)" nat-source-port="(\S+)" nat-destination-address="(\S+)" nat-destination-port="(\S+)" src-nat-rule-name="(\S+)" dst-nat-rule-name="(\S+)" protocol-id="(\S+)" policy-name="(\S+)" source-zone-name="(\S+)" destination-zone-name="(\S+)" session-id-32="(\S+)" username="(\S+)" roles="(\S+)" packet-incoming-interface="(\S+)" application="(\S+)"</regex>
+    <order>nat_srcip,nat_srcport,nat_dstip,nat_dstport,src_nat_rule_name,dst_nat_rule_name,protocol_id,policy_name,source_zone,destination_zone,session_id_32,username,roles,packet_incoming_interface,application</order>
+</decoder>
+
+<!--
+Sep 23 13:54:55 192.168.1.1 junos-flow: 2017-09-23T13:54:54.803Z sis-srx-mic-01 RT_FLOW - RT_FLOW_SESSION_DENY [junos@2636.1.1.1.2.39 source-address="192.168.1.1" source-port="1080" destination-address="192.168.1.2" destination-port="8010" service-name="junos-dns-udp" protocol-id="17" icmp-type="0" policy-name="Local-Default-Deny" source-zone-name="trust" destination-zone-name="untrust" application="UNKNOWN" nested-application="UNKNOWN" username="N/A" roles="N/A" packet-incoming-interface="intf2.302" encrypted="UNKNOWN" reason="policy deny"]
+-->
+
+<decoder name="junos-rt-flow-session-deny">
+    <parent>junos-rt-flow</parent>
+    <prematch>RT_FLOW_SESSION_DENY</prematch>
+    <regex offset="after_parent"> (\.+) (\S+) - (\S+) \S+ source-address="(\S+)"</regex>
+    <order>firewall_name,cat, subcat,srcip</order>
+</decoder>
+
+<decoder name="junos-rt-flow-session-deny">
+    <parent>junos-rt-flow</parent>
+    <regex offset="after_parent">source-port="(\S+)"</regex>
+    <order>srcport</order>
+</decoder>
+
+<decoder name="junos-rt-flow-session-deny">
+    <parent>junos-rt-flow</parent>
+    <regex offset="after_parent">destination-address="(\S+)"</regex>
+    <order>dstip</order>
+</decoder>
+
+<decoder name="junos-rt-flow-session-deny">
+    <parent>junos-rt-flow</parent>
+    <regex offset="after_parent">destination-port="(\S+)"</regex>
+    <order>dstport</order>
+</decoder>
+
+<decoder name="junos-rt-flow-session-deny">
+    <parent>junos-rt-flow</parent>
+    <regex offset="after_parent">service-name="(\S+)"</regex>
+    <order>service_name</order>
+</decoder>
+
+<decoder name="junos-rt-flow-session-deny">
+    <parent>junos-rt-flow</parent>
+    <regex offset="after_parent">protocol-id="(\S+)" icmp-type="(\S+)" policy-name="(\S+)" source-zone-name="(\S+)" destination-zone-name="(\S+)" application="(\S+)" nested-application="(\S+)" username="(\S+)" roles="(\S+)" packet-incoming-interface="(\S+)" encrypted="(\S+)" reason="(\.+)"]</regex>
+    <order>protocol_id,icm_type,policy_name,source_zone,destination_zone,application,nested_application,username,roles,packet_incoming_interface,encrypted</order>
+</decoder>
+
+<decoder name="junos-rt-flow-session-deny">
+    <parent>junos-rt-flow</parent>
+    <regex offset="after_parent">reason="(\.+)"</regex>
+    <order>reason</order>
+</decoder>
+
+<!--
+Sep 23 18:54:06 192.168.1.1 junos-flow: 2017-09-23T18:54:07.507Z sis-srx-GBS-01 RT_FLOW - RT_FLOW_SESSION_CLOSE [junos@2636.1.1.1.2.39 reason="application failure or action" source-address="192.168.1.1" source-port="1080" destination-address="192.168.1.2" destination-port="8010" service-name="junos-ntp" nat-source-address="192.168.0.1" nat-source-port="1008" nat-destination-address="192.168.0.2" nat-destination-port="8001" src-nat-rule-name="None" dst-nat-rule-name="None" protocol-id="17" policy-name="Local-UAC" source-zone-name="untrust" destination-zone-name="trust" session-id-32="5xxx8" packets-from-client="0" bytes-from-client="0" packets-from-server="0" bytes-from-server="0"
+-->
+
+
+<decoder name="junos-rt-flow-session-close">
+    <parent>junos-rt-flow</parent>
+    <prematch>RT_FLOW_SESSION_CLOSE</prematch>
+    <regex offset="after_parent"> (\.+) (\S+) - (\S+) \S+ reason="(\.+)"</regex>
+    <order>firewall_name,cat, subcat,reason</order>
+</decoder>
+
+<decoder name="junos-rt-flow-session-close">
+    <parent>junos-rt-flow</parent>
+    <regex offset="after_parent">source-address="(\S+)"</regex>
+    <order>srcip</order>
+</decoder>
+
+<decoder name="junos-rt-flow-session-close">
+    <parent>junos-rt-flow</parent>
+    <regex offset="after_parent">source-port="(\S+)"</regex>
+    <order>srcport</order>
+</decoder>
+
+<decoder name="junos-rt-flow-session-close">
+    <parent>junos-rt-flow</parent>
+    <regex offset="after_parent">destination-address="(\S+)"</regex>
+    <order>dstip</order>
+</decoder>
+
+<decoder name="junos-rt-flow-session-close">
+    <parent>junos-rt-flow</parent>
+    <regex offset="after_parent">destination-port="(\S+)"</regex>
+    <order>dstport</order>
+</decoder>
+
+<decoder name="junos-rt-flow-session-close">
+    <parent>junos-rt-flow</parent>
+    <regex offset="after_parent">service-name="(\S+)"</regex>
+    <order>service_name</order>
+</decoder>
+
+<decoder name="junos-rt-flow-session-close">
+    <parent>junos-rt-flow</parent>
+    <regex offset="after_parent">nat-source-address="(\S+)" nat-source-port="(\S+)" nat-destination-address="(\S+)" nat-destination-port="(\S+)" src-nat-rule-name="(\S+)" dst-nat-rule-name="(\S+)" protocol-id="(\S+)" policy-name="(\S+)" source-zone-name="(\S+)" destination-zone-name="(\S+)" session-id-32="(\S+)" packets-from-client="(\S+)" bytes-from-client="(\S+)" packets-from-server="(\S+)" bytes-from-server="(\S+)"</regex>
+    <order>nat_srcip,nat_srcport,nat_dstip,nat_dstport,src_nat_rule_name,dst_nat_rule_name,protocol_id,policy_name,source_zone,destination_zone,session_id_32,packets_from_client,bytes_from_client,packets_from_serve,bytes_from_server</order>
+</decoder>
+
+
+<!--
+Sep 23 18:54:55 192.168.1.1 junos-flow: 2017-09-23T18:54:55.266Z sis-srx-oxn-02 RT_FLOW - FLOW_REASSEMBLE_FAIL [junos@2636.1.1.1.2.39 source-address="192.168.1.1" destination-address="192.168.1.2" assembly-id="3xxx9"]
+-->
+
+<decoder name="junos-rt-flow-reassemble-fail">
+    <parent>junos-rt-flow</parent>
+    <prematch>FLOW_REASSEMBLE_FAIL</prematch>
+    <regex offset="after_parent"> (\.+) (\S+) - (\S+) \S+ source-address="(\S+)"</regex>
+    <order>firewall_name,cat, subcat,srcip</order>
+</decoder>
+
+<decoder name="junos-rt-flow-reassemble-fail">
+    <parent>junos-rt-flow</parent>
+    <regex offset="after_parent">destination-address="(\S+)"</regex>
+    <order>dstip</order>
+
+</decoder>
+
+<decoder name="junos-rt-flow-reassemble-fail">
+    <parent>junos-rt-flow</parent>
+    <regex offset="after_parent">assembly-id="(\S+)"</regex>
+    <order>assembly_id</order>
+</decoder>
+
+<!--
+Sep 23 14:00:59 192.168.1.1 junos-flow: 2017-09-23T14:00:58.570Z sis-srx-dvr-01 RT_FLOW - FLOW_REASSEMBLE_SUCCEED [junos@2636.1.1.1.2.39 source-address="192.168.1.1" destination-address="192.168.1.2" assembly-id="4xxx6"]
+-->
+
+<decoder name="junos-rt-flow-reassemble-succeed">
+    <parent>junos-rt-flow</parent>
+    <prematch>FLOW_REASSEMBLE_SUCCEED</prematch>
+    <regex offset="after_parent"> (\.+) (\S+) - (\S+) \S+ source-address="(\S+)"</regex>
+    <order>firewall_name,cat, subcat,srcip</order>
+</decoder>
+
+<decoder name="junos-rt-flow-reassemble-succeed">
+    <parent>junos-rt-flow</parent>
+    <regex offset="after_parent">destination-address="(\S+)"</regex>
+    <order>dstip</order>
+
+</decoder>
+
+<decoder name="junos-rt-flow-reassemble-succeed">
+    <parent>junos-rt-flow</parent>
+    <regex offset="after_parent">assembly-id="(\S+)"</regex>
+    <order>assembly_id</order>
+</decoder>
+
+<!--
+Sep 21 15:25:06 192.168.1.1 junos-flow: 2017-09-21T15:25:06.141Z sis-srx-ICP-01 RT_FLOW - FLOW_MCAST_RPF_FAIL [junos@2636.1.1.1.2.39 interface-name="intf1.326" source-address="192.168.1.1" destination-address="192.168.1.2" protocol-name="udp"]
+-->
+
+<decoder name="junos-rt-flow-mcast-rpf-fail">
+    <parent>junos-rt-flow</parent>
+    <prematch>FLOW_MCAST_RPF_FAIL</prematch>
+    <regex offset="after_parent"> (\.+) (\S+) - (\S+) \S+ interface-name="(\S+)"</regex>
+    <order>firewall_name,cat, subcat,interface</order>
+</decoder>
+
+<decoder name="junos-rt-flow-mcast-rpf-fail">
+    <parent>junos-rt-flow</parent>
+    <regex offset="after_parent">source-address="(\S+)"</regex>
+    <order>srcip</order>
+</decoder>
+
+<decoder name="junos-rt-flow-mcast-rpf-fail">
+    <parent>junos-rt-flow</parent>
+    <regex offset="after_parent">destination-address="(\S+)"</regex>
+    <order>dstip</order>
+</decoder>
+
+<decoder name="junos-rt-flow-mcast-rpf-fail">
+    <parent>junos-rt-flow</parent>
+    <regex offset="after_parent">protocol-name="(\S+)"]</regex>
+    <order>protocol_name</order>
+</decoder>

--- a/rules/0575-junos_rules.xml
+++ b/rules/0575-junos_rules.xml
@@ -1,0 +1,33 @@
+<!--
+  Junos ruleset
+  Created by Wazuh, Inc. <support@wazuh.com>.
+  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2.
+-->
+
+<group name="junos-ids,junos,rsyslog">
+
+    <rule id="200100" level="0">
+        <decoded_as>junos-ids</decoded_as>
+        <description>Junos IDS</description>
+    </rule>
+
+    <rule id="200101" level="10">
+        <if_sid>200100</if_sid>
+        <description>Junos IDS: $(attack.name)</description>
+    </rule>
+
+</group>
+
+<group name="rsyslog,junos,junos-rtflow,">
+
+    <rule id="130000" level="0">
+        <decoded_as>junos-rt-flow</decoded_as>
+        <description>Junos RT Flow</description>
+    </rule>
+
+    <rule id="130001" level="5">
+        <if_sid>130000</if_sid>
+        <description>Junos RT flow: $(subcat)</description>
+    </rule>
+
+</group>


### PR DESCRIPTION
We have created rules and decoders for Junos IDS.

Examples:


```
Aug 24 04:58:58 192.168.1.1 junos-ids: 2017-08-24T04:58:58.724Z sis-srx-EUH-03 RT_IDS - RT_SCREEN_IP [junos@2636.1.1.1.2.35 attack-name="IP spoofing!" source-address="192.168.1.1" destination-address="192.168.1.2" protocol-id="17" source-zone-name="mpls-untrust" interface-name="intf2.210" action="drop"]


**Phase 1: Completed pre-decoding.
       full event: 'Aug 24 04:58:58 192.168.1.1 junos-ids: 2017-08-24T04:58:58.724Z sis-srx-EUH-03 RT_IDS - RT_SCREEN_IP [junos@2636.1.1.1.2.35 attack-name="IP spoofing!" source-address="192.168.1.1" destination-address="192.168.1.2" protocol-id="17" source-zone-name="mpls-untrust" interface-name="intf2.210" action="drop"]'
       timestamp: 'Aug 24 04:58:58'
       hostname: '192.168.1.1'
       program_name: 'junos-ids'
       log: '2017-08-24T04:58:58.724Z sis-srx-EUH-03 RT_IDS - RT_SCREEN_IP [junos@2636.1.1.1.2.35 attack-name="IP spoofing!" source-address="192.168.1.1" destination-address="192.168.1.2" protocol-id="17" source-zone-name="mpls-untrust" interface-name="intf2.210" action="drop"]'

**Phase 2: Completed decoding.
       decoder: 'junos-ids'
       firewall_name: 'sis-srx-EUH-03'
       cat: 'RT_IDS'
       sub_cat: 'RT_SCREEN_IP'
       attack.name: 'IP spoofing!'
       srcip: '192.168.1.1'
       dstip: '192.168.1.2'
       protocol_id: '17'
       source_zone: 'mpls-untrust'
       interface: 'intf2.210'
       action: 'drop'

**Phase 3: Completed filtering (rules).
       Rule id: '200101'
       Level: '10'
       Description: 'Junos IDS: IP spoofing!'
**Alert to be generated.
```

```
Sep 23 13:54:55 192.168.1.1 junos-flow: 2017-09-23T13:54:54.803Z sis-srx-mic-01 RT_FLOW - RT_FLOW_SESSION_DENY [junos@2636.1.1.1.2.39 source-address="192.168.1.1" source-port="1080" destination-address="192.168.1.2" destination-port="8010" service-name="junos-dns-udp" protocol-id="17" icmp-type="0" policy-name="Local-Default-Deny" source-zone-name="trust" destination-zone-name="untrust" application="UNKNOWN" nested-application="UNKNOWN" username="N/A" roles="N/A" packet-incoming-interface="intf2.302" encrypted="UNKNOWN" reason="policy deny"]


**Phase 1: Completed pre-decoding.
       full event: 'Sep 23 13:54:55 192.168.1.1 junos-flow: 2017-09-23T13:54:54.803Z sis-srx-mic-01 RT_FLOW - RT_FLOW_SESSION_DENY [junos@2636.1.1.1.2.39 source-address="192.168.1.1" source-port="1080" destination-address="192.168.1.2" destination-port="8010" service-name="junos-dns-udp" protocol-id="17" icmp-type="0" policy-name="Local-Default-Deny" source-zone-name="trust" destination-zone-name="untrust" application="UNKNOWN" nested-application="UNKNOWN" username="N/A" roles="N/A" packet-incoming-interface="intf2.302" encrypted="UNKNOWN" reason="policy deny"]'
       timestamp: 'Sep 23 13:54:55'
       hostname: '192.168.1.1'
       program_name: 'junos-flow'
       log: '2017-09-23T13:54:54.803Z sis-srx-mic-01 RT_FLOW - RT_FLOW_SESSION_DENY [junos@2636.1.1.1.2.39 source-address="192.168.1.1" source-port="1080" destination-address="192.168.1.2" destination-port="8010" service-name="junos-dns-udp" protocol-id="17" icmp-type="0" policy-name="Local-Default-Deny" source-zone-name="trust" destination-zone-name="untrust" application="UNKNOWN" nested-application="UNKNOWN" username="N/A" roles="N/A" packet-incoming-interface="intf2.302" encrypted="UNKNOWN" reason="policy deny"]'

**Phase 2: Completed decoding.
       decoder: 'junos-rt-flow'
       firewall_name: 'sis-srx-mic-01'
       cat: 'RT_FLOW'
       subcat: 'RT_FLOW_SESSION_DENY'
       srcip: '192.168.1.1'
       srcport: '1080'
       dstip: '192.168.1.2'
       dstport: '8010'
       service_name: 'junos-dns-udp'
       protocol_id: '17'
       icm_type: '0'
       policy_name: 'Local-Default-Deny'
       source_zone: 'trust'
       destination_zone: 'untrust'
       application: 'UNKNOWN'
       nested_application: 'UNKNOWN'
       username: 'N/A'
       roles: 'N/A'
       packet_incoming_interface: 'intf2.302'
       encrypted: 'UNKNOWN'
       reason: 'policy deny'

**Phase 3: Completed filtering (rules).
       Rule id: '130001'
       Level: '5'
       Description: 'Junos RT flow: RT_FLOW_SESSION_DENY'
**Alert to be generated.
```


```
Sep 21 15:25:06 192.168.1.1 junos-flow: 2017-09-21T15:25:06.141Z sis-srx-ICP-01 RT_FLOW - FLOW_MCAST_RPF_FAIL [junos@2636.1.1.1.2.39 interface-name="intf1.326" source-address="192.168.1.1" destination-address="192.168.1.2" protocol-name="udp"]


**Phase 1: Completed pre-decoding.
       full event: 'Sep 21 15:25:06 192.168.1.1 junos-flow: 2017-09-21T15:25:06.141Z sis-srx-ICP-01 RT_FLOW - FLOW_MCAST_RPF_FAIL [junos@2636.1.1.1.2.39 interface-name="intf1.326" source-address="192.168.1.1" destination-address="192.168.1.2" protocol-name="udp"]'
       timestamp: 'Sep 21 15:25:06'
       hostname: '192.168.1.1'
       program_name: 'junos-flow'
       log: '2017-09-21T15:25:06.141Z sis-srx-ICP-01 RT_FLOW - FLOW_MCAST_RPF_FAIL [junos@2636.1.1.1.2.39 interface-name="intf1.326" source-address="192.168.1.1" destination-address="192.168.1.2" protocol-name="udp"]'

**Phase 2: Completed decoding.
       decoder: 'junos-rt-flow'
       firewall_name: 'sis-srx-ICP-01'
       cat: 'RT_FLOW'
       subcat: 'FLOW_MCAST_RPF_FAIL'
       interface: 'intf1.326'
       srcip: '192.168.1.1'
       dstip: '192.168.1.2'
       protocol_name: 'udp'

**Phase 3: Completed filtering (rules).
       Rule id: '130001'
       Level: '5'
       Description: 'Junos RT flow: FLOW_MCAST_RPF_FAIL'
**Alert to be generated.
```

Kind regards,

Alfonso Ruiz-Bravo