### PR TITLE
Fix 0295-sonicwall_decoders.xml

### DIFF
--- a/decoders/0295-sonicwall_decoders.xml
+++ b/decoders/0295-sonicwall_decoders.xml
@@ -16,6 +16,8 @@
   - id=firewall sn=C0EAE4599999 time="2019-02-15 09:45:17 UTC" fw=2.228.169.242 pri=5 c=512 m=1233 msg="Unhandled link-local or multicast IPv6 packet dropped" n=56642 srcV6=fe80::9851:b780:9d9d:a29e src=:49702:X0-V514 dstV6=ff02::1:3 dst=:5355 srcMac=90:e6:ba:32:5c:45 dstMac=33:33:00:01:00:03 proto=udp/5355
   - id=NSA3500BR sn=0017C5DFCEEC time="2019-03-14 16:37:19 UTC" fw=172.29.169.2 pri=1 c=32 m=1388 msg="IPSec VPN Decryption Failed" n=1064050271 src=37.186.204.2 dst=172.29.168.2 note="Replay check failure."
   - id=NSA3600  sn=C0EAE4599999 time="2019-02-27 12:55:40 UTC" fw=2.228.169.242 pri=5 c=0 m=1197 msg="NAT Mapping" n=4748427 src=10.12.14.9::X0-V500 dst=217.56.236.4::X3 proto=icmp note="Source: 2.228.169.242, 63130, Destination: 217.56.236.4, 8, Protocol: 1" rule="17 (LAN->WAN)"
+  - id=NSA2650GG sn=18B169D79980 time="2019-03-19 06:44:01 UTC" fw=83.211.91.146 pri=3 c=4 m=14 msg="Web site access denied" app=49177 appName="General HTTPS" n=856789 src=192.168.0.46:59668:X0:nb020.example.com dst=34.194.213.204:443:X1:example.com srcMac=a0:ce:c8:13:99:c5 dstMac=1a:b1:69:d7:99:80 proto=tcp/https dstname=example.com arg=/ code=49 Category="Freeware/Software Downloads"
+  - id=NSA2650GG sn=18B169D79980 time="2019-03-18 08:33:45 UTC" fw=83.211.91.146 pri=3 c=4 m=14 msg="Web site access denied" app=49177 appName="General HTTPS" n=838005 src=192.168.0.62:54993:X0:pc048.example.com dst=151.101.242.49:443:X1 srcMac=c8:9c:dc:fd:9d:02 dstMac=1a:b1:69:d7:99:80 proto=tcp/https dstname=example.com arg=/ code=49 Category="Freeware/Software Downloads"
   -->
 
 <decoder name="sonicwall">
@@ -38,13 +40,26 @@
 <decoder name="sonicwall-fields">
   <parent>sonicwall</parent>
   <regex offset="after_regex">src=(\d+.\d+.\d+.\d+):(\d+):\S* dst=(\d+.\d+.\d+.\d+):(\d+):\S*</regex>
-  <order>scrip, scrport ,dstip, dstport, protocol</order>
+  <order>srcip, srcport ,dstip, dstport, protocol</order>
 </decoder>
 
 <decoder name="sonicwall-fields">
   <parent>sonicwall</parent>
   <regex offset="after_regex">src=(\d+.\d+.\d+.\d+)\S* dst=(\d+.\d+.\d+.\d+)\S*</regex>
-  <order>scrip, dstip, protocol</order>
+  <order>srcip, dstip, protocol</order>
+</decoder>
+
+
+<decoder name="sonicwall-fields">
+  <parent>sonicwall</parent>
+  <regex>app=(\S+)\s+appName="(\.+)"\.+dstname=(\S+)\.+Category="(\.+)"</regex>
+  <order>app, appName, dstname, Category</order>
+</decoder>
+
+<decoder name="sonicwall-software_downloads">
+  <parent>sonicwall</parent>
+  <regex>id=(\S+)\s+sn=(\S+)\s+time="(\d+-\d\d-\d\d \d\d:\d\d:\d\d) (\S+)"\s+fw=(\S+)\s+pri=(\S+)\s+c=(\S+)\s+m=(\S+)\s+msg="(\.+)"\s+app=(\S+)\s+appName="(\.+)"\s+n=(\S+)\s+src=(\S+)\s+dst=(\S+)\s+srcMac=(\S+)\s+dstMac=(\S+)\s+proto=(\S+)\s+dstname=(\S+)\s+arg=(\S+)\s+code=(\S+)\s+Category="(\.+)"</regex>
+  <order>id,sn,time,timezone,fw,pri,c,m,msg,app,appName,n,src,dst,srcMac,dstMac,proto,dstname,arg,code,Category</order>
 </decoder>
 
 <decoder name="sonicwall-fields">

--- a/decoders/0295-sonicwall_decoders.xml
+++ b/decoders/0295-sonicwall_decoders.xml
@@ -12,12 +12,12 @@
   - Examples:
   - Jan  3 13:45:36 192.168.5.1 id=firewall sn=000SERIAL time="2007-01-03 14:48:06" fw=1.1.1.1 pri=6 c=262144 m=98 msg="Connection Opened" n=23419 src=2.2.2.2:36701:WAN dst=1.1.1.1:50000:WAN proto=tcp/50000
   - Jan  3 13:45:36 192.168.5.1 id=firewall sn=000SERIAL time="2007-01-03 14:48:07" fw=1.1.1.1 pri=1 c=32 m=30 msg="Administrator login denied due to bad credentials" n=7 src=2.2.2.2:36701:WAN dst=1.1.1.1:50000:WAN
-  - id=firewall sn=00301E0526B1 time="2004-04-01 10:39:35"
-  fw=67.32.44.2 pri=5 c=64 m=36 msg="TCP connection dropped" n=2686 src=67.101.200.27:4507:WAN dst=67.32.44.2:445:LAN rule=0
+  - id=firewall sn=00301E0526B1 time="2004-04-01 10:39:35" fw=67.32.44.2 pri=5 c=64 m=36 msg="TCP connection dropped" n=2686 src=67.101.200.27:4507:WAN dst=67.32.44.2:445:LAN rule=0
+  - id=firewall sn=C0EAE4599999 time="2019-02-15 09:45:17 UTC" fw=2.228.169.242 pri=5 c=512 m=1233 msg="Unhandled link-local or multicast IPv6 packet dropped" n=56642 srcV6=fe80::9851:b780:9d9d:a29e src=:49702:X0-V514 dstV6=ff02::1:3 dst=:5355 srcMac=90:e6:ba:32:5c:45 dstMac=33:33:00:01:00:03 proto=udp/5355
   -->
 
 <decoder name="sonicwall">
-   <prematch>^id=\w+ sn=\w+ time=\S+ \S+ fw=\S+ </prematch>
+   <prematch>^id=\w+ sn=\w+ time="\.+" fw=\S+ </prematch>
    <plugin_decoder>SonicWall_Decoder</plugin_decoder>
 </decoder>
 

--- a/decoders/0295-sonicwall_decoders.xml
+++ b/decoders/0295-sonicwall_decoders.xml
@@ -14,10 +14,12 @@
   - Jan  3 13:45:36 192.168.5.1 id=firewall sn=000SERIAL time="2007-01-03 14:48:07" fw=1.1.1.1 pri=1 c=32 m=30 msg="Administrator login denied due to bad credentials" n=7 src=2.2.2.2:36701:WAN dst=1.1.1.1:50000:WAN
   - id=firewall sn=00301E0526B1 time="2004-04-01 10:39:35" fw=67.32.44.2 pri=5 c=64 m=36 msg="TCP connection dropped" n=2686 src=67.101.200.27:4507:WAN dst=67.32.44.2:445:LAN rule=0
   - id=firewall sn=C0EAE4599999 time="2019-02-15 09:45:17 UTC" fw=2.228.169.242 pri=5 c=512 m=1233 msg="Unhandled link-local or multicast IPv6 packet dropped" n=56642 srcV6=fe80::9851:b780:9d9d:a29e src=:49702:X0-V514 dstV6=ff02::1:3 dst=:5355 srcMac=90:e6:ba:32:5c:45 dstMac=33:33:00:01:00:03 proto=udp/5355
+  - id=NSA3500BR sn=0017C5DFCEEC time="2019-03-14 16:37:19 UTC" fw=172.29.169.2 pri=1 c=32 m=1388 msg="IPSec VPN Decryption Failed" n=1064050271 src=37.186.204.2 dst=172.29.168.2 note="Replay check failure."
+  - id=NSA3600  sn=C0EAE4599999 time="2019-02-27 12:55:40 UTC" fw=2.228.169.242 pri=5 c=0 m=1197 msg="NAT Mapping" n=4748427 src=10.12.14.9::X0-V500 dst=217.56.236.4::X3 proto=icmp note="Source: 2.228.169.242, 63130, Destination: 217.56.236.4, 8, Protocol: 1" rule="17 (LAN->WAN)"
   -->
 
 <decoder name="sonicwall">
-   <prematch>^id=\w+ sn=\w+ time="\.+" fw=\S+ </prematch>
+   <prematch>^id=\w+\s+sn=\w+\s+time="\.+"\s+fw=\S+ </prematch>
    <plugin_decoder>SonicWall_Decoder</plugin_decoder>
 </decoder>
 
@@ -39,6 +41,11 @@
   <order>scrip, scrport ,dstip, dstport, protocol</order>
 </decoder>
 
+<decoder name="sonicwall-fields">
+  <parent>sonicwall</parent>
+  <regex offset="after_regex">src=(\d+.\d+.\d+.\d+)\S* dst=(\d+.\d+.\d+.\d+)\S*</regex>
+  <order>scrip, dstip, protocol</order>
+</decoder>
 
 <decoder name="sonicwall-fields">
   <parent>sonicwall</parent>

--- a/decoders/0295-sonicwall_decoders.xml
+++ b/decoders/0295-sonicwall_decoders.xml
@@ -15,8 +15,33 @@
   - id=firewall sn=00301E0526B1 time="2004-04-01 10:39:35"
   fw=67.32.44.2 pri=5 c=64 m=36 msg="TCP connection dropped" n=2686 src=67.101.200.27:4507:WAN dst=67.32.44.2:445:LAN rule=0
   -->
+
 <decoder name="sonicwall">
-  <type>firewall</type>
-  <prematch>^id=\w+ sn=\w+ time=\S+ \S+ fw=\S+ pri=\d </prematch>
-  <plugin_decoder>SonicWall_Decoder</plugin_decoder>
+   <prematch>^id=\w+ sn=\w+ time=\S+ \S+ fw=\S+ </prematch>
+   <plugin_decoder>SonicWall_Decoder</plugin_decoder>
+</decoder>
+
+<decoder name="sonicwall-fields">
+  <parent>sonicwall</parent>
+  <regex offset="after_parent">pri=(\S+)</regex>
+  <order>status</order>
+</decoder>
+
+<decoder name="sonicwall-fields">
+  <parent>sonicwall</parent>
+  <regex offset="after_regex"> msg="(\.+)"</regex>
+  <order>action</order>
+</decoder>
+
+<decoder name="sonicwall-fields">
+  <parent>sonicwall</parent>
+  <regex offset="after_regex">src=(\d+.\d+.\d+.\d+):(\d+):\S* dst=(\d+.\d+.\d+.\d+):(\d+):\S*</regex>
+  <order>scrip, scrport ,dstip, dstport, protocol</order>
+</decoder>
+
+
+<decoder name="sonicwall-fields">
+  <parent>sonicwall</parent>
+  <regex offset="after_regex">proto=(\S+)</regex>
+  <order> protocol</order>
 </decoder>

--- a/tools/rules-testing/tests/SonicWall.ini
+++ b/tools/rules-testing/tests/SonicWall.ini
@@ -1,0 +1,31 @@
+[SonicWall: acl ]
+log 1 pass = id=NSA3600  sn=C0EAE4599999 time="2019-02-27 12:55:40 UTC" fw=2.228.169.242 pri=5 c=0 m=1197 msg="NAT Mapping" n=4748427 src=10.12.14.9::X0-V500 dst=217.56.236.4::X3 proto=icmp note="Source: 2.228.169.242, 63130, Destination: 217.56.236.4, 8, Protocol: 1" rule="17 (LAN->WAN)"
+log 2 pass = id=firewall sn=C0EAE4599999 time="2019-02-15 09:45:17 UTC" fw=2.228.169.242 pri=5 c=512 m=1233 msg="Unhandled link-local or multicast IPv6 packet dropped" n=56642 srcV6=fe80::9851:b780:9d9d:a29e src=:49702:X0-V514 dstV6=ff02::1:3 dst=:5355 srcMac=90:e6:ba:32:5c:45 dstMac=33:33:00:01:00:03 proto=udp/5355
+log 3 pass = id=firewall sn=00301E0526B1 time="2004-04-01 10:39:35" fw=67.32.44.2 pri=5 c=64 m=36 msg="TCP connection dropped" n=2686 src=67.101.200.27:4507:WAN dst=67.32.44.2:445:LAN rule=0
+
+rule = 4805
+alert = 0
+decoder = sonicwall
+
+[SonicWall : ac2 ]
+log 1 pass = Jan  3 13:45:36 192.168.5.1 id=firewall sn=000SERIAL time="2007-01-03 14:48:06" fw=1.1.1.1 pri=6 c=262144 m=98 msg="Connection Opened" n=23419 src=2.2.2.2:36701:WAN dst=1.1.1.1:50000:WAN proto=tcp/50000
+
+rule = 4806
+alert = 0
+decoder = sonicwall
+
+[SonicWall : ac3 ]
+log 1 pass = id=NSA3500BR sn=0017C5DFCEEC time="2019-03-14 16:37:19 UTC" fw=172.29.169.2 pri=1 c=32 m=1388 msg="IPSec VPN Decryption Failed" n=1064050271 src=37.186.204.2 dst=172.29.168.2 note="Replay check failure."
+log 2 pass = Jan  3 13:45:36 192.168.5.1 id=firewall sn=000SERIAL time="2007-01-03 14:48:07" fw=1.1.1.1 pri=1 c=32 m=30 msg="Administrator login denied due to bad credentials" n=7 src=2.2.2.2:36701:WAN dst=1.1.1.1:50000:WAN
+
+rule = 4801
+alert = 8
+decoder = sonicwall
+
+[SonicWall : ac4 ]
+log 1 pass = id=NSA2650GG sn=18B169D79980 time="2019-03-18 08:33:45 UTC" fw=83.211.91.146 pri=3 c=4 m=14 msg="Web site access denied" app=49177 appName="General HTTPS" n=838005 src=192.168.0.62:54993:X0:pc048.example.com dst=151.101.242.49:443:X1 srcMac=c8:9c:dc:fd:9d:02 dstMac=1a:b1:69:d7:99:80 proto=tcp/https dstname=example.com arg=/ code=49 Category="Freeware/Software Downloads"
+log 2 pass = id=NSA2650GG sn=18B169D79980 time="2019-03-19 06:44:01 UTC" fw=83.211.91.146 pri=3 c=4 m=14 msg="Web site access denied" app=49177 appName="General HTTPS" n=856789 src=192.168.0.46:59668:X0:nb020.example.com dst=34.194.213.204:443:X1:example.com srcMac=a0:ce:c8:13:99:c5 dstMac=1a:b1:69:d7:99:80 proto=tcp/https dstname=example.com arg=/ code=49 Category="Freeware/Software Downloads"
+
+rule = 4803
+alert = 4
+decoder = sonicwall


### PR DESCRIPTION
This commit helps preventing False positives caused by the previous Decoder, and it is related to this issue https://github.com/wazuh/wazuh-ruleset/issues/162.

When using this new decoder we will be able to extract all the fields mentioned (srcip, dstip ...) and especially the status id which is used by the sonicwall rules otherwise they would never be triggered.

As you can see below the fields are extracted as well the sonicwall rules are being implemented :
```

Jan  3 13:45:36 192.168.5.1 id=firewall sn=000SERIAL time="2007-01-03 14:48:06" fw=1.1.1.1 pri=6 c=262144 m=98 msg="Connection Opened" n=23419 src=2.2.2.2:36701:WAN dst=1.1.1.1:50000:WAN proto=tcp/50000


**Phase 1: Completed pre-decoding.
       full event: 'Jan  3 13:45:36 192.168.5.1 id=firewall sn=000SERIAL time="2007-01-03 14:48:06" fw=1.1.1.1 pri=6 c=262144 m=98 msg="Connection Opened" n=23419 src=2.2.2.2:36701:WAN dst=1.1.1.1:50000:WAN proto=tcp/50000'
       timestamp: 'Jan  3 13:45:36'
       hostname: '192.168.5.1'
       program_name: '(null)'
       log: 'id=firewall sn=000SERIAL time="2007-01-03 14:48:06" fw=1.1.1.1 pri=6 c=262144 m=98 msg="Connection Opened" n=23419 src=2.2.2.2:36701:WAN dst=1.1.1.1:50000:WAN proto=tcp/50000'

**Phase 2: Completed decoding.
       decoder: 'sonicwall'
       status: '6'
       action: 'Connection Opened'
       scrip: '2.2.2.2'
       scrport: '36701'
       dstip: '1.1.1.1'
       dstport: '50000'
       protocol: 'tcp/50000'

**Phase 3: Completed filtering (rules).
       Rule id: '4806'
       Level: '0'
       Description: 'SonicWall informational message.'
Jan  3 13:45:36 192.168.5.1 id=firewall sn=000SERIAL time="2007-01-03 14:48:07" fw=1.1.1.1 pri=1 c=32 m=30 msg="Administrator login denied due to bad credentials" n=7 src=2.2.2.2:36701:WAN dst=1.1.1.1:50000:WAN


**Phase 1: Completed pre-decoding.
       full event: 'Jan  3 13:45:36 192.168.5.1 id=firewall sn=000SERIAL time="2007-01-03 14:48:07" fw=1.1.1.1 pri=1 c=32 m=30 msg="Administrator login denied due to bad credentials" n=7 src=2.2.2.2:36701:WAN dst=1.1.1.1:50000:WAN'
       timestamp: 'Jan  3 13:45:36'
       hostname: '192.168.5.1'
       program_name: '(null)'
       log: 'id=firewall sn=000SERIAL time="2007-01-03 14:48:07" fw=1.1.1.1 pri=1 c=32 m=30 msg="Administrator login denied due to bad credentials" n=7 src=2.2.2.2:36701:WAN dst=1.1.1.1:50000:WAN'

**Phase 2: Completed decoding.
       decoder: 'sonicwall'
       status: '1'
       action: 'Administrator login denied due to bad credentials'
       scrip: '2.2.2.2'
       scrport: '36701'
       dstip: '1.1.1.1'
       dstport: '50000'

**Phase 3: Completed filtering (rules).
       Rule id: '4801'
       Level: '8'
       Description: 'SonicWall critical message.'
**Alert to be generated.
```

