### PR TITLE
Increase Windows error alert level

### DIFF
--- a/rules/0585-win-application_rules.xml
+++ b/rules/0585-win-application_rules.xml
@@ -24,7 +24,7 @@
     <group>gpg13_4.12,</group>
   </rule>
 
-  <rule id="60602" level="5">
+  <rule id="60602" level="9">
     <if_sid>60003</if_sid>
     <field name="win.system.severityValue">^ERROR</field>
     <description>Windows Application error event</description>


### PR DESCRIPTION
This PR increases the Windows Application error alert level.
Related issue: https://github.com/wazuh/wazuh-ruleset/issues/343