### PR TITLE
Huawei usg new rules and decoders

### DIFF
--- a/decoders/0377-huawei-usg_decoders.xml
+++ b/decoders/0377-huawei-usg_decoders.xml
@@ -1,7 +1,7 @@
 <!--
   -  Huawei USG decoders
-  -  Author: Miguel Ruiz.
-  -  Wazuh, Inc. <support@wazuh.com>.
+  -  Created by Wazuh, Inc.
+  -  Copyright (C) 2015-2019, Wazuh Inc.
   -  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2.
 -->
 

--- a/decoders/0377-huawei-usg_decoders.xml
+++ b/decoders/0377-huawei-usg_decoders.xml
@@ -1,0 +1,89 @@
+<!--
+  -  Huawei USG decoders
+  -  Author: Miguel Ruiz.
+  -  Wazuh, Inc. <support@wazuh.com>.
+  -  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2.
+-->
+
+
+<!--
+  - Group for Huawei USG messages.
+  - %%01SECLOG/6/SESSION_TEARDOWN(l):
+  - USG6300 %%01SECLOG/6/SESSION_TEARDOWN(l):
+  - Oct  5 2018 10:52:12 USG6300 %%01POLICY/6/POLICYPERMIT(l):
+  - 2018-10-05 10:52:13 USG6300 %%01SECLOG/6/SESSION_TEARDOWN(l):
+ -->
+
+<decoder name="huawei-usg">
+  <prematch>^%%\d\d\S+/\d/\S+\(\w\):</prematch>
+</decoder>
+
+<decoder name="huawei-usg">
+  <prematch>^USG\d\d\d\d\s+%%\d\d\S+/\d/\S+\(\w\):</prematch>
+</decoder>
+
+<!--
+  - Month, day, year and hour
+  - Oct  5 2018 10:52:12 USG6300 %%01POLICY/6/POLICYPERMIT(l):
+-->
+<decoder name="huawei-usg">
+  <prematch>^\w+\s+\d+\s+\d+\s+\d+:\d+:\d+\s+USG\d\d\d\d\s+%%\d\d\S+/\d/\S+\(\w\):</prematch>
+</decoder>
+
+<!--
+  - yyyy-mm-dd hh:mm:ss date format
+  - 2018-10-05 10:52:13 USG6300 %%01SECLOG/6/SESSION_TEARDOWN(l):
+-->
+
+<decoder name="huawei-usg">
+  <prematch>^\d\d\d\d-\d\d-\d\d\s+\d\d:\d\d:\d\d\s+USG\d\d\d\d\s+%%\d\d\S+/\d/\S+\(\w\):</prematch>
+</decoder>
+
+<!--
+  - yyyy-mm-dd hh:mm:ss date format
+  - 2018/10/05 09:52:14 USG6300 %%01URL/4/FILTER(l):
+-->
+
+<decoder name="huawei-usg">
+  <prematch>^\d\d\d\d/\d\d/\d\d\s+\d\d:\d\d:\d\d\s+USG\d\d\d\d\s+%%\d\d\S+/\d/\S+\(\w\):</prematch>
+</decoder>
+
+<!-- Huawei USG Filter
+  - Extracts the ID of USG messages.
+  - Sample:
+  - 2018/10/05 09:52:14 USG6300 %%01URL/4/FILTER(l): The URL filtering policy was matched. (SyslogId=1932435, VSys="public", Policy="Internet access", SrcIp=1.1.1.1, DstIp=2.2.2.2, SrcPort=53722, DstPort=80, SrcZone=dmz, DstZone=untrust, User="unknown", Protocol=TCP, Application="example.com", Profile="prof01", Type=Timeout or default action, EventNum=1, Category="none", SubCategory="none", Page="*reinstall", Host="service.example.com", Item="none", Action=Alert)
+  -->
+
+<decoder name="huawei-usg-filter">
+  <parent>huawei-usg</parent>
+  <prematch>%%\d\dURL/4/FILTER\(l\):</prematch>
+  <regex>(%%\d\d\S+/\d/\S+)\(\w\):</regex>
+  <order>id</order>
+</decoder>
+
+<decoder name="huawei-usg-filter">
+  <parent>huawei-usg</parent>
+  <regex>SyslogId=\d+, VSys="\S*", Policy="\.*", SrcIp=(\S+), DstIp=(\S+), SrcPort=(\d+), DstPort=(\d+)</regex>
+  <order>srcip, dstip, srcport, dstport</order>
+</decoder>
+
+<decoder name="huawei-usg-filter">
+  <parent>huawei-usg</parent>
+  <regex>User="(\.+)", Protocol=(\S+), Application="(\S+)", Profile="(\.+)"</regex>
+  <order>user, protocol, application, profile</order>
+</decoder>
+
+<decoder name="huawei-usg-filter">
+  <parent>huawei-usg</parent>
+  <regex>Host="(\S+)", Item="\.*", Action=(\w+)\)</regex>
+  <order>host, action</order>
+</decoder>
+
+<!-- Huawei USG Default
+  - Extracts the ID of USG messages.
+  -->
+<decoder name="huawei-usg-default">
+  <parent>huawei-usg</parent>
+  <regex>(%%\d\d\S+/\d/\S+)\(\w\):</regex>
+  <order>id</order>
+</decoder>

--- a/rules/0565-huawei-usg_rules.xml
+++ b/rules/0565-huawei-usg_rules.xml
@@ -1,0 +1,66 @@
+<!--
+  -  Huawei USG rules
+  -  Author: Miguel Ruiz
+  -  Wazuh, Inc. <support@wazuh.com>.
+  -  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2.
+-->
+<!-- ID: 88200 - 88399 -->
+
+<group name="syslog,huawei_usg,">
+  <rule id="88200" level="0">
+    <decoded_as>huawei-usg</decoded_as>
+    <description>Grouping of Huawei USG rules.</description>
+  </rule>
+
+  <rule id="88210" level="10">
+    <if_sid>88200</if_sid>
+    <id>/0/</id>
+    <description>Huawei USG emergency message.</description>
+    <group>gpg13_3.2,gdpr_IV_35.7.d,</group>
+  </rule>
+
+  <rule id="88211" level="7">
+    <if_sid>88200</if_sid>
+    <id>/1/</id>
+    <description>Huawei USG alert message.</description>
+    <group>gpg13_3.2,</group>
+  </rule>
+
+  <rule id="88212" level="5">
+    <if_sid>88200</if_sid>
+    <id>/2/</id>
+    <description>Huawei USG critical message.</description>
+    <group>gpg13_3.2,</group>
+  </rule>
+
+  <rule id="88213" level="4">
+    <if_sid>88200</if_sid>
+    <id>/3/</id>
+    <description>Huawei USG error message.</description>
+    <group>gpg13_3.5,</group>
+  </rule>
+
+  <rule id="88214" level="3">
+    <if_sid>88200</if_sid>
+    <id>/4/</id>
+    <description>Huawei USG warning message.</description>
+  </rule>
+
+  <rule id="88215" level="0">
+    <if_sid>88200</if_sid>
+    <id>/5/</id>
+    <description>Huawei USG notification message.</description>
+  </rule>
+
+  <rule id="88216" level="0">
+    <if_sid>88200</if_sid>
+    <id>/6/</id>
+    <description>Huawei USG informational message.</description>
+  </rule>
+
+  <rule id="88217" level="0">
+    <if_sid>88200</if_sid>
+    <id>/7/</id>
+    <description>Huawei USG debug message.</description>
+  </rule>
+</group>

--- a/tools/rules-testing/tests/huawei_usg.ini
+++ b/tools/rules-testing/tests/huawei_usg.ini
@@ -1,0 +1,19 @@
+[huawei usg: filter]
+log 1 pass = 2018/10/05 09:52:14 USG6300 %%01URL/4/FILTER(l): The URL filtering policy was matched. (SyslogId=1906054, VSys="public", Policy="Internet Access", SrcIp=1.1.1.1, DstIp=2.2.2.2, SrcPort=5702, DstPort=80, SrcZone=dmz, DstZone=untrust, User="unknown", Protocol=TCP, Application="google", Profile="prof1", Type=Pre-defined, EventNum=1, Category="Search Engines/Portals", SubCategory="Search Engines", Page="*", Host="www.google.com", Item="none", Action=Alert)
+
+
+rule = 88214
+alert = 4
+decoder = huawei-usg-filter
+
+
+[huawei usg: default-level-6 ]
+log 1 pass = Oct  5 2018 10:52:19 USG6300 %%01POLICY/6/POLICYPERMIT(l):vsys=public, protocol=17, source-ip=1.1.1.1, source-port=2426, destination-ip=2.2.2.2, destination-port=2234, time=2018/10/5 09:52:19, source-zone=dmz, destination-zone=untrust, rule-name=Internet Access.
+log 2 pass = 2018-10-05 10:52:13 USG6300 %%01SECLOG/6/SESSION_TEARDOWN(l):IPVer=4,Protocol=tcp,SourceIP=1.1.1.1,DestinationIP=2.2.2.2,SourcePort=6182,DestinationPort=443,BeginTime=1538736476,EndTime=1538736733,SendPkts=21,SendBytes=2135,RcvPkts=18,RcvBytes=1534,SourceVpnID=0,DestinationVpnID=0,PolicyName=Internet Access.
+
+
+rule = 88216
+alert = 0
+decoder = huawei-usg
+
+

--- a/tools/rules-testing/tests/huawei_usg.ini
+++ b/tools/rules-testing/tests/huawei_usg.ini
@@ -4,7 +4,7 @@ log 1 pass = 2018/10/05 09:52:14 USG6300 %%01URL/4/FILTER(l): The URL filtering 
 
 rule = 88214
 alert = 4
-decoder = huawei-usg-filter
+decoder = huawei-usg
 
 
 [huawei usg: default-level-6 ]

--- a/tools/rules-testing/tests/huawei_usg.ini
+++ b/tools/rules-testing/tests/huawei_usg.ini
@@ -3,7 +3,7 @@ log 1 pass = 2018/10/05 09:52:14 USG6300 %%01URL/4/FILTER(l): The URL filtering 
 
 
 rule = 88214
-alert = 4
+alert = 3
 decoder = huawei-usg
 
 


### PR DESCRIPTION
Hi team,
I created new rules and decoders for Huawei USG devices.

Here some log examples I used to create the decoders:
```
Oct  5 2018 10:52:19 USG6300 %%01POLICY/6/POLICYPERMIT(l):vsys=public, protocol=17, source-ip=1.1.1.1, source-port=2426, destination-ip=2.2.2.2, destination-port=2234, time=2018/10/5 09:52:19, source-zone=dmz, destination-zone=untrust, rule-name=Internet Access.
2018/10/05 09:52:14 USG6300 %%01URL/4/FILTER(l): The URL filtering policy was matched. (SyslogId=1906054, VSys="public", Policy="Internet Access", SrcIp=1.1.1.1, DstIp=2.2.2.2, SrcPort=5702, DstPort=80, SrcZone=dmz, DstZone=untrust, User="unknown", Protocol=TCP, Application="google", Profile="prof1", Type=Pre-defined, EventNum=1, Category="Search Engines/Portals", SubCategory="Search Engines", Page="*", Host="www.google.com", Item="none", Action=Alert)
2018-10-05 10:52:13 USG6300 %%01SECLOG/6/SESSION_TEARDOWN(l):IPVer=4,Protocol=tcp,SourceIP=1.1.1.1,DestinationIP=2.2.2.2,SourcePort=6182,DestinationPort=443,BeginTime=1538736476,EndTime=1538736733,SendPkts=21,SendBytes=2135,RcvPkts=18,RcvBytes=1534,SourceVpnID=0,DestinationVpnID=0,PolicyName=Internet Access.
```
To create the rules, I used the alerts severity level included in the log between '/' as you can see [here](http://support.huawei.com/view/contentview!getFileStream.action?mid=SUPE_DOC&viewNid=EDOC1000047754&nid=EDOC1000047754&partNo=j004&type=htm#cbb100023_02)
 and the severity table is [here](http://support.huawei.com/hedex/pages/EDOC100009448831188717/02/EDOC100009448831188717/02/resources/cbb/dc_cbb_log_severity.html)

I also created unit tests with the samples I have.

Kind regards,
Miguel R.