### PR TITLE
Generalize description for 83201, plus exclusion

### DIFF
--- a/rules/0435-ms_logs_rules.xml
+++ b/rules/0435-ms_logs_rules.xml
@@ -20,11 +20,17 @@
 
     <!--
     2017 Mar 28 09:46:17 WinEvtLog: System: INFORMATION(104): Microsoft-Windows-Eventlog: Alberto: WIN-P57C9KN929H: WIN-P57C9KN929H: The Internet Explorer log file was cleared.
+    2018 Dec 05 08:22:48 WinEvtLog: System: INFORMATION(104): Microsoft-Windows-Eventlog: joesmith: ABCNET: Samuel.abcnet.org: The Microsoft-Windows-CAPI2/Operational log file was cleared.
+    2018 Dec 05 08:22:48 WinEvtLog: System: INFORMATION(104): Microsoft-Windows-Eventlog: joesmith: ABCNET: Samuel.abcnet.org: The Microsoft-Windows-IdCtrls/Operational log file was cleared.  
+    2018 Dec 05 08:22:48 WinEvtLog: System: INFORMATION(104): Microsoft-Windows-Eventlog: joesmith: ABCNET: Samuel.abcnet.org: The Microsoft-Windows-WebAuth/Operational log file was cleared.  
+    Should not fire on this example:
+    2018 Nov 30 13:29:28 WinEvtLog: System: INFORMATION(104): Microsoft-Windows-ResourcePublication: LOCAL SERVICE: NT AUTHORITY: REBEKAH.abcnet.org: BeginPublication
     -->
     <rule id="83201" level="5">
         <if_sid>18101</if_sid>
         <id>^104$</id>
-        <description>The Internet Explorer log file was cleared</description>
+        <extra_data>Microsoft-Windows-Eventlog</extra_data>
+        <description>A Windows log file was cleared</description>
         <group>log_clearing_ie,gpg13_10.1,gdpr_II_5.1.f,</group>
     </rule>
 


### PR DESCRIPTION
83201 is firing on Windows eventlog 104 clearing event logs in general, not just those involving Internet Explorer.  Also this misfires on Microsoft-Windows-ResourcePublication event #104.