### PR TITLE
Improve Audit decoders

### DIFF
--- a/decoders/0040-auditd_decoders.xml
+++ b/decoders/0040-auditd_decoders.xml
@@ -26,8 +26,8 @@ type=SYSCALL msg=audit(1479982525.380:50): arch=c000003e syscall=2 success=yes e
 <!-- SYSCALL -->
 <decoder name="auditd-syscall">
     <parent>auditd</parent>
-    <regex offset="after_regex">^arch=(\S+) syscall=(\d+) success=(\S+) exit=(\S+) a0=(\S+) a1=(\S+) a2=(\S+) a3=(\S+) items=(\S+) ppid=(\S+) pid=(\S+) auid=(\S+) uid=(\S+) gid=(\S+) euid=(\S+) suid=(\S+) fsuid=(\S+) egid=(\S+) sgid=(\S+) fsgid=(\S+) tty=(\S+) ses=(\S+) comm=\p(\S+)\p exe=\p(\S+)\p</regex>
-    <order>audit.arch,audit.syscall,audit.success,audit.exit,audit.a0,audit.a1,audit.a2,audit.a3,audit.items,audit.ppid,audit.pid,audit.auid,audit.uid,audit.gid,audit.euid,audit.suid,audit.fsuid,audit.egid,audit.sgid,audit.fsgid,audit.tty,audit.session,audit.command,audit.exe</order>
+    <regex offset="after_regex">^arch=(\S+) syscall=(\d+) success=(\S+) exit=(\S+) a0=\S+ a1=\S+ a2=\S+ a3=\S+ items=\S+ ppid=(\S+) pid=(\S+) auid=(\S+) uid=(\S+) gid=(\S+) euid=(\S+) suid=(\S+) fsuid=(\S+) egid=(\S+) sgid=(\S+) fsgid=(\S+) tty=(\S+) ses=(\S+) comm=\p(\S+)\p exe=\p(\S+)\p</regex>
+    <order>audit.arch,audit.syscall,audit.success,audit.exit,audit.ppid,audit.pid,audit.auid,audit.uid,audit.gid,audit.euid,audit.suid,audit.fsuid,audit.egid,audit.sgid,audit.fsgid,audit.tty,audit.session,audit.command,audit.exe</order>
 </decoder>
 
 <!-- SYSCALL - key -->
@@ -35,6 +35,55 @@ type=SYSCALL msg=audit(1479982525.380:50): arch=c000003e syscall=2 success=yes e
     <parent>auditd</parent>
     <regex offset="after_regex">key=\((\S+)\)|key="(\S+)"|key=(\S+) </regex>
     <order>audit.key</order>
+</decoder>
+
+<!-- EXECVE -->
+<decoder name="auditd-syscall">
+    <parent>auditd</parent>
+    <regex offset="after_regex">type=EXECVE msg=audit\(\S+\): argc=\d+ a0="(\.+)" </regex>
+    <order>audit.execve.a0</order>
+</decoder>
+
+<decoder name="auditd-syscall">
+    <parent>auditd</parent>
+    <regex offset="after_regex">a1="(\.+)" </regex>
+    <order>audit.execve.a1</order>
+</decoder>
+
+<decoder name="auditd-syscall">
+    <parent>auditd</parent>
+    <regex offset="after_regex">a2="(\.+)" </regex>
+    <order>audit.execve.a2</order>
+</decoder>
+
+<decoder name="auditd-syscall">
+    <parent>auditd</parent>
+    <regex offset="after_regex">a3="(\.+)" </regex>
+    <order>audit.execve.a3</order>
+</decoder>
+
+<decoder name="auditd-syscall">
+    <parent>auditd</parent>
+    <regex offset="after_regex">a4="(\.+)" </regex>
+    <order>audit.execve.a4</order>
+</decoder>
+
+<decoder name="auditd-syscall">
+    <parent>auditd</parent>
+    <regex offset="after_regex">a5="(\.+)" </regex>
+    <order>audit.execve.a5</order>
+</decoder>
+
+<decoder name="auditd-syscall">
+    <parent>auditd</parent>
+    <regex offset="after_regex">a6="(\.+)" </regex>
+    <order>audit.execve.a6</order>
+</decoder>
+
+<decoder name="auditd-syscall">
+    <parent>auditd</parent>
+    <regex offset="after_regex">a7="(\.+)" </regex>
+    <order>audit.execve.a7</order>
 </decoder>
 
 <!-- CWD -->

--- a/decoders/0040-auditd_decoders.xml
+++ b/decoders/0040-auditd_decoders.xml
@@ -40,7 +40,7 @@ type=SYSCALL msg=audit(1479982525.380:50): arch=c000003e syscall=2 success=yes e
 <!-- CWD -->
 <decoder name="auditd-syscall">
     <parent>auditd</parent>
-    <regex offset="after_regex">type=CWD msg=audit\(\S+\):  cwd="(\.+)" </regex>
+    <regex offset="after_regex">type=CWD msg=audit\(\S+\):\s+cwd="(\.+)" </regex>
     <order>audit.cwd</order>
 </decoder>
 


### PR DESCRIPTION
|Fixes|
|---|
|#300|

## Change summary

- Fix extraction of `cwd` field: that part of the log includes one or two leading whitespaces, depending on the platform.
- Do not extract `a0`, `a1`, `a2`, `a3` and `items` from _SYSCALL_.
- Instead, extract `a0`, `a1` ... `a7` from _EXECVE_.

## Sample alert
```json
{
  "timestamp": "2019-02-25T19:52:58.422-0800",
  "agent": {
    "id": "000",
    "name": "stretch64"
  },
  "manager": {
    "name": "stretch64"
  },
  "id": "1551153178.762332",
  "full_log": "type=SYSCALL msg=audit(1551153176.810:106): arch=c000003e syscall=59 success=yes exit=0 a0=1a456c8 a1=2350608 a2=196e008 a3=59a items=2 ppid=493 pid=1379 auid=1000 uid=1000 gid=1000 euid=0 suid=0 fsuid=0 egid=1000 sgid=1000 fsgid=1000 tty=pts4 ses=41 comm=\"ping\" exe=\"/bin/ping\" key=\"audit-wazuh-c\" type=BPRM_FCAPS msg=audit(1551153176.810:106): fver=0 fp=0000000000000000 fi=0000000000000000 fe=0 old_pp=0000000000000000 old_pi=0000000000000000 old_pe=0000000000000000 new_pp=0000003fffffffff new_pi=0000000000000000 new_pe=0000003fffffffff type=EXECVE msg=audit(1551153176.810:106): argc=4 a0=\"ping\" a1=\"-W\" a2=\"1\" a3=\"www.google.com\" type=CWD msg=audit(1551153176.810:106): cwd=\"/home/vagrant\" type=PATH msg=audit(1551153176.810:106): item=0 name=\"/bin/ping\" inode=80 dev=08:01 mode=0104755 ouid=0 ogid=0 rdev=00:00 nametype=NORMAL type=PATH msg=audit(1551153176.810:106): item=1 name=\"/lib64/ld-linux-x86-64.so.2\" inode=259590 dev=08:01 mode=0100755 ouid=0 ogid=0 rdev=00:00 nametype=NORMAL type=PROCTITLE msg=audit(1551153176.810:106): proctitle=70696E67002D570031007777772E676F6F676C652E636F6D",
  "decoder": {
    "name": "auditd",
    "parent": "auditd"
  },
  "data": {
    "audit": {
      "type": "SYSCALL",
      "id": "106",
      "arch": "c000003e",
      "syscall": "59",
      "success": "yes",
      "exit": "0",
      "ppid": "493",
      "pid": "1379",
      "auid": "1000",
      "uid": "1000",
      "gid": "1000",
      "euid": "0",
      "suid": "0",
      "fsuid": "0",
      "egid": "1000",
      "sgid": "1000",
      "fsgid": "1000",
      "tty": "pts4",
      "session": "41",
      "command": "ping",
      "exe": "/bin/ping",
      "key": "audit-wazuh-c",
      "file": {
        "name": "/bin/ping",
        "inode": "80",
        "mode": "0104755"
      },
      "cwd": "/home/vagrant",
      "execve": {
        "a0": "ping",
        "a1": "-W",
        "a2": "1",
        "a3": "www.google.com"
      }
    }
  },
  "location": "/var/log/audit/audit.log",
  "rule": {
    "level": 3,
    "description": "Audit: Command: /bin/ping",
    "id": "80792",
    "firedtimes": 5,
    "mail": false,
    "groups": [
      "audit",
      "audit_command"
    ],
    "gdpr": [
      "IV_30.1.g"
    ]
  }
}
```