### PR TITLE
Fix auditd decoders

### DIFF
--- a/decoders/0040-auditd_decoders.xml
+++ b/decoders/0040-auditd_decoders.xml
@@ -250,7 +250,7 @@ type=TEST_GENERIC msg=audit(1234567890.123:1234): addr=10.10.10.10 ses=20 exe="l
 
 <decoder name="auditd-generic">
     <parent>auditd</parent>
-    <regex>uid=(\S+)</regex>
+    <regex> uid=(\S+)</regex>
     <order>audit.uid</order>
 </decoder>
 


### PR DESCRIPTION
Hi team,

This PR fixed an issue where auditd-generic decoders makes `auditd.uid` the same value as auid.

```
**Phase 1: Completed pre-decoding.
       full event: 'type=ANOM_ABEND msg=audit(1545007249.541:227013641): auid=4294967295 uid=1000 gid=33 ses=4294967295 pid=95382 comm="apache2" exe="/usr/sbin/apache2" sig=11'
       timestamp: '(null)'
       hostname: '31f8f1e5e096'
       program_name: '(null)'
       log: 'type=ANOM_ABEND msg=audit(1545007249.541:227013641): auid=4294967295 uid=1000 gid=33 ses=4294967295 pid=95382 comm="apache2" exe="/usr/sbin/apache2" sig=11'

**Phase 2: Completed decoding.
       decoder: 'auditd'
       audit.type: 'ANOM_ABEND'
       audit.id: '227013641'
       audit.pid: '95382'
       audit.auid: '4294967295'
       audit.uid: '4294967295'  <- same as auid
       audit.gid: '33'
       audit.session: '4294967295'
       audit.command: 'apache2'
       audit.exe: '/usr/sbin/apache2'
```

After this fix, `auditd.uid` will be the correct value.

```
**Phase 1: Completed pre-decoding.
       full event: 'type=ANOM_ABEND msg=audit(1545007249.541:227013641): auid=4294967295 uid=1000 gid=33 ses=4294967295 pid=95382 comm="apache2" exe="/usr/sbin/apache2" sig=11'
       timestamp: '(null)'
       hostname: '31f8f1e5e096'
       program_name: '(null)'
       log: 'type=ANOM_ABEND msg=audit(1545007249.541:227013641): auid=4294967295 uid=1000 gid=33 ses=4294967295 pid=95382 comm="apache2" exe="/usr/sbin/apache2" sig=11'

**Phase 2: Completed decoding.
       decoder: 'auditd'
       audit.type: 'ANOM_ABEND'
       audit.id: '227013641'
       audit.pid: '95382'
       audit.auid: '4294967295'
       audit.uid: '1000'  <- fixed
       audit.gid: '33'
       audit.session: '4294967295'
       audit.command: 'apache2'
       audit.exe: '/usr/sbin/apache2'
```