### PR TITLE
Corrected values of 2.3.10.6 + 2.3.10.10

### DIFF
--- a/configuration-assessment/windows/cis_win2012r2_memberL1_rcl.yml
+++ b/configuration-assessment/windows/cis_win2012r2_memberL1_rcl.yml
@@ -429,7 +429,7 @@ checks:
     - cis_csc: "14.1, 16"
    condition: any
    rules:
-     - 'r:HKEY_LOCAL_MACHINE\System\CurrentControlSet\Services\LanManServer\Parameters -> NullSessionPipes -> !r:lsarpc|netlogon|samr;'
+     - 'r:HKEY_LOCAL_MACHINE\System\CurrentControlSet\Services\LanManServer\Parameters -> NullSessionPipes -> r:\S*;'
      - 'r:HKEY_LOCAL_MACHINE\System\CurrentControlSet\Services\LanManServer\Parameters -> !NullSessionPipes;'
  - id: 9030
    title: "Configure 'Network access: Remotely accessible registry paths'"
@@ -474,7 +474,7 @@ checks:
     - cis_csc: "14, 16"
    condition: any
    rules:
-     - 'r:HKEY_LOCAL_MACHINE\System\CurrentControlSet\Services\LanManServer\Parameters -> NullSessionShares -> r:\.+;'
+     - 'r:HKEY_LOCAL_MACHINE\System\CurrentControlSet\Services\LanManServer\Parameters -> NullSessionShares -> r:\S*;'
  - id: 9034
    title: "Ensure 'Network access: Sharing and security model for local accounts' is set to 'Classic - local users authenticate as themselves'"
    description: "This policy setting determines how network logons that use local accounts are authenticated. The Classic option allows precise control over access to resources, including the ability to assign different types of access to different users for the same resource. The Guest only option allows you to treat all users equally. In this context, all users authenticate as Guest only to receive the same access level to a given resource.  The recommended state for this setting is: Classic - local users authenticate as themselves.  Note: This setting does not affect interactive logons that are performed remotely by using such services as Telnet or Remote Desktop Services (formerly called Terminal Services)."


### PR DESCRIPTION
The checked registry value should be empty on a member server. On my test-machine empty values seems to be filles with spaces. So wazuh shoul check if there is anything not spaces within.