### PR TITLE
Fix Sysmon ID #3 with empty DestinationPortName:

### DIFF
--- a/decoders/0380-windows_decoders.xml
+++ b/decoders/0380-windows_decoders.xml
@@ -258,6 +258,8 @@ Event ID 2: A process changed a file creation time
 Event ID 3: Network connection
 
 2015 Nov 19 20:33:25 WinEvtLog: Microsoft-Windows-Sysmon/Operational: INFORMATION(3): Microsoft-Windows-Sysmon: SYSTEM: NT AUTHORITY: WIN-K3UD9R5LCEL: Network connection detected:  UtcTime: 2015-11-19 19:33:23.824  ProcessGuid: {0B364D7C-23F6-564E-0000-00100D5A1100}  ProcessId: 2028  Image: C:\Program Files (x86)\Internet Explorer\iexplore.exe  User: WIN-K3UD9R5LCEL\Administrator  Protocol: tcp  Initiated: true  SourceIsIpv6: false  SourceIp: 192.168.2.201  SourceHostname: WIN-K3UD9R5LCEL.LinDomain  SourcePort: 49192  SourcePortName:   DestinationIsIpv6: false  DestinationIp: XXX.58.XXX.206  DestinationHostname: webdest  DestinationPort: 443  DestinationPortName: https
+2018 Nov 03 14:41:15 WinEvtLog: Microsoft-Windows-Sysmon/Operational: INFORMATION(3): Microsoft-Windows-Sysmon: SYSTEM: NT AUTHORITY: HOST2.abcusa.local: Network connection detected:  RuleName:   UtcTime: 2018-11-03 18:41:12.049  ProcessGuid: {1DCE106C-1FD9-5BD9-0000-001089032E01}  ProcessId: 12836  Image: C:\Windows\System32\mmc.exe  User: ABCUSA\admin.smith  Protocol: tcp  Initiated: true  SourceIsIpv6: false  SourceIp: 10.150.133.7  SourceHostname: HOST2.abcusa.local  SourcePort: 54709  SourcePortName:   DestinationIsIpv6: false  DestinationIp: 10.150.133.6  DestinationHostname: HOST1.abcusa.local  DestinationPort: 49161  DestinationPortName: 
+
 -->
 
 <decoder name="Sysmon-EventID#3">
@@ -271,7 +273,7 @@ Event ID 3: Network connection
 <decoder name="Sysmon-EventID#3">
     <parent>windows</parent>
     <type>windows</type>
-    <regex offset="after_regex">ProcessGuid: (\.*) \s*ProcessId: (\.*) \s*Image: (\.*)\s+User: (\.*)\s+Protocol: (\S*)\s+Initiated: (\.*) \s*SourceIsIpv6: (\.*) \s*SourceIp: (\S*)\s+SourceHostname: (\.*) \s*SourcePort: (\S*)\s+SourcePortName: (\.*)\s*DestinationIsIpv6: (\.*) \s*DestinationIp: (\S*)\s+DestinationHostname: (\.*) \s*DestinationPort: (\S*)\s*DestinationPortName: (\S*)\s*$</regex>
+    <regex offset="after_regex">ProcessGuid: (\.*) \s*ProcessId: (\.*) \s*Image: (\.*)\s+User: (\.*)\s+Protocol: (\S*)\s+Initiated: (\.*) \s*SourceIsIpv6: (\.*) \s*SourceIp: (\S*)\s+SourceHostname: (\.*) \s*SourcePort: (\S*)\s+SourcePortName: (\.*)\s*DestinationIsIpv6: (\.*) \s*DestinationIp: (\S*)\s+DestinationHostname: (\.*) \s*DestinationPort: (\S*)\s*DestinationPortName:\s*(\S*)\s*$</regex>
     <order>sysmon.processGuid, sysmon.processId, sysmon.image, srcuser, protocol, sysmon.initiated, sysmon.sourceIsIpv6, srcip, sysmon.sourceHostname, srcport, sysmon.srcPortName, sysmon.destinationIsIpv6, dstip, sysmon.destinationHostname, dstport, sysmon.dstPortName</order>
 </decoder>
 


### PR DESCRIPTION
Previously the Sysmon ID #3 decoder would fail to parse fields if the log entry ended with an empty "DestinationPortName:" value.