### PR TITLE
Update 0220-msauth_rules.xml

### DIFF
--- a/rules/0220-msauth_rules.xml
+++ b/rules/0220-msauth_rules.xml
@@ -900,7 +900,7 @@
     <if_sid>18107</if_sid>
     <id>^4624$</id>
     <match>Logon Type:   8</match>
-    <description>MS Exchange Logon Success.</description>
+    <description>IIS NetworkCleartext Logon Success</description>
     <group>pci_dss_10.2.5,gpg13_7.1,gpg13_7.2,gdpr_IV_32.2,</group>
   </rule>
 


### PR DESCRIPTION
Logon type 8 Windows events are for "NetworkCleartext" type logins, like when logging in to IIS via Basic Authentication.  This is not just for Exchange logins, though they might be one example of this broader category.