### PR TITLE
Silence 100% of use in snap disks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 
+## [v3.6.1]
+
+### Fixed
+
+- Silence rule about full disk for SNAP partitions. ([#183](https://github.com/wazuh/wazuh-ruleset/pull/183))
+
+
 ## [v3.6.0]
 
 ### Fixed

--- a/rules/0015-ossec_rules.xml
+++ b/rules/0015-ossec_rules.xml
@@ -186,7 +186,7 @@
   <rule id="536" level="0">
     <if_sid>531</if_sid>
       <regex>'df -P':\s+/dev/loop\d+\s+\d+\s+\d+\s+0\s+100%\s+/snap/\w+/\d+</regex>
-      <description>Ignore snap disks because are always 100% of capacity</description>
+      <description>Ignore snap disks because they are always at 100% of capacity</description>
   </rule>
 
 

--- a/rules/0015-ossec_rules.xml
+++ b/rules/0015-ossec_rules.xml
@@ -183,6 +183,13 @@
     <description>List of the last logged in users.</description>
   </rule>
 
+  <rule id="536" level="0">
+    <if_sid>531</if_sid>
+      <regex>'df -P':\s+/dev/loop\d+\s+\d+\s+\d+\s+0\s+100%\s+/snap/\w+/\d+</regex>
+      <description>Ignore snap disks because are always 100% of capacity</description>
+  </rule>
+
+
   <rule id="550" level="7">
     <category>ossec</category>
     <decoded_as>syscheck_integrity_changed</decoded_as>


### PR DESCRIPTION
Added Rule 536 in ossec_rules to silence the alerts of snap disks at 100% of capacity. 
Issue Reference: https://github.com/wazuh/wazuh/issues/996