### PR TITLE
Improve update rules

### DIFF
--- a/update_ruleset
+++ b/update_ruleset
@@ -277,7 +277,7 @@ def get_new_ruleset(source, url, branch_name=None):
         # Extract
         try:
             with contextlib.closing(ZipFile(ruleset_zip)) as z:
-                zip_dir = search('^wazuh-ruleset-{0}([0-9a-z-]+)?$'.format(branch), z.namelist()[0].strip('/')).group(0)
+                zip_dir = search('^wazuh-ruleset-\S*', z.namelist()[0].strip('/')).group(0)
                 z.extractall(update_downloads)
         except Exception as e:
             exit(2, "\tError extracting file '{0}': {1}.".format(ruleset_zip, e))

--- a/update_ruleset
+++ b/update_ruleset
@@ -232,6 +232,8 @@ def get_ossec_version():
 
 
 def get_ruleset_version():
+    ossec_path = common.ossec_path
+    ossec_ruleset_version_path = "{0}/ruleset/VERSION".format(ossec_path)
     try:
         with open(ossec_ruleset_version_path) as version_file:
             lines = version_file.readlines()
@@ -492,7 +494,7 @@ def main():
             os.remove(ossec_update_script+'-old')
             os.remove(ossec_ruleset_version_path+'-old')
             exit(2,"Upgrade aborted: Unexpected version in the new ruleset. " + \
-                "Expected version {0}. Found version {1}".format(old_version[:-1]+'x',
+                "Expected version greater than {0}. Found version {1}".format(old_version,
                 status['new_version']))
         # remove temporary files
         os.remove(ossec_update_script+'-old')
@@ -552,9 +554,9 @@ def same_major_minor(old_version, new_version):
         return False
 
 def usage():
-    branch = get_branch()  # 'stable' 'master' 'development'
+    ruleset_version = get_ruleset_version()  # 'stable' 'master' 'development'
     msg = """
-    Update ruleset v3.2.0
+    Update ruleset {0}
     Github repository: https://github.com/wazuh/wazuh-ruleset
     Full documentation: http://documentation.wazuh.com/en/latest/wazuh_ruleset.html
 
@@ -571,12 +573,12 @@ def usage():
     Additional Params:
     \t-f, --force-update  Force to update the ruleset. By default, only it is updated the new/changed decoders/rules/rootchecks.
     \t-s, --source        Select ruleset source path (instead of download it).
-    \t-j, --json          JSON output. It should be used with '-s' argument.
+    \t-j, --json          JSON output.
     \t-d, --debug         Debug mode.
     \t-u, --url           URL of ruleset zip (default: https://github.com/wazuh/wazuh-ruleset/archive/$BRANCH-NAME.zip)
     \t                    It requires -n parameter.
     \t-n, --branch-name   Branch name (default: stable)
-    """.format(branch)
+    """.format(ruleset_version)
     print(msg)
 
 


### PR DESCRIPTION
When rules is updated by tag you get the following error:
>ERROR: Error extracting file '/var/ossec/tmp/ruleset/downloads/ruleset.zip': 'NoneType' object has no attribute 'group'.

Like it happens in this [issue](https://github.com/wazuh/wazuh-ruleset/issues/215). The code that fails is:
``` 
# Extract
try:
   with contextlib.closing(ZipFile(ruleset_zip)) as z:
      zip_dir = search('^wazuh-ruleset-{0}([0-9a-z-]+)?$'.format(branch), z.namelist()[0].strip('/')).group(0)
      z.extractall(update_downloads)
except Exception as e:
   exit(2, "\tError extracting file '{0}': {1}.".format(ruleset_zip, e))
```
Because the directory inside de zip don't have name `wazuh-ruleset-{0}([0-9a-z-]+)?$'.format(branch)`. For example:
If i execute `bin/update_ruleset -u https://github.com/wazuh/wazuh-ruleset/archive/v3.8.2.zip` or `bin/update_ruleset -n v3.8.2` branch will be v3.8.2 but directory inside zip will be wazuh-ruleset-3.8.2, without v.
I don't know if it's the correct but if change the line to `zip_dir = search('^wazuh-ruleset-\S*', z.namelist()[0].strip('/')).group(0)` you can update by tag.