### PR TITLE
Fix for pause rule in Docker

### DIFF
--- a/rules/0560-docker_integration_rules.xml
+++ b/rules/0560-docker_integration_rules.xml
@@ -42,7 +42,7 @@ ID: 87900 - 87999
 
     <rule id="87905" level="3">
         <if_sid>87900</if_sid>
-        <field name="docker.status">pause</field>
+        <field name="docker.status">^pause</field>
         <description>Container $(docker.Actor.Attributes.name) paused</description>
     </rule>
 


### PR DESCRIPTION
Hi team,

I fixed `pause` rule for Docker containers. This rule caught `unpause` events as `pause` events:
```bash
{
  "timestamp": "2018-10-18T08:37:53.898+0200",
  "rule": {
    "level": 3,
    "description": "Container apache paused",
    "id": "87905",
    "mail": false,
    "groups": [
      "docker"
    ]
  },
  "agent": {
    "id": "002",
    "name": "agent002",
    "ip": "192.168.122.19",
    "labels": {
      "aws": {
        "instance-id": "i-052a1838c",
        "sec-group": "sg-1103"
      },
      "network": {
        "ip": "172.17.0.0",
        "mac": "02:42:ac:11:00:02"
      }
    }
  },
  "manager": {
    "name": "localhost.localdomain"
  },
  "id": "1539844673.206605",
  "cluster": {
    "name": "wazuh",
    "node": "master"
  },
  "full_log": "{\"docker\": {\"status\": \"unpause\", \"timeNano\": 1539844673885548900, \"from\": \"httpd\", \"Actor\": {\"Attributes\": {\"image\": \"httpd\", \"name\": \"apache\"}, \"ID\": \"018205fa7e170e32578b8487e3b7040aad00b8accedb983bc2ad029238ca3620\"}, \"time\": 1539844673, \"Action\": \"unpause\", \"Type\": \"container\", \"id\": \"018205fa7e170e32578b8487e3b7040aad00b8accedb983bc2ad029238ca3620\"}, \"integration\": \"docker\"}",
  "decoder": {
    "name": "json"
  },
  "data": {
    "docker": {
      "status": "unpause",
      "timeNano": "1539844673885548800.000000",
      "from": "httpd",
      "Actor": {
        "Attributes": {
          "image": "httpd",
          "name": "apache"
        },
        "ID": "018205fa7e170e32578b8487e3b7040aad00b8accedb983bc2ad029238ca3620"
      },
      "time": "1539844673",
      "Action": "unpause",
      "Type": "container",
      "id": "018205fa7e170e32578b8487e3b7040aad00b8accedb983bc2ad029238ca3620"
    },
    "integration": "docker"
  },
  "location": "Wazuh-Docker"
}
```
After this fix, `unpause` events are caught properly:
```bash
{
  "timestamp": "2018-10-18T08:42:00.57+0200",
  "rule": {
    "level": 3,
    "description": "Container apache unpaused",
    "id": "87906",
    "mail": false,
    "groups": [
      "docker"
    ]
  },
  "agent": {
    "id": "002",
    "name": "agent002",
    "ip": "192.168.122.19",
    "labels": {
      "aws": {
        "instance-id": "i-052a1838c",
        "sec-group": "sg-1103"
      },
      "network": {
        "ip": "172.17.0.0",
        "mac": "02:42:ac:11:00:02"
      }
    }
  },
  "manager": {
    "name": "localhost.localdomain"
  },
  "id": "1539844920.227536",
  "cluster": {
    "name": "wazuh",
    "node": "master"
  },
  "full_log": "{\"docker\": {\"status\": \"unpause\", \"timeNano\": 1539844920052313662, \"from\": \"httpd\", \"Actor\": {\"Attributes\": {\"image\": \"httpd\", \"name\": \"apache\"}, \"ID\": \"018205fa7e170e32578b8487e3b7040aad00b8accedb983bc2ad029238ca3620\"}, \"time\": 1539844920, \"Action\": \"unpause\", \"Type\": \"container\", \"id\": \"018205fa7e170e32578b8487e3b7040aad00b8accedb983bc2ad029238ca3620\"}, \"integration\": \"docker\"}",
  "decoder": {
    "name": "json"
  },
  "data": {
    "docker": {
      "status": "unpause",
      "timeNano": "1539844920052313600.000000",
      "from": "httpd",
      "Actor": {
        "Attributes": {
          "image": "httpd",
          "name": "apache"
        },
        "ID": "018205fa7e170e32578b8487e3b7040aad00b8accedb983bc2ad029238ca3620"
      },
      "time": "1539844920",
      "Action": "unpause",
      "Type": "container",
      "id": "018205fa7e170e32578b8487e3b7040aad00b8accedb983bc2ad029238ca3620"
    },
    "integration": "docker"
  },
  "location": "Wazuh-Docker"
}
```
Best regards,

Demetrio.