### PR TITLE
Cisco IOS rules improvement

### DIFF
--- a/decoders/0065-cisco-ios_decoders.xml
+++ b/decoders/0065-cisco-ios_decoders.xml
@@ -73,6 +73,39 @@
   <prematch>^\d+:\s+\p*\w+\s+\d+\s+\S+\s+\w+:\s+%</prematch>
 </decoder>
 
+<!--
+  - Sequence number, date (preceded by * or . or nothing) and hour
+  - 4425: Aug 23 00:17:55.356:
+-->
+
+<decoder name="cisco-ios">
+  <prematch>^\d+:\s+\w+\s+\d+\s+\S+\s+%</prematch>
+</decoder>
+
+
+<!-- Cisco IOS
+  - Extracts the ID of cisco ios messages IF NOT IDS/ACL log.
+  - 4425: Aug 23 00:17:55.356: %SSH-5-SSH2_SESSION: SSH2 Session request from x.x.x.x (tty = 0) using crypto cipher 'aes-111-sdf0', hmac 'hmac-sha1' Succeeded
+  -->
+<decoder name="cisco-ios-ssh-session">
+  <parent>cisco-ios</parent>
+  <prematch>%SSH-5-SSH2_SESSION: </prematch>
+  <regex>(\S+): SSH2 Session request from (\S+) </regex>
+  <order>id, srcip</order>
+</decoder>
+
+
+<!-- Cisco IOS
+  - Extracts the ID of cisco ios messages IF NOT IDS/ACL log.
+  - 4423: Aug 23 00:16:18.200: %SSH-5-SSH2_USERAUTH: User 'xxxx' authentication for SSH2 Session from x.x.x.x (tty = 0) using crypto cipher 'aes111-sdf0', hmac 'hmac-sha1' Succeeded
+  -->
+<decoder name="cisco-ios-ssh-userauth">
+  <parent>cisco-ios</parent>
+  <prematch>%SSH-5-SSH2_USERAUTH: </prematch>
+  <regex>(\S+): User '(\w+)' authentication for SSH2 Session from (\S+) </regex>
+  <order>id, srcuser, srcip</order>
+</decoder>
+
 
 <!-- Cisco IOS
   - Will extract the action, srcip, srcport, dstip and dstport
@@ -81,7 +114,6 @@
   - %SEC-6-IPACCESSLOGP: list 102 denied tcp 10.0.6.56(3067) -> 172.36.4.7(139), 1 packet
   - %SEC-6-IPACCESSLOGP: list 199 denied tcp 10.0.61.108(1477) -> 10.0.127.20(445), 1 packet
   -->
-
 <decoder name="cisco-ios-acl">
   <parent>cisco-ios</parent>
   <type>firewall</type>
@@ -118,3 +150,6 @@
   <regex>(%\w+-\d-\w+):</regex>
   <order>id</order>
 </decoder>
+
+
+

--- a/rules/0075-cisco-ios_rules.xml
+++ b/rules/0075-cisco-ios_rules.xml
@@ -87,4 +87,18 @@
     <group>authentication_failed,pci_dss_10.2.5,pci_dss_10.2.4,gpg13_3.6,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
   </rule>
 
+  <rule id="4725" level="3">
+    <if_sid>4715</if_sid>
+    <id>^%SSH-5-SSH2_SESSION</id>
+    <description>Cisco IOS: Successful SSH2 session request to the router.</description>
+    <group>authentication_success,pci_dss_10.2.5,gpg13_3.6,gdpr_IV_32.2,</group>
+  </rule>
+
+  <rule id="4726" level="3">
+    <if_sid>4715</if_sid>
+    <id>^%SSH-5-SSH2_USERAUTH</id>
+    <description>Cisco IOS: Successful SSH2 authentication to the router.</description>
+    <group>authentication_success,pci_dss_10.2.5,gpg13_3.6,gdpr_IV_32.2,</group>
+  </rule>
+
 </group>


### PR DESCRIPTION
This PR solves https://github.com/wazuh/wazuh-ruleset/issues/207
```
4425: Aug 23 00:17:55.356: %SSH-5-SSH2_SESSION: SSH2 Session request from x.x.x.x (tty = 0) using crypto cipher 'aes-111-sdf0', hmac 'hmac-sha1' Succeeded


**Phase 1: Completed pre-decoding.
       full event: '4425: Aug 23 00:17:55.356: %SSH-5-SSH2_SESSION: SSH2 Session request from x.x.x.x (tty = 0) using crypto cipher 'aes-111-sdf0', hmac 'hmac-sha1' Succeeded'
       timestamp: '(null)'
       hostname: 'lopezziur-S551LN'
       program_name: '(null)'
       log: '4425: Aug 23 00:17:55.356: %SSH-5-SSH2_SESSION: SSH2 Session request from x.x.x.x (tty = 0) using crypto cipher 'aes-111-sdf0', hmac 'hmac-sha1' Succeeded'

**Phase 2: Completed decoding.
       decoder: 'cisco-ios'
       id: '%SSH-5-SSH2_SESSION'
       srcip: 'x.x.x.x'

**Phase 3: Completed filtering (rules).
       Rule id: '4725'
       Level: '3'
       Description: 'Cisco IOS: Successful SSH2 session request to the router.'
**Alert to be generated.

```
```

4423: Aug 23 00:16:18.200: %SSH-5-SSH2_USERAUTH: User 'xxxx' authentication for SSH2 Session from x.x.x.x (tty = 0) using crypto cipher 'aes111-sdf0', hmac 'hmac-sha1' Succeeded


**Phase 1: Completed pre-decoding.
       full event: '4423: Aug 23 00:16:18.200: %SSH-5-SSH2_USERAUTH: User 'xxxx' authentication for SSH2 Session from x.x.x.x (tty = 0) using crypto cipher 'aes111-sdf0', hmac 'hmac-sha1' Succeeded'
       timestamp: '(null)'
       hostname: 'lopezziur-S551LN'
       program_name: '(null)'
       log: '4423: Aug 23 00:16:18.200: %SSH-5-SSH2_USERAUTH: User 'xxxx' authentication for SSH2 Session from x.x.x.x (tty = 0) using crypto cipher 'aes111-sdf0', hmac 'hmac-sha1' Succeeded'

**Phase 2: Completed decoding.
       decoder: 'cisco-ios'
       id: '%SSH-5-SSH2_USERAUTH'
       srcuser: 'xxxx'
       srcip: 'x.x.x.x'

**Phase 3: Completed filtering (rules).
       Rule id: '4726'
       Level: '3'
       Description: 'Cisco IOS: Successful SSH2 authentication to the router.'
**Alert to be generated.
```