### PR TITLE
Unnecessary blanks

### DIFF
--- a/decoders/0040-auditd_decoders.xml
+++ b/decoders/0040-auditd_decoders.xml
@@ -32,7 +32,7 @@ type=SYSCALL msg=audit(1479982525.380:50): arch=c000003e syscall=2 success=yes e
 <!-- SYSCALL - key -->
 <decoder name="auditd-syscall">
     <parent>auditd</parent>
-    <regex offset="after_regex">key=\p(\S+)\p </regex>
+    <regex offset="after_regex">key="(\w+)"</regex>
     <order>audit.key</order>
 </decoder>
 
@@ -76,7 +76,7 @@ type=CONFIG_CHANGE msg=audit(1480085540.632:5846): auid=0 ses=1 op="remove rule"
 
 <decoder name="auditd-config_change">
     <parent>auditd</parent>
-    <regex offset="after_regex">key=\p(\S+)\p</regex>
+    <regex offset="after_regex">key="(\w+)"</regex>
     <order>audit.key</order>
 </decoder>
 


### PR DESCRIPTION
hi!
I use audit logs, but there seems to be extra blanks in the `key` parsing.
```
# grep wazuh /var/log/audit/audit.log| cat -e | tail -1
type=SYSCALL msg=audit(1545272850.206:43539988): arch=c000003e syscall=59 success=yes exit=0 a0=1e2af08 a1=1f63a88 a2=1f50008 a3=598 items=2 ppid=8007 pid=8127 auid=10301 uid=10301 gid=2000 euid=10301 suid=10301 fsuid=10301 egid=2000 sgid=2000 fsgid=2000 tty=pts6 ses=29123 comm="ls" exe="/bin/ls" key="audit-wazuh-c"$
```