### PR TITLE
Improve rules for Docker listener

### DIFF
--- a/rules/0560-docker_integration_rules.xml
+++ b/rules/0560-docker_integration_rules.xml
@@ -199,4 +199,11 @@ ID: 87900 - 87999
         <description>Network disconnected for container $(docker.Actor.Attributes.name)</description>
         <options>no_full_log</options>
     </rule>
+
+    <rule id="87927" level="3">
+        <if_sid>87900</if_sid>
+        <field name="docker.status">^pull$</field>
+        <description>Image $(docker.Actor.Attributes.name) was pulled.</description>
+        <options>no_full_log</options>
+    </rule>
 </group>

--- a/rules/0560-docker_integration_rules.xml
+++ b/rules/0560-docker_integration_rules.xml
@@ -14,7 +14,7 @@ ID: 87900 - 87999
     <rule id="87900" level="0">
         <decoded_as>json</decoded_as>
         <field name="integration">^docker$</field>
-        <description>Docker alerts: $(docker.Type).</description>
+        <description>Docker alerts: $(docker.Type)</description>
         <options>no_full_log</options>
     </rule>
 
@@ -203,7 +203,7 @@ ID: 87900 - 87999
     <rule id="87927" level="3">
         <if_sid>87900</if_sid>
         <field name="docker.status">^pull$</field>
-        <description>Image $(docker.Actor.Attributes.name) was pulled.</description>
+        <description>Image $(docker.Actor.Attributes.name) was pulled</description>
         <options>no_full_log</options>
     </rule>
 </group>

--- a/rules/0560-docker_integration_rules.xml
+++ b/rules/0560-docker_integration_rules.xml
@@ -63,13 +63,13 @@ ID: 87900 - 87999
     <rule id="87907" level="3">
         <if_sid>87900</if_sid>
         <field name="docker.status">^exec_start: </field>
-        <description>Command run in container $(docker.Actor.Attributes.name). Action: '$(docker.Action)'</description>
+        <description>Command run in container $(docker.Actor.Attributes.name). Action: "$(docker.Action)"</description>
         <options>no_full_log</options>
     </rule>
 
     <rule id="87908" level="3">
         <if_sid>87907</if_sid>
-        <field name="docker.status">^exec_start: bash</field>
+        <field name="docker.status">^exec_start: bash $|^exec_start: /bin/bash $|^exec_start: sh $|^exec_start: dash $|^exec_start: /bin/dash $</field>
         <description>Started shell session in container $(docker.Actor.Attributes.name)</description>
         <options>no_full_log</options>
     </rule>
@@ -125,15 +125,15 @@ ID: 87900 - 87999
 
     <rule id="87916" level="3">
         <if_sid>87900</if_sid>
-        <field name="docker.status">^untag$</field>
-        <description>Image $(docker.Actor.Attributes.name) untagged</description>
+        <field name="docker.status">^tag$</field>
+        <description>Image $(docker.Actor.Attributes.name) tagged</description>
         <options>no_full_log</options>
     </rule>
 
     <rule id="87917" level="3">
         <if_sid>87900</if_sid>
-        <field name="docker.status">^delete$</field>
-        <description>Container $(docker.Actor.Attributes.name) deleted</description>
+        <field name="docker.status">^untag$</field>
+        <description>Image $(docker.Actor.Attributes.name) untagged</description>
         <options>no_full_log</options>
     </rule>
 
@@ -160,26 +160,19 @@ ID: 87900 - 87999
 
     <rule id="87921" level="3">
         <if_sid>87900</if_sid>
-        <field name="docker.status">^kill$</field>
-        <description>Container $(docker.Actor.Attributes.name) received the action: kill</description>
+        <field name="docker.status">^kill$|^die$</field>
+        <description>Container $(docker.Actor.Attributes.name) received the action: $(docker.status)</description>
         <options>no_full_log</options>
     </rule>
 
     <rule id="87922" level="3">
-        <if_sid>87900</if_sid>
-        <field name="docker.status">^die$</field>
-        <description>Container $(docker.Actor.Attributes.name) received the action: die</description>
-        <options>no_full_log</options>
-    </rule>
-
-    <rule id="87923" level="3">
         <if_sid>87900</if_sid>
         <field name="docker.status">^update$</field>
         <description>Container $(docker.Actor.Attributes.name) updated its configuration</description>
         <options>no_full_log</options>
     </rule>
 
-    <rule id="87924" level="3">
+    <rule id="87923" level="3">
         <if_sid>87900</if_sid>
         <field name="docker.status">^top$</field>
         <description>Container $(docker.Actor.Attributes.name) displayed its running processes</description>

--- a/rules/0560-docker_integration_rules.xml
+++ b/rules/0560-docker_integration_rules.xml
@@ -60,4 +60,11 @@ ID: 87900 - 87999
         <options>no_full_log</options>
     </rule>
 
+    <rule id="87907" level="3">
+        <if_sid>87900</if_sid>
+        <field name="docker.status">^exec_start: </field>
+        <description>Command run in container $(docker.Actor.Attributes.name)</description>
+        <options>no_full_log</options>
+    </rule>
+
 </group>

--- a/rules/0560-docker_integration_rules.xml
+++ b/rules/0560-docker_integration_rules.xml
@@ -13,49 +13,49 @@ ID: 87900 - 87999
 
     <rule id="87900" level="0">
         <decoded_as>json</decoded_as>
-        <field name="integration">docker</field>
+        <field name="integration">^docker$</field>
         <description>Docker alerts: $(docker.Type).</description>
         <options>no_full_log</options>
     </rule>
 
      <rule id="87901" level="3">
         <if_sid>87900</if_sid>
-        <field name="docker.status">create</field>
+        <field name="docker.status">^create$</field>
         <description>Container $(docker.Actor.Attributes.name) created</description>
         <options>no_full_log</options>
     </rule>
 
     <rule id="87902" level="3">
         <if_sid>87900</if_sid>
-        <field name="docker.status">destroy</field>
+        <field name="docker.status">^destroy$</field>
         <description>Container $(docker.Actor.Attributes.name) destroyed</description>
         <options>no_full_log</options>
     </rule>
 
     <rule id="87903" level="3">
         <if_sid>87900</if_sid>
-        <field name="docker.status">start</field>
+        <field name="docker.status">^start$</field>
         <description>Container $(docker.Actor.Attributes.name) started</description>
         <options>no_full_log</options>
     </rule>
 
-	<rule id="87904" level="3">
+    <rule id="87904" level="3">
         <if_sid>87900</if_sid>
-        <field name="docker.status">stop</field>
+        <field name="docker.status">^stop$</field>
         <description>Container $(docker.Actor.Attributes.name) stopped</description>
         <options>no_full_log</options>
     </rule>
 
     <rule id="87905" level="3">
         <if_sid>87900</if_sid>
-        <field name="docker.status">^pause</field>
+        <field name="docker.status">^pause$</field>
         <description>Container $(docker.Actor.Attributes.name) paused</description>
         <options>no_full_log</options>
     </rule>
 
     <rule id="87906" level="3">
         <if_sid>87900</if_sid>
-        <field name="docker.status">unpause</field>
+        <field name="docker.status">^unpause$</field>
         <description>Container $(docker.Actor.Attributes.name) unpaused</description>
         <options>no_full_log</options>
     </rule>

--- a/rules/0560-docker_integration_rules.xml
+++ b/rules/0560-docker_integration_rules.xml
@@ -15,42 +15,49 @@ ID: 87900 - 87999
         <decoded_as>json</decoded_as>
         <field name="integration">docker</field>
         <description>Docker alerts: $(docker.Type).</description>
+        <options>no_full_log</options>
     </rule>
 
      <rule id="87901" level="3">
         <if_sid>87900</if_sid>
         <field name="docker.status">create</field>
         <description>Container $(docker.Actor.Attributes.name) created</description>
+        <options>no_full_log</options>
     </rule>
 
     <rule id="87902" level="3">
         <if_sid>87900</if_sid>
         <field name="docker.status">destroy</field>
         <description>Container $(docker.Actor.Attributes.name) destroyed</description>
+        <options>no_full_log</options>
     </rule>
 
     <rule id="87903" level="3">
         <if_sid>87900</if_sid>
         <field name="docker.status">start</field>
         <description>Container $(docker.Actor.Attributes.name) started</description>
+        <options>no_full_log</options>
     </rule>
 
 	<rule id="87904" level="3">
         <if_sid>87900</if_sid>
         <field name="docker.status">stop</field>
         <description>Container $(docker.Actor.Attributes.name) stopped</description>
+        <options>no_full_log</options>
     </rule>
 
     <rule id="87905" level="3">
         <if_sid>87900</if_sid>
         <field name="docker.status">^pause</field>
         <description>Container $(docker.Actor.Attributes.name) paused</description>
+        <options>no_full_log</options>
     </rule>
 
     <rule id="87906" level="3">
         <if_sid>87900</if_sid>
         <field name="docker.status">unpause</field>
         <description>Container $(docker.Actor.Attributes.name) unpaused</description>
+        <options>no_full_log</options>
     </rule>
 
 </group>

--- a/rules/0560-docker_integration_rules.xml
+++ b/rules/0560-docker_integration_rules.xml
@@ -63,8 +63,126 @@ ID: 87900 - 87999
     <rule id="87907" level="3">
         <if_sid>87900</if_sid>
         <field name="docker.status">^exec_start: </field>
-        <description>Command run in container $(docker.Actor.Attributes.name)</description>
+        <description>Command run in container $(docker.Actor.Attributes.name). Action: '$(docker.Action)'</description>
         <options>no_full_log</options>
     </rule>
 
+    <rule id="87908" level="3">
+        <if_sid>87907</if_sid>
+        <field name="docker.status">^exec_start: bash</field>
+        <description>Started shell session in container $(docker.Actor.Attributes.name)</description>
+        <options>no_full_log</options>
+    </rule>
+
+    <rule id="87909" level="3">
+        <if_sid>87900</if_sid>
+        <field name="docker.status">^restart$</field>
+        <description>Container $(docker.Actor.Attributes.name) restarted</description>
+        <options>no_full_log</options>
+    </rule>
+
+    <rule id="87910" level="3">
+        <if_sid>87900</if_sid>
+        <field name="docker.status">^extract-to-dir$</field>
+        <description>Copied a file from host to $(docker.Actor.Attributes.name)</description>
+        <options>no_full_log</options>
+    </rule>
+
+    <rule id="87911" level="3">
+        <if_sid>87900</if_sid>
+        <field name="docker.status">^archive-path$</field>
+        <description>Copied a file from $(docker.Actor.Attributes.name) to host</description>
+        <options>no_full_log</options>
+    </rule>
+
+    <rule id="87912" level="0">
+        <if_sid>87900</if_sid>
+        <field name="docker.Type">^volume$</field>
+        <description>Docker volume action</description>
+        <options>no_full_log</options>
+    </rule>
+
+    <rule id="87913" level="3">
+        <if_sid>87912</if_sid>
+        <field name="docker.Action">^create$</field>
+        <description>Volume created in $(docker.Actor.Attributes.driver)</description>
+        <options>no_full_log</options>
+    </rule>
+
+    <rule id="87914" level="3">
+        <if_sid>87912</if_sid>
+        <field name="docker.Action">^destroy$</field>
+        <description>Volume destroyed in $(docker.Actor.Attributes.driver)</description>
+        <options>no_full_log</options>
+    </rule>
+
+    <rule id="87915" level="3">
+        <if_sid>87900</if_sid>
+        <field name="docker.status">^commit$</field>
+        <description>Container $(docker.Actor.Attributes.name) commited</description>
+        <options>no_full_log</options>
+    </rule>
+
+    <rule id="87916" level="3">
+        <if_sid>87900</if_sid>
+        <field name="docker.status">^untag$</field>
+        <description>Image $(docker.Actor.Attributes.name) untagged</description>
+        <options>no_full_log</options>
+    </rule>
+
+    <rule id="87917" level="3">
+        <if_sid>87900</if_sid>
+        <field name="docker.status">^delete$</field>
+        <description>Container $(docker.Actor.Attributes.name) deleted</description>
+        <options>no_full_log</options>
+    </rule>
+
+    <rule id="87918" level="3">
+        <if_sid>87900</if_sid>
+        <field name="docker.status">^delete$</field>
+        <description>Container $(docker.Actor.Attributes.name) deleted</description>
+        <options>no_full_log</options>
+    </rule>
+
+    <rule id="87919" level="3">
+        <if_sid>87900</if_sid>
+        <field name="docker.status">^attach$</field>
+        <description>Container $(docker.Actor.Attributes.name) attached standard input, output and error</description>
+        <options>no_full_log</options>
+    </rule>
+
+    <rule id="87920" level="3">
+        <if_sid>87900</if_sid>
+        <field name="docker.status">^export$</field>
+        <description>Container $(docker.Actor.Attributes.name) exported its filesystem</description>
+        <options>no_full_log</options>
+    </rule>
+
+    <rule id="87921" level="3">
+        <if_sid>87900</if_sid>
+        <field name="docker.status">^kill$</field>
+        <description>Container $(docker.Actor.Attributes.name) received the action: kill</description>
+        <options>no_full_log</options>
+    </rule>
+
+    <rule id="87922" level="3">
+        <if_sid>87900</if_sid>
+        <field name="docker.status">^die$</field>
+        <description>Container $(docker.Actor.Attributes.name) received the action: die</description>
+        <options>no_full_log</options>
+    </rule>
+
+    <rule id="87923" level="3">
+        <if_sid>87900</if_sid>
+        <field name="docker.status">^update$</field>
+        <description>Container $(docker.Actor.Attributes.name) updated its configuration</description>
+        <options>no_full_log</options>
+    </rule>
+
+    <rule id="87924" level="3">
+        <if_sid>87900</if_sid>
+        <field name="docker.status">^top$</field>
+        <description>Container $(docker.Actor.Attributes.name) displayed its running processes</description>
+        <options>no_full_log</options>
+    </rule>
 </group>

--- a/rules/0560-docker_integration_rules.xml
+++ b/rules/0560-docker_integration_rules.xml
@@ -178,4 +178,25 @@ ID: 87900 - 87999
         <description>Container $(docker.Actor.Attributes.name) displayed its running processes</description>
         <options>no_full_log</options>
     </rule>
+
+    <rule id="87924" level="3">
+        <if_sid>87900</if_sid>
+        <field name="docker.Type">^network$</field>
+        <description>Container $(docker.Actor.Attributes.name) displayed its running processes</description>
+        <options>no_full_log</options>
+    </rule>
+
+    <rule id="87925" level="3">
+        <if_sid>87924</if_sid>
+        <field name="docker.Action">^connect$</field>
+        <description>Network connected for container $(docker.Actor.Attributes.name)</description>
+        <options>no_full_log</options>
+    </rule>
+
+    <rule id="87926" level="3">
+        <if_sid>87924</if_sid>
+        <field name="docker.Action">^disconnect$</field>
+        <description>Network disconnected for container $(docker.Actor.Attributes.name)</description>
+        <options>no_full_log</options>
+    </rule>
 </group>


### PR DESCRIPTION
## Issues detected

1. `docker exec` incorrectly triggered rules 87901 (container created) and 87903 (container started).
2. Alerts from Docker listener included the _full_log_ even through the input is fully decoded (JSON).

### Point (2) rationale:

`docker exec` produces a log like this:

```json
{
  "docker": {
    "status": "exec_start: bash ",
    (...)
    "id": "7697fa3fec2a0221e448886e5c574c082309fbe0cac8b358d11c3830164c5e37"
  },
  "integration": "docker"
}
```

Rule 87901 contains this filter:
```xml
<field name="docker.status">start</field>
```

This makes `docker exec` trigger rule 87903.

## Changes proposed

1. Disable the _full_log_ in the Docker listener rules.
2. Fix `<field>` filters in those rules to match the exact string (instead of a substring).
3. Add a specific rule (87907) for command execution in containers (`docker exec`).

## Sample alert

```json
{
  "timestamp": "2019-02-21T18:01:44.193-0800",
  "rule": {
    "level": 3,
    "description": "Command run in container reverent_ishizaka",
    "id": "87907",
    "firedtimes": 2,
    "mail": false,
    "groups": [
      "docker"
    ]
  },
  "agent": {
    "id": "001",
    "name": "DemoAgent",
    "ip": "192.168.33.1"
  },
  "manager": {
    "name": "stretch64"
  },
  "id": "1550800904.201466",
  "decoder": {
    "name": "json"
  },
  "data": {
    "docker": {
      "status": "exec_start: echo Hello World",
      "timeNano": "1550800904187913984.000000",
      "from": "ubuntu",
      "Actor": {
        "Attributes": {
          "execID": "4270b190f78fcad1849ce23300b1be4e1907111747457ee470e878214aeec38c",
          "image": "ubuntu",
          "name": "reverent_ishizaka"
        },
        "ID": "4b478281f9c8a9d504a1835b409e4c35f8dd95cff1d21da0dd440effd9d85fe3"
      },
      "time": "1550800904",
      "Action": "exec_start: echo Hello World",
      "scope": "local",
      "Type": "container",
      "id": "4b478281f9c8a9d504a1835b409e4c35f8dd95cff1d21da0dd440effd9d85fe3"
    },
    "integration": "docker"
  },
  "location": "Wazuh-Docker"
}
```