### PR TITLE
Disable update_ruleset on worker nodes

### DIFF
--- a/update_ruleset
+++ b/update_ruleset
@@ -26,6 +26,10 @@ from filecmp import cmp
 from time import time
 from json import dumps
 
+# Set framework path
+sys.path.append(os.path.dirname(sys.argv[0]) + '/../framework')  # It is necessary to import Wazuh package
+from wazuh.cluster.cluster import read_config
+
 try:
     from urllib2 import urlopen, URLError, HTTPError
 except:
@@ -580,6 +584,10 @@ def usage():
 
 
 if __name__ == "__main__":
+
+    if read_config()['node_type'] != 'master':
+        print("This script only works on master nodes.")
+        sys.exit()
 
     if os.geteuid() != 0:
         print("You need root privileges to run this script. Please try again, using 'sudo'. Exiting.")

--- a/update_ruleset
+++ b/update_ruleset
@@ -586,8 +586,8 @@ def usage():
 if __name__ == "__main__":
 
     if read_config()['node_type'] != 'master':
-        print("This script only works on master nodes.")
-        sys.exit()
+        print("This script only works on master nodes. Exiting.")
+        sys.exit(1)
 
     if os.geteuid() != 0:
         print("You need root privileges to run this script. Please try again, using 'sudo'. Exiting.")

--- a/update_ruleset
+++ b/update_ruleset
@@ -585,11 +585,13 @@ def usage():
 
 if __name__ == "__main__":
 
-    if read_config()['node_type'] != 'master' and read_config()['disabled'] == 'no':
-        binary_name = "update_ruleset"
-        master_ip = read_config()['nodes'][0]
-        print("Wazuh is running in cluster mode: {BINARY_NAME} is not available in worker nodes. "
-            "Please, try again in the master node: {MASTER_IP}".format(BINARY_NAME=binary_name, MASTER_IP=master_ip))
+    cluster_config = read_config()
+
+    if cluster_config['node_type'] != 'master' and cluster_config['disabled'] == 'no':
+        executable_name = "update_ruleset"
+        master_ip = cluster_config['nodes'][0]
+        print("Wazuh is running in cluster mode: {EXECUTABLE_NAME} is not available in worker nodes. "
+            "Please, try again in the master node: {MASTER_IP}".format(EXECUTABLE_NAME=executable_name, MASTER_IP=master_ip))
         sys.exit(1)
 
     if os.geteuid() != 0:

--- a/update_ruleset
+++ b/update_ruleset
@@ -585,8 +585,11 @@ def usage():
 
 if __name__ == "__main__":
 
-    if read_config()['node_type'] != 'master':
-        print("This script only works on master nodes. Exiting.")
+    if read_config()['node_type'] != 'master' and read_config()['disabled'] == 'no':
+        binary_name = "update_ruleset"
+        master_ip = read_config()['nodes'][0]
+        print("Wazuh is running in cluster mode: {BINARY_NAME} is not available in worker nodes. "
+            "Please, try again in the master node: {MASTER_IP}".format(BINARY_NAME=binary_name, MASTER_IP=master_ip))
         sys.exit(1)
 
     if os.geteuid() != 0:


### PR DESCRIPTION
Hi team,

This PR is for disabling `update_ruleset` script on worker nodes:
```bash
# /var/ossec/bin/update_ruleset
Wazuh is running in cluster mode: update_ruleset is not available in worker nodes. Please, try again in the master node: 192.168.122.143
```
Best regards,

Demetrio.