### PR TITLE
0170-nginx_decoders.xml: Make server: content optional

### DIFF
--- a/decoders/0170-nginx_decoders.xml
+++ b/decoders/0170-nginx_decoders.xml
@@ -19,7 +19,7 @@
 
 <decoder name="nginx-errorlog-ip">
   <parent>nginx-errorlog</parent>
-  <prematch offset="after_parent">, client: \S+, server: \S+, request: "\S+ </prematch>
+  <prematch offset="after_parent">, client: \S+, server: \S*, request: "\S+ </prematch>
   <regex offset="after_parent">, client: (\S+), </regex>
   <order>srcip</order>
 </decoder>


### PR DESCRIPTION
"Live" logs of a current nginx where the server: string was empty and the decode wasn't able to extract
the source IP:

```
2018/12/10 11:51:44 [error] 7547#7547: *578685 open() "/usr/share/nginx/html/%{(#dm=@ognl.OgnlContext@DEFAULT_MEMBER_ACCESS).(#_memberAccess?(#_memberAccess=#dm):((#container=#context['com.opensymphony.xwork2.ActionContext.container']).(#ognlUtil=#container.getInstance(@com.opensymphony.xwork2.ognl.OgnlUtil@class)).(#ognlUtil.getExcludedPackageNames().clear()).(#ognlUtil.getExcludedClasses().clear()).(#context.setMemberAccess(#dm)))).(#res=@org.apache.struts2.ServletActionContext@getResponse()).(#res.addHeader('eresult','struts2_security_check'))}/user.action" failed (36: File name too long), client: redacted, server: , request: "POST /%25%7b(%23dm%3d%40ognl.OgnlContext%40DEFAULT_MEMBER_ACCESS).(%23_memberAccess%3f(%23_memberAccess%3d%23dm)%3a((%23container%3d%23context%5b%27com.opensymphony.xwork2.ActionContext.container%27%5d).(%23ognlUtil%3d%23container.getInstance(%40com.opensymphony.xwork2.ognl.OgnlUtil%40class)).(%23ognlUtil.getExcludedPackageNames().clear()).(%23ognlUtil.getExcludedClasses().clear()).(%23context.setMemberAccess(%23dm)))).(%23res%3d%40org.apache.struts2.ServletActionContext%40getResponse()).(%23res.addHeader(%27eresult%27%2c%27struts2_security_check%27))%7d/user.action HTTP/1.1", host: "redacted:80"
```