### PR TITLE
Corrected value check 18.8.22.1.11

### DIFF
--- a/configuration-assessment/windows/cis_win2012r2_domainL2_rcl.yml
+++ b/configuration-assessment/windows/cis_win2012r2_domainL2_rcl.yml
@@ -305,7 +305,7 @@ checks:
     - cis_csc: "13"
    condition: any
    rules:
-     - 'r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Messenger\Client -> CEIP -> !0;'
+     - 'r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Messenger\Client -> CEIP -> !2;'
      - 'r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Messenger\Client -> !CEIP;'
  - id: 8522
    title: "Ensure 'Turn off Windows Customer Experience Improvement Program' is set to 'Enabled'"


### PR DESCRIPTION
The correct registry value for enabling Turn off of CEIP is 2.