### PR TITLE
Fix description for Sysmon rules

### DIFF
--- a/rules/0330-sysmon_rules.xml
+++ b/rules/0330-sysmon_rules.xml
@@ -130,7 +130,7 @@
     <rule id="20487" level="0">
         <if_sid>20485</if_sid>
         <field name="win.system.eventID">^2$</field>
-        <description>Sysmon - Event 2: A process changed a file creation time $(win.eventdata.description)</description>
+        <description>Sysmon - Event 2: A process changed a file creation time by $(win.eventdata.sourceImage)</description>
         <options>no_full_log</options>
         <group>sysmon_event2,</group>
     </rule>
@@ -138,7 +138,7 @@
     <rule id="20488" level="0">
         <if_sid>20485</if_sid>
         <field name="win.system.eventID">^3$</field>
-        <description>Sysmon - Event 3: Network connection $(win.eventdata.description)</description>
+        <description>Sysmon - Event 3: Network connection by $(win.eventdata.sourceImage)</description>
         <options>no_full_log</options>
         <group>sysmon_event3,</group>
     </rule>
@@ -146,7 +146,7 @@
     <rule id="20489" level="0">
         <if_sid>20485</if_sid>
         <field name="win.system.eventID">^4$</field>
-        <description>Sysmon - Event 4: Sysmon service state changed $(win.eventdata.description)</description>
+        <description>Sysmon - Event 4: Sysmon service state changed by $(win.eventdata.sourceImage)</description>
         <options>no_full_log</options>
         <group>sysmon_event4,</group>
     </rule>
@@ -154,7 +154,7 @@
     <rule id="20490" level="0">
         <if_sid>20485</if_sid>
         <field name="win.system.eventID">^5$</field>
-        <description>Sysmon - Event 5: Process terminated $(win.eventdata.description)</description>
+        <description>Sysmon - Event 5: Process terminated by $(win.eventdata.sourceImage)</description>
         <options>no_full_log</options>
         <group>sysmon_event5,</group>
     </rule>
@@ -162,7 +162,7 @@
     <rule id="20491" level="0">
         <if_sid>20485</if_sid>
         <field name="win.system.eventID">^6$</field>
-        <description>Sysmon - Event 6: Driver loaded $(win.eventdata.description)</description>
+        <description>Sysmon - Event 6: Driver loaded by $(win.eventdata.sourceImage)</description>
         <options>no_full_log</options>
         <group>sysmon_event6,</group>
     </rule>
@@ -170,7 +170,7 @@
     <rule id="20492" level="0">
         <if_sid>20485</if_sid>
         <field name="win.system.eventID">^7$</field>
-        <description>Sysmon - Event 7: Image loaded $(win.eventdata.description)</description>
+        <description>Sysmon - Event 7: Image loaded by $(win.eventdata.sourceImage)</description>
         <options>no_full_log</options>
         <group>sysmon_event7,</group>
     </rule>
@@ -178,7 +178,7 @@
     <rule id="20493" level="0">
         <if_sid>20485</if_sid>
         <field name="win.system.eventID">^8$</field>
-        <description>Sysmon - Event 8: CreateRemoteThread $(win.eventdata.description)</description>
+        <description>Sysmon - Event 8: CreateRemoteThread by $(win.eventdata.sourceImage)</description>
         <options>no_full_log</options>
         <group>sysmon_event8,</group>
     </rule>
@@ -186,7 +186,7 @@
     <rule id="20494" level="0">
         <if_sid>20485</if_sid>
         <field name="win.system.eventID">^9$</field>
-        <description>Sysmon - Event 9: RawAccessRead $(win.eventdata.description)</description>
+        <description>Sysmon - Event 9: RawAccessRead by $(win.eventdata.sourceImage)</description>
         <options>no_full_log</options>
         <group>sysmon_event9,</group>
     </rule>
@@ -194,7 +194,7 @@
     <rule id="20495" level="0">
         <if_sid>20485</if_sid>
         <field name="win.system.eventID">^10$</field>
-        <description>Sysmon - Event 10: ProcessAccess $(win.eventdata.description)</description>
+        <description>Sysmon - Event 10: ProcessAccess by $(win.eventdata.sourceImage)</description>
         <options>no_full_log</options>
         <group>sysmon_event_10,</group>
     </rule>
@@ -202,7 +202,7 @@
     <rule id="20496" level="0">
         <if_sid>20485</if_sid>
         <field name="win.system.eventID">^11$</field>
-        <description>Sysmon - Event 11: FileCreate $(win.eventdata.description)</description>
+        <description>Sysmon - Event 11: FileCreate by $(win.eventdata.sourceImage)</description>
         <options>no_full_log</options>
         <group>sysmon_event_11,</group>
     </rule>
@@ -210,7 +210,7 @@
     <rule id="20497" level="0">
         <if_sid>20485</if_sid>
         <field name="win.system.eventID">^12$</field>
-        <description>Sysmon - Event 12: RegistryEvent (Object create and delete) $(win.eventdata.description)</description>
+        <description>Sysmon - Event 12: RegistryEvent (Object create and delete) by $(win.eventdata.sourceImage)</description>
         <options>no_full_log</options>
         <group>sysmon_event_12,</group>
     </rule>
@@ -218,7 +218,7 @@
     <rule id="20498" level="0">
         <if_sid>20485</if_sid>
         <field name="win.system.eventID">^13$</field>
-        <description>Sysmon - Event 13: RegistryEvent (Value Set) $(win.eventdata.description)</description>
+        <description>Sysmon - Event 13: RegistryEvent (Value Set) by $(win.eventdata.sourceImage)</description>
         <options>no_full_log</options>
         <group>sysmon_event_13,</group>
     </rule>
@@ -226,7 +226,7 @@
     <rule id="20499" level="0">
         <if_sid>20485</if_sid>
         <field name="win.system.eventID">^14$</field>
-        <description>Sysmon - Event 14: RegistryEvent (Key and Value Rename) $(win.eventdata.description)</description>
+        <description>Sysmon - Event 14: RegistryEvent (Key and Value Rename) by $(win.eventdata.sourceImage)</description>
         <options>no_full_log</options>
         <group>sysmon_event_14,</group>
     </rule>
@@ -234,7 +234,7 @@
     <rule id="20500" level="0">
         <if_sid>20485</if_sid>
         <field name="win.system.eventID">^15$</field>
-        <description>Sysmon - Event 15: FileCreateStreamHash $(win.eventdata.description)</description>
+        <description>Sysmon - Event 15: FileCreateStreamHash by $(win.eventdata.sourceImage)</description>
         <options>no_full_log</options>
         <group>sysmon_event_15,</group>
     </rule>


### PR DESCRIPTION
This PR replaces the field `win.eventdata.description` from the rules' description by `win.eventdata.sourceImage`, as the first one was only showing in event 1 from Sysmon.

Sample alert for Sysmon event ID 10:

```
** Alert 1551266725.690062: - sysmon,sysmon_event_10,
2019 Feb 27 12:25:25 (win) any->EventChannel
Rule: 20495 (level 8) -> 'Sysmon - Event 10: ProcessAccess by C:\Users\user\Downloads\mimikatz_trunk\x64\mimikatz.exe'
{"win":{"system":{"providerName":"Microsoft-Windows-Sysmon","providerGuid":"{5770385F-C22A-43E0-BF4C-06F5698FFBD9}","eventID":"10","version":"3","level":"4","task":"10","opcode":"0","keywords":"0x8000000000000000","systemTime":"2019-02-27T11:25:24.030328100Z","eventRecordID":"184","processID":"3468","threadID":"2032","channel":"Microsoft-Windows-Sysmon/Operational","computer":"pcname","severityValue":"INFORMATION","message":"Process accessed:"},"eventData":{"ruleName":"","utcTime":"2019-02-27 11:25:24.030","sourceProcessGUID":"{A2E669BA-7399-5C76-0000-0010BAE24B00}","sourceProcessId":"3140","sourceThreadId":"1112","sourceImage":"C:\\Users\\user\\Downloads\\mimikatz_trunk\\x64\\mimikatz.exe","targetProcessGUID":"{A2E669BA-6683-5C76-0000-00104C790000}","targetProcessId":"572","targetImage":"C:\\Windows\\system32\\lsass.exe","grantedAccess":"0x143a","callTrace":"C:\\Windows\\SYSTEM32\\tdll.dll+909ba|C:\\Windows\\system32\\KERNELBASE.dll+2f2e|C:\\Users\\user\\Downloads\\mimikatz_trunk\\x64\\mimikatz.exe+643c9|C:\\Users\\user\\Downloads\\mimikatz_trunk\\x64\\mimikatz.exe+63f53|C:\\Users\\user\\Downloads\\mimikatz_trunk\\x64\\mimikatz.exe+4d28c|C:\\Users\\user\\Downloads\\mimikatz_trunk\\x64\\mimikatz.exe+4d0c4|C:\\Users\\user\\Downloads\\mimikatz_trunk\\x64\\mimikatz.exe+4cea1|C:\\Users\\user\\Downloads\\mimikatz_trunk\\x64\\mimikatz.exe+80675|C:\\Windows\\system32\\KERNEL32.DLL+13d2|C:\\Windows\\SYSTEM32\\tdll.dll+154f4"}}}
win.system.providerName: Microsoft-Windows-Sysmon
win.system.providerGuid: {5770385F-C22A-43E0-BF4C-06F5698FFBD9}
win.system.eventID: 10
win.system.version: 3
win.system.level: 4
win.system.task: 10
win.system.opcode: 0
win.system.keywords: 0x8000000000000000
win.system.systemTime: 2019-02-27T11:25:24.030328100Z
win.system.eventRecordID: 184
win.system.processID: 3468
win.system.threadID: 2032
win.system.channel: Microsoft-Windows-Sysmon/Operational
win.system.computer: pcname
win.system.severityValue: INFORMATION
win.system.message: Process accessed:
win.eventData.utcTime: 2019-02-27 11:25:24.030
win.eventData.sourceProcessGUID: {A2E669BA-7399-5C76-0000-0010BAE24B00}
win.eventData.sourceProcessId: 3140
win.eventData.sourceThreadId: 1112
win.eventData.sourceImage: C:\Users\user\Downloads\mimikatz_trunk\x64\mimikatz.exe
win.eventData.targetProcessGUID: {A2E669BA-6683-5C76-0000-00104C790000}
win.eventData.targetProcessId: 572
win.eventData.targetImage: C:\Windows\system32\lsass.exe
win.eventData.grantedAccess: 0x143a
win.eventData.callTrace: C:\Windows\SYSTEM32\tdll.dll+909ba|C:\Windows\system32\KERNELBASE.dll+2f2e|C:\Users\user\Downloads\mimikatz_trunk\x64\mimikatz.exe+643c9|C:\Users\user\Downloads\mimikatz_trunk\x64\mimikatz.exe+63f53|C:\Users\user\Downloads\mimikatz_trunk\x64\mimikatz.exe+4d28c|C:\Users\user\Downloads\mimikatz_trunk\x64\mimikatz.exe+4d0c4|C:\Users\user\Downloads\mimikatz_trunk\x64\mimikatz.exe+4cea1|C:\Users\user\Downloads\mimikatz_trunk\x64\mimikatz.exe+80675|C:\Windows\system32\KERNEL32.DLL+13d2|C:\Windows\SYSTEM32\tdll.dll+154f4
```