### PR TITLE
Add Docker network create alert

### DIFF
--- a/rules/0560-docker_integration_rules.xml
+++ b/rules/0560-docker_integration_rules.xml
@@ -203,11 +203,18 @@ ID: 87900 - 87999
     <rule id="87927" level="3">
         <if_sid>87924</if_sid>
         <field name="docker.Action">^create$</field>
-        <description>Network of type $(docker.Actor.Attributes.type) was created for container $(docker.Actor.Attributes.name)</description>
+        <description>Network $(docker.Actor.Attributes.name) of type $(docker.Actor.Attributes.type) created</description>
         <options>no_full_log</options>
     </rule>
 
     <rule id="87928" level="3">
+        <if_sid>87924</if_sid>
+        <field name="docker.Action">^destroy$</field>
+        <description>Network $(docker.Actor.Attributes.name) of type $(docker.Actor.Attributes.type) deleted</description>
+        <options>no_full_log</options>
+    </rule>
+
+    <rule id="87929" level="3">
         <if_sid>87900</if_sid>
         <field name="docker.status">^pull$</field>
         <description>Image $(docker.Actor.Attributes.name) was pulled</description>

--- a/rules/0560-docker_integration_rules.xml
+++ b/rules/0560-docker_integration_rules.xml
@@ -201,6 +201,13 @@ ID: 87900 - 87999
     </rule>
 
     <rule id="87927" level="3">
+        <if_sid>87924</if_sid>
+        <field name="docker.Action">^create$</field>
+        <description>Network of type $(docker.Actor.Attributes.type) was created for container $(docker.Actor.Attributes.name)</description>
+        <options>no_full_log</options>
+    </rule>
+
+    <rule id="87928" level="3">
         <if_sid>87900</if_sid>
         <field name="docker.status">^pull$</field>
         <description>Image $(docker.Actor.Attributes.name) was pulled</description>


### PR DESCRIPTION
This PR adds the rule for command `docker network create`.
Below there is a sample alert:

```
** Alert 1551196088.889416: - docker,
2019 Feb 26 16:48:08 misi->Wazuh-Docker
Rule: 87927 (level 3) -> 'Network of type bridge was created for container br1'
{"integration": "docker", "docker": {"Type": "network", "Action": "create", "Actor": {"ID": "b47514cd0f184aeb1f334affc2eb754b08f0455d2fbbffd3e4919acbde4e22e3", "Attributes": {"name": "br1", "type": "bridge"}}, "scope": "local", "time": 1551196088, "timeNano": 1551196088379074771}}
integration: docker
docker.Type: network
docker.Action: create
docker.Actor.ID: b47514cd0f184aeb1f334affc2eb754b08f0455d2fbbffd3e4919acbde4e22e3
docker.Actor.Attributes.name: br1
docker.Actor.Attributes.type: bridge
docker.scope: local
docker.time: 1551196088
docker.timeNano: 1551196088379074816.000000

```

