### PR TITLE
Postfix decoder: Making ending doubled dot optional

### DIFF
--- a/decoders/0220-postfix_decoders.xml
+++ b/decoders/0220-postfix_decoders.xml
@@ -46,7 +46,7 @@
   <use_own_name>true</use_own_name>
   <parent>postfix</parent>
   <prematch>^warning:</prematch>
-  <regex>^warning: (\S+):|warning: Illegal address syntax from unknown[(\S+)]|warning: hostname \S+ does not resolve to address (\S+): </regex>
+  <regex>^warning: (\S+):|warning: Illegal address syntax from unknown[(\S+)]|warning: hostname \S+ does not resolve to address (\S+)</regex>
   <order>srcip</order>
 </decoder>
 

--- a/decoders/0220-postfix_decoders.xml
+++ b/decoders/0220-postfix_decoders.xml
@@ -11,16 +11,18 @@
 <!--
   - Will extract the srcip
   - Examples:
-  - postfix/smtpd[32297]: NOQUEUE: reject: RCPT from unknown[213.255.237.245]: 554
+  - May 08 08:26:55 mail postfix/smtpd[32297]: NOQUEUE: reject: RCPT from unknown[213.255.237.245]: 554
     <ce101@ce.metu.edu.tr>: Relay access denied; from=<kryonomm@yahoo.com>
     to=<e10445@jubiipost.dk> proto=SMTP helo=<SM01.net>
-  - postfix/smtpd[472]: warning: 199.249.24.179.list.dsbl.org: RBL lookup error: Host or domain name not found. Name service error for name=199.249.24.179.list.dsbl.org type=A: Host not found, try again
-  - postfix/smtpd[5268]: warning: 89.248.162.178: hostname no-reverse-dns-configured.com verification failed: Name or service not known
-  - postfix/master[1741]: warning: process /usr/libexec/postfix/cleanup pid 27541 exit status 1
-  - postfix/smtpd[32655]: warning: Illegal address syntax from unknown[157.122.148.252] in MAIL command: <adgjlo@78.41.116.116>
-  - postfix/smtpd[32655]: too many errors after RCPT from unknown[157.122.148.252]
-  - May  8 08:26:55 mail postfix/smtpd[27712]: NOQUEUE: reject: MAIL from localhost[127.0.0.1]: 452 Insufficient system storage
-  - May  8 08:26:55 mail postfix/postscreen[22055]: NOQUEUE: reject: RCPT from [157.122.148.242]:47407: 550 5.7.1 Service unavailable...
+  - May 08 08:26:55 mail postfix/smtpd[472]: warning: 199.249.24.179.list.dsbl.org: RBL lookup error: Host or domain name not found. Name service error for name=199.249.24.179.list.dsbl.org type=A: Host not found, try again
+  - May 08 08:26:55 mail postfix/smtpd[5268]: warning: 89.248.162.178: hostname no-reverse-dns-configured.com verification failed: Name or service not known
+  - May 08 08:26:55 mail postfix/master[1741]: warning: process /usr/libexec/postfix/cleanup pid 27541 exit status 1
+  - May 08 08:26:55 mail postfix/smtpd[32655]: warning: Illegal address syntax from unknown[157.122.148.252] in MAIL command: <adgjlo@78.41.116.116>
+  - May 08 08:26:55 mail postfix/smtpd[32655]: too many errors after RCPT from unknown[157.122.148.252]
+  - May 08 08:26:55 mail postfix/smtpd[27712]: NOQUEUE: reject: MAIL from localhost[127.0.0.1]: 452 Insufficient system storage
+  - May 08 08:26:55 mail postfix/postscreen[22055]: NOQUEUE: reject: RCPT from [157.122.148.242]:47407: 550 5.7.1 Service unavailable...
+  - May 08 08:26:55 mail postfix/smtpd[27266]: warning: hostname other.host does not resolve to address 1.2.3.4: no address associated with name
+  - May 08 08:26:55 mail postfix/smtpd[27266]: warning: hostname other.host does not resolve to address 1.2.3.4
  -->
 
 <decoder name="postfix">
@@ -46,7 +48,7 @@
   <use_own_name>true</use_own_name>
   <parent>postfix</parent>
   <prematch>^warning:</prematch>
-  <regex>^warning: (\S+):|warning: Illegal address syntax from unknown[(\S+)]|warning: hostname \S+ does not resolve to address (\S+)</regex>
+  <regex>^warning: (\S+):|warning: Illegal address syntax from unknown[(\S+)]|warning: hostname \S+ does not resolve to address (\S+): |warning: hostname \S+ does not resolve to address (\S+)</regex>
   <order>srcip</order>
 </decoder>
 

--- a/decoders/0220-postfix_decoders.xml
+++ b/decoders/0220-postfix_decoders.xml
@@ -11,9 +11,7 @@
 <!--
   - Will extract the srcip
   - Examples:
-  - May 08 08:26:55 mail postfix/smtpd[32297]: NOQUEUE: reject: RCPT from unknown[213.255.237.245]: 554
-    <ce101@ce.metu.edu.tr>: Relay access denied; from=<kryonomm@yahoo.com>
-    to=<e10445@jubiipost.dk> proto=SMTP helo=<SM01.net>
+  - May 08 08:26:55 mail postfix/smtpd[32297]: NOQUEUE: reject: RCPT from unknown[213.255.237.245]: 554 <ce101@ce.metu.edu.tr>: Relay access denied; from=<kryonomm@yahoo.com> to=<e10445@jubiipost.dk> proto=SMTP helo=<SM01.net>
   - May 08 08:26:55 mail postfix/smtpd[472]: warning: 199.249.24.179.list.dsbl.org: RBL lookup error: Host or domain name not found. Name service error for name=199.249.24.179.list.dsbl.org type=A: Host not found, try again
   - May 08 08:26:55 mail postfix/smtpd[5268]: warning: 89.248.162.178: hostname no-reverse-dns-configured.com verification failed: Name or service not known
   - May 08 08:26:55 mail postfix/master[1741]: warning: process /usr/libexec/postfix/cleanup pid 27541 exit status 1

--- a/decoders/0220-postfix_decoders.xml
+++ b/decoders/0220-postfix_decoders.xml
@@ -11,16 +11,16 @@
 <!--
   - Will extract the srcip
   - Examples:
-  - May 08 08:26:55 mail postfix/smtpd[32297]: NOQUEUE: reject: RCPT from unknown[213.255.237.245]: 554 <ce101@ce.metu.edu.tr>: Relay access denied; from=<kryonomm@yahoo.com> to=<e10445@jubiipost.dk> proto=SMTP helo=<SM01.net>
-  - May 08 08:26:55 mail postfix/smtpd[472]: warning: 199.249.24.179.list.dsbl.org: RBL lookup error: Host or domain name not found. Name service error for name=199.249.24.179.list.dsbl.org type=A: Host not found, try again
-  - May 08 08:26:55 mail postfix/smtpd[5268]: warning: 89.248.162.178: hostname no-reverse-dns-configured.com verification failed: Name or service not known
-  - May 08 08:26:55 mail postfix/master[1741]: warning: process /usr/libexec/postfix/cleanup pid 27541 exit status 1
-  - May 08 08:26:55 mail postfix/smtpd[32655]: warning: Illegal address syntax from unknown[157.122.148.252] in MAIL command: <adgjlo@78.41.116.116>
-  - May 08 08:26:55 mail postfix/smtpd[32655]: too many errors after RCPT from unknown[157.122.148.252]
-  - May 08 08:26:55 mail postfix/smtpd[27712]: NOQUEUE: reject: MAIL from localhost[127.0.0.1]: 452 Insufficient system storage
-  - May 08 08:26:55 mail postfix/postscreen[22055]: NOQUEUE: reject: RCPT from [157.122.148.242]:47407: 550 5.7.1 Service unavailable...
-  - May 08 08:26:55 mail postfix/smtpd[27266]: warning: hostname other.host does not resolve to address 1.2.3.4: no address associated with name
-  - May 08 08:26:55 mail postfix/smtpd[27266]: warning: hostname other.host does not resolve to address 1.2.3.4
+  - May  8 08:26:55 mail postfix/smtpd[32297]: NOQUEUE: reject: RCPT from unknown[213.255.237.245]: 554 <ce101@ce.metu.edu.tr>: Relay access denied; from=<kryonomm@yahoo.com> to=<e10445@jubiipost.dk> proto=SMTP helo=<SM01.net>
+  - May  8 08:26:55 mail postfix/smtpd[472]: warning: 199.249.24.179.list.dsbl.org: RBL lookup error: Host or domain name not found. Name service error for name=199.249.24.179.list.dsbl.org type=A: Host not found, try again
+  - May  8 08:26:55 mail postfix/smtpd[5268]: warning: 89.248.162.178: hostname no-reverse-dns-configured.com verification failed: Name or service not known
+  - May  8 08:26:55 mail postfix/master[1741]: warning: process /usr/libexec/postfix/cleanup pid 27541 exit status 1
+  - May  8 08:26:55 mail postfix/smtpd[32655]: warning: Illegal address syntax from unknown[157.122.148.252] in MAIL command: <adgjlo@78.41.116.116>
+  - May  8 08:26:55 mail postfix/smtpd[32655]: too many errors after RCPT from unknown[157.122.148.252]
+  - May  8 08:26:55 mail postfix/smtpd[27712]: NOQUEUE: reject: MAIL from localhost[127.0.0.1]: 452 Insufficient system storage
+  - May  8 08:26:55 mail postfix/postscreen[22055]: NOQUEUE: reject: RCPT from [157.122.148.242]:47407: 550 5.7.1 Service unavailable...
+  - May  8 08:26:55 mail postfix/smtpd[27266]: warning: hostname other.host does not resolve to address 1.2.3.4: no address associated with name
+  - May  8 08:26:55 mail postfix/smtpd[27266]: warning: hostname other.host does not resolve to address 1.2.3.4
  -->
 
 <decoder name="postfix">


### PR DESCRIPTION
Dec 14 22:23:34 myhost postfix/smtpd[27266]: warning: hostname other.host does not resolve to address 1.2.3.4