### PR TITLE
Fixed Cisco-ios acl decoder and prematch

### DIFF
--- a/decoders/0065-cisco-ios_decoders.xml
+++ b/decoders/0065-cisco-ios_decoders.xml
@@ -84,10 +84,23 @@
 <decoder name="cisco-ios-acl">
   <parent>cisco-ios</parent>
   <type>firewall</type>
-  <prematch>^%SEC-6-IPACCESSLOGP: </prematch>
+  <prematch>%SEC-6-IPACCESSLOGP: </prematch>
   <regex offset="after_prematch">^list \S+ (\w+) (\w+) </regex>
+  <order>action, protocol</order>
+</decoder>
+
+<decoder name="cisco-ios-acl">
+  <parent>cisco-ios</parent>
+  <type>firewall</type>
   <regex>(\S+)\((\d+)\) -> (\S+)\((\d+)\),</regex>
-  <order>action, protocol, srcip, srcport, dstip, dstport</order>
+  <order>srcip, srcport, dstip, dstport</order>
+</decoder>
+
+<decoder name="cisco-ios-acl">
+  <parent>cisco-ios</parent>
+  <type>firewall</type>
+  <regex>(\S+)\((\d+)\) \((\S+) (\S*)\) -> (\S+)\((\d+)\),</regex>
+  <order>srcip, srcport, interface, macaddr, dstip, dstport</order>
 </decoder>
 
 
@@ -100,7 +113,7 @@
 <decoder name="cisco-ios-ids">
   <parent>cisco-ios</parent>
   <type>ids</type>
-  <prematch>^%IPS-4-SIGNATURE: </prematch>
+  <prematch>%IPS-4-SIGNATURE: </prematch>
   <regex offset="after_prematch">^Sig:(\d+) \.+[(\S+):(\d+) -> </regex>
   <regex>(\S+):(\d+)]</regex>
   <order>id, srcip, srcport, dstip, dstport</order>

--- a/decoders/0065-cisco-ios_decoders.xml
+++ b/decoders/0065-cisco-ios_decoders.xml
@@ -72,6 +72,17 @@
   <prematch>^\d+:\s+\p*\w+\s+\d+\s+\S+\s+\w+:\s+%</prematch>
 </decoder>
 
+<!--
+  - Sequence number, date (preceded by * or . or nothing) and hour without timezone
+  - 25439: .Oct 11 19:32:10: %SEC-6-IPACCESSLOGS:
+  - 25439: *Oct 11 19:32:10: %SEC-6-IPACCESSLOGS:
+  - 25439: Oct 11 19:32:10: %SEC-6-IPACCESSLOGS:
+-->
+
+<decoder name="cisco-ios">
+  <prematch>^\d+:\s+\p*\w+\s+\d+\s+\S+:\s+%</prematch>
+</decoder>
+
 
 <!-- Cisco IOS
   - Will extract the action, srcip, srcport, dstip and dstport

--- a/tools/rules-testing/tests/cisco_ios.ini
+++ b/tools/rules-testing/tests/cisco_ios.ini
@@ -12,7 +12,8 @@ decoder = cisco-ios
 [cisco ios: acl ]
 log 1 pass = Sep  1 10:25:29 10.10.10.1 %SEC-6-IPACCESSLOGP: list 102 denied tcp 10.0.6.56(3067) -> 172.36.4.7(139), 1 packet
 log 2 pass = Sep  1 10:25:29 10.10.10.1 %SEC-6-IPACCESSLOGP: list 199 denied tcp 10.0.61.108(1477) -> 10.0.127.20(445), 1 packet
-
+log 3 pass = 3924923: *Oct 6 03:32:04 mng: %SEC-6-IPACCESSLOGP: list 1111 denied tcp 10.0.3.100(50150) (Serial4/3 ) -> 192.168.216.1(443), 1 packet
+log 4 pass = Oct 6 03:32:02 gmt: %SEC-6-IPACCESSLOGP: list bes_in denied udp xx.xxx.xx.xx(137) (GigabitEthernet0/1.6 ca5c.1da2.ba43) -> xx.xx.xx.xx(137), 1 packet
 
 rule = 4100
 alert = 0


### PR DESCRIPTION
Fixes #205 

Tested with this samples:
Logs with correct timestamp keeps working
``Oct  6 03:32:02 mng: %SEC-6-IPACCESSLOGP: list 1111 denied udp xx.xxx.xx.xx(137) -> xxx.xxx.xxx.xx(137), 1 packet ``

Logs with other not predecoded formats and log including interface being now decoded properly
``3924923: *Oct  6 03:32:04 mng: %SEC-6-IPACCESSLOGP: list 1111 denied tcp 10.0.3.100(50150) (Serial4/3 ) -> 192.168.216.1(443), 1 packet ``

``Oct  6 03:32:02 gmt: %SEC-6-IPACCESSLOGP: list bes_in denied udp xx.xxx.xx.xx(137) (GigabitEthernet0/1.6 ca5c.1da2.ba43) -> xx.xx.xx.xx(137), 1 packet ``

Regards,
Miguel
