### PR TITLE
Improve squid

### DIFF
--- a/decoders/0305-squid_decoders.xml
+++ b/decoders/0305-squid_decoders.xml
@@ -8,18 +8,48 @@
 -->
 
 
-<!--
-  - Will extract the srcip.
-  - Author: Ahmet Ozturk
+<!-- 
+  - Pre mach for Squid's log file access.log
   - Examples:
-  - 1140701044.525   1231 192.168.1.201 TCP_DENIED/400 1536
-    GET ahmet - NONE/- text/html
-  - 1140701230.827    781 192.168.1.210 TCP_DENIED/407 1785
-    GET http://www.ossec.net oahmet NONE/- text/html
-  -->
+  - 1140701230.827    781 192.168.1.210 TCP_DENIED/407 1785 GET http://www.ossec.net oahmet NONE/- text/html
+  - 1140701044.525   1231 192.168.1.201 TCP_DENIED/400 1536 GET ahmet - NONE/- text/html
+  - 1286536318.542    755 192.168.0.68 TCP_MISS/200 507 POST http://wazuh.com- DIRECT/X.X.X.X application/xml
+-->
 <decoder name="squid-accesslog">
   <type>squid</type>
-  <prematch>^\d+ \S+ </prematch>
+  <prematch>^\d+ \S+ TCP_\S+ |^\d+ \S+ UDP_\S+ |^\d+ \S+ NONE\S+ </prematch>
+</decoder>
+
+<!--
+  - Extract srcip, action, id and url.
+  -->
+<decoder name="squid-accesslog-default">
+  <parent>squid-accesslog</parent>
   <regex>^\d+ (\S+) (\w+)/(\d+) \d+ \w+ (\S+) </regex>
   <order>srcip,action,id,url</order>
+</decoder>
+
+
+<!--
+  - Pre mach for Squid's log file cache.log
+  - Examples:
+  - 2019/03/21 08:36:27 kid1| HTCP Disabled
+  - 2019/03/21 08:36:27| pinger: Initialising ICMP pinger ...
+  - 2019/03/21 08:36:27| pinger: ICMP socket opened.
+  - 2019/03/21 08:36:27| pinger: ICMPv6 socket opened
+  - 2010/10/03 12:17:45| FD 60 Closing HTTP connection
+  - 2010/10/03 12:17:45| FD 62 Closing HTTP connection
+-->
+<decoder name="squid-cachelog">
+  <type>squid</type>
+  <prematch>^\d+/\d+/\d+ \d+:\d+:\d+\| |^\d+/\d+/\d+ \d+:\d+:\d+ \w+\| </prematch>
+</decoder>
+
+<!--
+  - Extract action
+-->
+<decoder name="squid-cachelog-default">
+  <parent>squid-cachelog</parent>
+  <regex>\S+ \.+\| (\.+)</regex>
+  <order>action</order>
 </decoder>


### PR DESCRIPTION
The Squid decoder is the following:
```
<decoder name="squid-accesslog">
  <type>squid</type>
  <prematch>^\d+ \S+ </prematch>
  <regex>^\d+ (\S+) (\w+)/(\d+) \d+ \w+ (\S+) </regex>
  <order>srcip,action,id,url</order>
</decoder>
```
The decoder is very general and a lot of logs mach with this. For example:
In [issue](https://github.com/wazuh/wazuh-ruleset/issues/224), our client try to logtest the following NTP logline:
`6 Oct 02:28:37 ntpd[2474]: 0.0.0.0 c016 06 restart`
I think it's a syslog's log but the logtest result is:
>**Phase 1: Completed pre-decoding.
       full event: '6 Oct 02:28:37 ntpd[2474]: 0.0.0.0 c016 06 restart'
       timestamp: '(null)'
       hostname: 'psingh'
       program_name: '(null)'
       log: '6 Oct 02:28:37 ntpd[2474]: 0.0.0.0 c016 06 restart'

>**Phase 2: Completed decoding.
       decoder: 'squid-accesslog'

>**Phase 3: Completed filtering (rules).
       Rule id: '35000'
       Level: '0'
       Description: 'Squid messages grouped.'

I think the new Squid decoder only mach with the Squid's log