### PR TITLE
Update vuln-detector ruleset to 3.7.1

### DIFF
--- a/rules/0520-vulnerability-detector.xml
+++ b/rules/0520-vulnerability-detector.xml
@@ -17,6 +17,15 @@
       <options>no_full_log</options>
       <field name="vulnerability.severity">Low</field>
       <description>$(vulnerability.title)</description>
+      <group>gdpr_IV_35.7.d,</group>
+  </rule>
+
+  <rule id="23507" level="4">
+      <if_sid>23503</if_sid>
+      <options>no_full_log</options>
+      <field name="vulnerability.package.condition">Could not</field>
+      <description>It was not possible to verify whether $(vulnerability.cve) affects $(vulnerability.package.name).</description>
+      <group>gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="23504" level="7">
@@ -24,6 +33,14 @@
       <options>no_full_log</options>
       <field name="vulnerability.severity">Medium|Moderate|Unknown</field>
       <description>$(vulnerability.title)</description>
+      <group>gdpr_IV_35.7.d,</group>
+  </rule>
+
+  <rule id="23508" level="6">
+      <if_sid>23504</if_sid>
+      <options>no_full_log</options>
+      <field name="vulnerability.package.condition">Could not</field>
+      <description>It was not possible to verify whether $(vulnerability.cve) affects $(vulnerability.package.name).</description>
       <group>gdpr_IV_35.7.d,</group>
   </rule>
 
@@ -35,11 +52,27 @@
       <group>gdpr_IV_35.7.d,</group>
   </rule>
 
+  <rule id="23509" level="9">
+      <if_sid>23505</if_sid>
+      <options>no_full_log</options>
+      <field name="vulnerability.package.condition">Could not</field>
+      <description>It was not possible to verify whether $(vulnerability.cve) affects $(vulnerability.package.name).</description>
+      <group>gdpr_IV_35.7.d,</group>
+  </rule>
+
   <rule id="23506" level="13">
       <if_sid>23501</if_sid>
       <options>no_full_log</options>
       <field name="vulnerability.severity">Critical</field>
       <description>$(vulnerability.title)</description>
+      <group>gdpr_IV_35.7.d,</group>
+  </rule>
+
+  <rule id="23510" level="12">
+      <if_sid>23506</if_sid>
+      <options>no_full_log</options>
+      <field name="vulnerability.package.condition">Could not</field>
+      <description>It was not possible to verify whether $(vulnerability.cve) affects $(vulnerability.package.name).</description>
       <group>gdpr_IV_35.7.d,</group>
   </rule>
 </group>


### PR DESCRIPTION
This PR includes the rules of https://github.com/wazuh/wazuh/pull/1932.

Now, if a vulnerability cannot be checked, a lower level alert will be given. This level will be one unit lower than the original rule.

