### PR TITLE
Fix typos in rootcheck system_audit_rcl.txt

### DIFF
--- a/rootchecks/system_audit_rcl.txt
+++ b/rootchecks/system_audit_rcl.txt
@@ -89,10 +89,10 @@ d:$web_dirs -> ^version.php$ -> r:var \.RELEASE && r:'3.4.8';
 d:$web_dirs -> ^application_top.php$ -> r:'osCommerce 2.2-;
 
 ## Looking for known backdoors
-[Web vulnerability - Backdoors / Web based malware found - eval(base64_decode {PCI_DSS: 6.5, 6.6, 11.4}] [any] []
+[Web vulnerability - Backdoors / Web based malware found - eval(base64_decode) {PCI_DSS: 6.5, 6.6, 11.4}] [any] []
 d:$web_dirs -> .php$ -> r:eval\(base64_decode\(\paWYo;
 
-[Web vulnerability - Backdoors / Web based malware found - eval(base64_decode(POST {PCI_DSS: 6.5, 6.6, 11.4}] [any] []
+[Web vulnerability - Backdoors / Web based malware found - eval(base64_decode(POST)) {PCI_DSS: 6.5, 6.6, 11.4}] [any] []
 d:$web_dirs -> .php$ -> r:eval\(base64_decode\(\S_POST;
 
 [Web vulnerability - .htaccess file compromised {PCI_DSS: 6.5, 6.6, 11.4}] [any] [http://blog.sucuri.net/2011/05/understanding-htaccess-attacks-part-1.html]

--- a/sca/generic/system_audit_rcl.yml
+++ b/sca/generic/system_audit_rcl.yml
@@ -42,35 +42,35 @@ checks:
      - 'f:$php.ini -> r:^display_errors = On;'
 # WEB checks
  - id: 1004
-   title: "Web exploits (uncommon file name inside htdocs) - Possible compromise"
+   title: "Web exploits: '.yop' is an uncommon file name inside htdocs - Possible compromise"
    compliance:
     - pci_dss: "6.5, 6.6, 11.4"
    condition: any
    rules:
      - 'd:$web_dirs -> ^.yop$;'
  - id: 1005
-   title: "Web exploits (uncommon file name inside htdocs) - Possible compromise"
+   title: "Web exploits: 'id' is an uncommon file name inside htdocs - Possible compromise"
    compliance:
     - pci_dss: "6.5, 6.6, 11.4"
    condition: any
    rules:
      - 'd:$web_dirs -> ^id$;'
  - id: 1006
-   title: "Web exploits (uncommon file name inside htdocs)"
+   title: "Web exploits: '.ssh' is an uncommon file name inside htdocs"
    compliance:
     - pci_dss: "6.5, 6.6, 11.4"
    condition: any
    rules:
      - 'd:$web_dirs -> ^.ssh$;'
  - id: 1007
-   title: "Web exploits (uncommon file name inside htdocs) - Possible compromise"
+   title: "Web exploits: '...' is an uncommon file name inside htdocs - Possible compromise"
    compliance:
     - pci_dss: "6.5, 6.6, 11.4"
    condition: any
    rules:
      - 'd:$web_dirs -> ^...$;'
  - id: 1008
-   title: "Web exploits (uncommon file name inside htdocs) - Possible compromise"
+   title: "Web exploits: '.shell' is an uncommon file name inside htdocs - Possible compromise"
    compliance:
     - pci_dss: "6.5, 6.6, 11.4"
    condition: any
@@ -100,14 +100,14 @@ checks:
      - "d:$web_dirs -> ^application_top.php$ -> r:'osCommerce 2.2-;"
 # Known backdoors
  - id: 1012
-   title: "Web vulnerability - Backdoors / Web based malware found - eval(base64_decode"
+   title: "Web vulnerability - Backdoors / Web based malware found - eval(base64_decode)"
    compliance:
     - pci_dss: "6.5, 6.6, 11.4"
    condition: any
    rules:
      - 'd:$web_dirs -> .php$ -> r:eval\(base64_decode\(\paWYo;'
  - id: 1013
-   title: "Web vulnerability - Backdoors / Web based malware found - eval(base64_decode(POST "
+   title: "Web vulnerability - Backdoors / Web based malware found - eval(base64_decode(POST))"
    compliance:
     - pci_dss: "6.5, 6.6, 11.4"
    condition: any


### PR DESCRIPTION
Hi, Team,

This PR just corrects a couple of typos in the rootcheck file `system_audit_rcl.txt`.

Initially:
```
[Web vulnerability - Backdoors / Web based malware found - eval(base64_decode {PCI_DSS: 6.5, 6.6, 11.4}]
...
[Web vulnerability - Backdoors / Web based malware found - eval(base64_decode(POST {PCI_DSS: 6.5, 6.6, 11.4}]
```

When the texts are shown, they look like this:
```
Web vulnerability - Backdoors / Web based malware found - eval(base64_decode
...
Web vulnerability - Backdoors / Web based malware found - eval(base64_decode(POST
```

The texts seem to be truncated, but actually they are not. The fix just closes the parenthesis.


Regards.
