### PR TITLE
PLEASE DELETE - Generalize description of rule 83201

### DIFF
--- a/rules/0435-ms_logs_rules.xml
+++ b/rules/0435-ms_logs_rules.xml
@@ -20,11 +20,14 @@
 
     <!--
     2017 Mar 28 09:46:17 WinEvtLog: System: INFORMATION(104): Microsoft-Windows-Eventlog: Alberto: WIN-P57C9KN929H: WIN-P57C9KN929H: The Internet Explorer log file was cleared.
+    2018 Dec 05 08:22:48 WinEvtLog: System: INFORMATION(104): Microsoft-Windows-Eventlog: joesmith: ABCNET: Samuel.abcnet.org: The Microsoft-Windows-CAPI2/Operational log file was cleared.
+    2018 Dec 05 08:22:48 WinEvtLog: System: INFORMATION(104): Microsoft-Windows-Eventlog: joesmith: ABCNET: Samuel.abcnet.org: The Microsoft-Windows-IdCtrls/Operational log file was cleared.  
+    2018 Dec 05 08:22:48 WinEvtLog: System: INFORMATION(104): Microsoft-Windows-Eventlog: joesmith: ABCNET: Samuel.abcnet.org: The Microsoft-Windows-WebAuth/Operational log file was cleared.  
     -->
     <rule id="83201" level="5">
         <if_sid>18101</if_sid>
         <id>^104$</id>
-        <description>The Internet Explorer log file was cleared</description>
+        <description>A Windows log file was cleared</description>
         <group>log_clearing_ie,gpg13_10.1,gdpr_II_5.1.f,</group>
     </rule>
 


### PR DESCRIPTION
Rule 83201 catches Windows info event 104 which fires on the clearing of all sorts of Windows logs, not just the Internet Explorer log.  See:
https://docs.microsoft.com/en-us/previous-versions/windows/it-pro/windows-server-2008-R2-and-2008/cc775044(v=ws.10)