### PR TITLE
Added requirements for Windows policies SCA

### DIFF
--- a/sca/windows/cis_win2012r2_domainL1_rcl.yml
+++ b/sca/windows/cis_win2012r2_domainL1_rcl.yml
@@ -20,6 +20,13 @@ policy:
   references:
     - https://www.cisecurity.org/cis-benchmarks/
 
+requirements:
+  title: "Check for Windows platform"
+  description: "Requirements for Windows"
+  condition: "any required"
+  rules:
+     - 'r:HKEY_LOCAL_MACHINE\SAM\SAM;'
+
 checks:
 # Section 1.1 - Password Policies
  - id: 8000

--- a/sca/windows/cis_win2012r2_domainL1_rcl.yml
+++ b/sca/windows/cis_win2012r2_domainL1_rcl.yml
@@ -25,7 +25,7 @@ requirements:
   description: "Requirements for Windows"
   condition: "any required"
   rules:
-     - 'r:HKEY_LOCAL_MACHINE\SAM\SAM;'
+     - 'r:HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion -> ProductName -> r:^Windows Server 2012 R2;'
 
 checks:
 # Section 1.1 - Password Policies

--- a/sca/windows/cis_win2012r2_domainL1_rcl.yml
+++ b/sca/windows/cis_win2012r2_domainL1_rcl.yml
@@ -22,7 +22,7 @@ policy:
 
 requirements:
   title: "Check that the Windows platform is Windows Server 2012 R2"
-  description: "Requirements for running the audit policy under a Windows platform"
+  description: "Requirements for running the CIS benchmark Domain Controller L1 under Windows Server 2012 R2"
   condition: "any required"
   rules:
      - 'r:HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion -> ProductName -> r:^Windows Server 2012 R2;'

--- a/sca/windows/cis_win2012r2_domainL1_rcl.yml
+++ b/sca/windows/cis_win2012r2_domainL1_rcl.yml
@@ -21,8 +21,8 @@ policy:
     - https://www.cisecurity.org/cis-benchmarks/
 
 requirements:
-  title: "Check for Windows platform"
-  description: "Requirements for Windows"
+  title: "Check that the Windows platform is Windows Server 2012 R2"
+  description: "Requirements for running the audit policy under a Windows platform"
   condition: "any required"
   rules:
      - 'r:HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion -> ProductName -> r:^Windows Server 2012 R2;'

--- a/sca/windows/cis_win2012r2_domainL2_rcl.yml
+++ b/sca/windows/cis_win2012r2_domainL2_rcl.yml
@@ -20,6 +20,12 @@ policy:
   references:
     - https://www.cisecurity.org/cis-benchmarks/
 
+requirements:
+  title: "Check for Windows platform"
+  description: "Requirements for Windows"
+  condition: "any required"
+  rules:
+     - 'r:HKEY_LOCAL_MACHINE\SAM\SAM;'
 checks:
 # Section 2.3 - Security Options
  - id: 8500

--- a/sca/windows/cis_win2012r2_domainL2_rcl.yml
+++ b/sca/windows/cis_win2012r2_domainL2_rcl.yml
@@ -25,7 +25,8 @@ requirements:
   description: "Requirements for Windows"
   condition: "any required"
   rules:
-     - 'r:HKEY_LOCAL_MACHINE\SAM\SAM;'
+     - 'r:HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion -> ProductName -> r:^Windows Server 2012 R2;'
+
 checks:
 # Section 2.3 - Security Options
  - id: 8500

--- a/sca/windows/cis_win2012r2_domainL2_rcl.yml
+++ b/sca/windows/cis_win2012r2_domainL2_rcl.yml
@@ -22,7 +22,7 @@ policy:
 
 requirements:
   title: "Check that the Windows platform is Windows Server 2012 R2"
-  description: "Requirements for running the audit policy under a Windows platform"
+  description: "Requirements for running the CIS benchmark Domain Controller L2 under Windows Server 2012 R2"
   condition: "any required"
   rules:
      - 'r:HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion -> ProductName -> r:^Windows Server 2012 R2;'

--- a/sca/windows/cis_win2012r2_domainL2_rcl.yml
+++ b/sca/windows/cis_win2012r2_domainL2_rcl.yml
@@ -21,8 +21,8 @@ policy:
     - https://www.cisecurity.org/cis-benchmarks/
 
 requirements:
-  title: "Check for Windows platform"
-  description: "Requirements for Windows"
+  title: "Check that the Windows platform is Windows Server 2012 R2"
+  description: "Requirements for running the audit policy under a Windows platform"
   condition: "any required"
   rules:
      - 'r:HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion -> ProductName -> r:^Windows Server 2012 R2;'

--- a/sca/windows/cis_win2012r2_memberL1_rcl.yml
+++ b/sca/windows/cis_win2012r2_memberL1_rcl.yml
@@ -20,6 +20,13 @@ policy:
   references:
     - https://www.cisecurity.org/cis-benchmarks/
 
+requirements:
+  title: "Check for Windows platform"
+  description: "Requirements for Windows"
+  condition: "any required"
+  rules:
+     - 'r:HKEY_LOCAL_MACHINE\SAM\SAM;'
+
 checks:
 # Section 1.1 - Password Policies
  - id: 9000

--- a/sca/windows/cis_win2012r2_memberL1_rcl.yml
+++ b/sca/windows/cis_win2012r2_memberL1_rcl.yml
@@ -25,7 +25,7 @@ requirements:
   description: "Requirements for Windows"
   condition: "any required"
   rules:
-     - 'r:HKEY_LOCAL_MACHINE\SAM\SAM;'
+     - 'r:HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion -> ProductName -> r:^Windows Server 2012 R2;'
 
 checks:
 # Section 1.1 - Password Policies

--- a/sca/windows/cis_win2012r2_memberL1_rcl.yml
+++ b/sca/windows/cis_win2012r2_memberL1_rcl.yml
@@ -22,7 +22,7 @@ policy:
 
 requirements:
   title: "Check that the Windows platform is Windows Server 2012 R2"
-  description: "Requirements for running the CIS benchmark Member Controller L1 under Windows Server 2012 R2"
+  description: "Requirements for running the CIS benchmark Member Server L1 under Windows Server 2012 R2"
   condition: "any required"
   rules:
      - 'r:HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion -> ProductName -> r:^Windows Server 2012 R2;'

--- a/sca/windows/cis_win2012r2_memberL1_rcl.yml
+++ b/sca/windows/cis_win2012r2_memberL1_rcl.yml
@@ -21,8 +21,8 @@ policy:
     - https://www.cisecurity.org/cis-benchmarks/
 
 requirements:
-  title: "Check for Windows platform"
-  description: "Requirements for Windows"
+  title: "Check that the Windows platform is Windows Server 2012 R2"
+  description: "Requirements for running the audit policy under a Windows platform"
   condition: "any required"
   rules:
      - 'r:HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion -> ProductName -> r:^Windows Server 2012 R2;'

--- a/sca/windows/cis_win2012r2_memberL1_rcl.yml
+++ b/sca/windows/cis_win2012r2_memberL1_rcl.yml
@@ -22,7 +22,7 @@ policy:
 
 requirements:
   title: "Check that the Windows platform is Windows Server 2012 R2"
-  description: "Requirements for running the audit policy under a Windows platform"
+  description: "Requirements for running the CIS benchmark Member Controller L1 under Windows Server 2012 R2"
   condition: "any required"
   rules:
      - 'r:HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion -> ProductName -> r:^Windows Server 2012 R2;'

--- a/sca/windows/cis_win2012r2_memberL2_rcl.yml
+++ b/sca/windows/cis_win2012r2_memberL2_rcl.yml
@@ -18,8 +18,8 @@ policy:
     - https://www.cisecurity.org/cis-benchmarks/
 
 requirements:
-  title: "Check for Windows platform"
-  description: "Requirements for Windows"
+  title: "Check that the Windows platform is Windows Server 2012 R2"
+  description: "Requirements for running the audit policy under a Windows platform"
   condition: "any required"
   rules:
      - 'r:HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion -> ProductName -> r:^Windows Server 2012 R2;'

--- a/sca/windows/cis_win2012r2_memberL2_rcl.yml
+++ b/sca/windows/cis_win2012r2_memberL2_rcl.yml
@@ -17,6 +17,13 @@ policy:
   references:
     - https://www.cisecurity.org/cis-benchmarks/
 
+requirements:
+  title: "Check for Windows platform"
+  description: "Requirements for Windows"
+  condition: "any required"
+  rules:
+     - 'r:HKEY_LOCAL_MACHINE\SAM\SAM;'
+
 checks:
 # Section 2.3.7 - Interactive logon
   - id: 9500

--- a/sca/windows/cis_win2012r2_memberL2_rcl.yml
+++ b/sca/windows/cis_win2012r2_memberL2_rcl.yml
@@ -19,7 +19,7 @@ policy:
 
 requirements:
   title: "Check that the Windows platform is Windows Server 2012 R2"
-  description: "Requirements for running the CIS benchmark Member Controller L2 under Windows Server 2012 R2"
+  description: "Requirements for running the CIS benchmark Member Server L2 under Windows Server 2012 R2"
   condition: "any required"
   rules:
      - 'r:HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion -> ProductName -> r:^Windows Server 2012 R2;'

--- a/sca/windows/cis_win2012r2_memberL2_rcl.yml
+++ b/sca/windows/cis_win2012r2_memberL2_rcl.yml
@@ -22,7 +22,7 @@ requirements:
   description: "Requirements for Windows"
   condition: "any required"
   rules:
-     - 'r:HKEY_LOCAL_MACHINE\SAM\SAM;'
+     - 'r:HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion -> ProductName -> r:^Windows Server 2012 R2;'
 
 checks:
 # Section 2.3.7 - Interactive logon

--- a/sca/windows/cis_win2012r2_memberL2_rcl.yml
+++ b/sca/windows/cis_win2012r2_memberL2_rcl.yml
@@ -19,7 +19,7 @@ policy:
 
 requirements:
   title: "Check that the Windows platform is Windows Server 2012 R2"
-  description: "Requirements for running the audit policy under a Windows platform"
+  description: "Requirements for running the CIS benchmark Member Controller L2 under Windows Server 2012 R2"
   condition: "any required"
   rules:
      - 'r:HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion -> ProductName -> r:^Windows Server 2012 R2;'

--- a/sca/windows/win_audit_rcl.yml
+++ b/sca/windows/win_audit_rcl.yml
@@ -14,6 +14,13 @@ policy:
   name: "Benchmark for Windows audit"
   description: "This document provides a way of ensuring the security of the Windows systems."
 
+requirements:
+  title: "Check for Windows platform"
+  description: "Requirements for Windows"
+  condition: "any required"
+  rules:
+     - 'r:HKEY_LOCAL_MACHINE\SAM\SAM;'
+
 checks:
  - id: 2500
    title: "Disabled Registry tools set"

--- a/sca/windows/win_audit_rcl.yml
+++ b/sca/windows/win_audit_rcl.yml
@@ -16,7 +16,7 @@ policy:
 
 requirements:
   title: "Check for Windows platform"
-  description: "Requirements for Windows"
+  description: "Requirements for running the audit policy under a Windows platform"
   condition: "any required"
   rules:
      - 'r:HKEY_LOCAL_MACHINE\SAM\SAM;'


### PR DESCRIPTION
### Requirements for running Windows SCA policies

A requirement section has been added to avoid Windows policy files being scanned on non Windows platforms.

Related issue https://github.com/wazuh/wazuh-ruleset/issues/312