### PR TITLE
Fix logon alerts triggering

### DIFF
--- a/rules/0220-msauth_rules.xml
+++ b/rules/0220-msauth_rules.xml
@@ -1146,6 +1146,15 @@
 
   <rule id="20019" level="3">
     <if_sid>20007</if_sid>
+    <field name="win.eventdata.workstationName">\.+</field>
+    <field name="win.eventdata.logonType">2</field>
+    <description>Windows Workstation Logon Success</description>
+    <options>no_full_log</options>
+    <group>authentication_success,pci_dss_10.2.5,gpg13_7.1,gpg13_7.2,gdpr_IV_32.2,</group>
+  </rule>
+
+  <rule id="20020" level="3">
+    <if_sid>20007</if_sid>
     <options>alert_by_email</options>
     <if_fts />
     <description>Windows: First time this user logged in this system</description>
@@ -1153,21 +1162,11 @@
     <group>authentication_success,pci_dss_10.2.5,gpg13_7.1,gpg13_7.2,gdpr_IV_32.2,</group>
   </rule>
 
-  <rule id="20020" level="0">
+  <rule id="20021" level="0">
     <if_sid>20005</if_sid>
     <field name="win.system.eventID">^680$</field>
     <description>Windows login attempt (ignored). Duplicated</description>
     <options>no_full_log</options>
-  </rule>
-
-  <rule id="20021" level="3">
-    <if_sid>20007</if_sid>
-    <field name="EventChannel.EventData.WorkstationName">\.+</field>
-    <field name="EventChannel.EventData.IpAddress">\.+</field>
-    <field name="EventChannel.EventData.IpPort">\.+</field>
-    <description>Windows Workstation Logon Success</description>
-    <options>no_full_log</options>
-    <group>authentication_success,pci_dss_10.2.5,gpg13_7.1,gpg13_7.2,gdpr_IV_32.2,</group>
   </rule>
 
   <rule id="20025" level="5">

--- a/rules/0220-msauth_rules.xml
+++ b/rules/0220-msauth_rules.xml
@@ -1160,6 +1160,16 @@
     <options>no_full_log</options>
   </rule>
 
+  <rule id="20021" level="3">
+    <if_sid>20007</if_sid>
+    <field name="EventChannel.EventData.WorkstationName">\.+</field>
+    <field name="EventChannel.EventData.IpAddress">\.+</field>
+    <field name="EventChannel.EventData.IpPort">\.+</field>
+    <description>Windows Workstation Logon Success</description>
+    <options>no_full_log</options>
+    <group>authentication_success,pci_dss_10.2.5,gpg13_7.1,gpg13_7.2,gdpr_IV_32.2,</group>
+  </rule>
+
   <rule id="20025" level="5">
     <if_sid>20002,20003</if_sid>
     <field name="win.system.eventID">^20187$|^20014$|^20078$|^20050$|^20049$|^20189$</field>

--- a/rules/0220-msauth_rules.xml
+++ b/rules/0220-msauth_rules.xml
@@ -1147,7 +1147,7 @@
   <rule id="20019" level="3">
     <if_sid>20007</if_sid>
     <field name="win.eventdata.workstationName">\.+</field>
-    <field name="win.eventdata.logonType">2</field>
+    <field name="win.eventdata.logonType">^2$</field>
     <description>Windows Workstation Logon Success</description>
     <options>no_full_log</options>
     <group>authentication_success,pci_dss_10.2.5,gpg13_7.1,gpg13_7.2,gdpr_IV_32.2,</group>
@@ -1916,7 +1916,7 @@
   <rule id="20166" level="3">
     <if_sid>20007</if_sid>
     <field name="win.system.eventID">^4624$</field>
-    <field name="win.eventdata.logonType">8</field>
+    <field name="win.eventdata.logonType">^8$</field>
     <description>MS Exchange Logon Success</description>
     <options>no_full_log</options>
     <group>pci_dss_10.2.5,gpg13_7.1,gpg13_7.2,gdpr_IV_32.2,</group>
@@ -1925,7 +1925,7 @@
   <rule id="20167" level="0">
     <if_sid>20049</if_sid>
     <field name="win.system.eventID">^4634$</field>
-    <field name="win.eventdata.logonType">8</field>
+    <field name="win.eventdata.logonType">^8$</field>
     <description>MS Exchange User Logoff</description>
     <options>no_full_log</options>
     <group>pci_dss_10.2.5,gpg13_7.1,gpg13_7.2,gdpr_IV_32.2,</group>


### PR DESCRIPTION
This PR solves the issue https://github.com/wazuh/wazuh-ruleset/issues/298 for Windows eventchannel. There is a new rule that checks if fields `workstation name`, `IP address` and `IP port` exist.