### PR TITLE
Update KMS rules

### DIFF
--- a/rules/0350-amazon_rules.xml
+++ b/rules/0350-amazon_rules.xml
@@ -292,14 +292,21 @@ ID: 80200 - 80499
         <group>aws_kms,</group>
     </rule>
 
-    <rule id="80491" level="3">
+    <rule id="80491" level="0">
         <if_sid>80490</if_sid>
+        <field name="aws.userIdentity.invokedBy">AWS Internal</field>
         <description>AWS KMS: [$(aws.eventName)] $(aws.userIdentity.type)</description>
         <group>aws_kms,</group>
     </rule>
 
     <rule id="80492" level="3">
-        <if_sid>80491</if_sid>
+        <if_sid>80490</if_sid>
+        <description>AWS KMS: [$(aws.eventName)] $(aws.userIdentity.type)</description>
+        <group>aws_kms,</group>
+    </rule>
+
+    <rule id="80493" level="3">
+        <if_sid>80492</if_sid>
         <field name="aws.userIdentity.userName">\.+</field>
         <description>AWS KMS: [$(aws.eventName)] $(aws.userIdentity.type) - $(aws.userIdentity.userName) - $(aws.sourceIPAddress)</description>
         <group>aws_kms,</group>

--- a/rules/0350-amazon_rules.xml
+++ b/rules/0350-amazon_rules.xml
@@ -292,22 +292,29 @@ ID: 80200 - 80499
         <group>aws_kms,</group>
     </rule>
 
-    <rule id="80491" level="0">
+    <rule id="80491" level="3">
         <if_sid>80490</if_sid>
-        <field name="aws.userIdentity.invokedBy">AWS Internal</field>
         <description>AWS KMS: [$(aws.eventName)] $(aws.userIdentity.type)</description>
         <group>aws_kms,</group>
     </rule>
 
     <rule id="80492" level="3">
-        <if_sid>80490</if_sid>
+        <if_sid>80491</if_sid>
+        <field name="aws.userIdentity.userName">\.+</field>
+        <description>AWS KMS: [$(aws.eventName)] $(aws.userIdentity.type) - $(aws.userIdentity.userName) - $(aws.sourceIPAddress)</description>
+        <group>aws_kms,</group>
+    </rule>
+
+    <rule id="80493" level="0">
+        <if_sid>80491</if_sid>
+        <field name="aws.userIdentity.invokedBy">AWS Internal</field>
         <description>AWS KMS: [$(aws.eventName)] $(aws.userIdentity.type)</description>
         <group>aws_kms,</group>
     </rule>
 
-    <rule id="80493" level="3">
+    <rule id="80494" level="0">
         <if_sid>80492</if_sid>
-        <field name="aws.userIdentity.userName">\.+</field>
+        <field name="aws.userIdentity.invokedBy">AWS Internal</field>
         <description>AWS KMS: [$(aws.eventName)] $(aws.userIdentity.type) - $(aws.userIdentity.userName) - $(aws.sourceIPAddress)</description>
         <group>aws_kms,</group>
     </rule>


### PR DESCRIPTION
Hi team,

This PR closes [#3904](https://github.com/wazuh/wazuh/issues/3094). I created a new rule with level 0 for `KMS` events with field `"aws.userIdentity.invokedBy` equal to `AWS Internal`.

Events of the current day with this field were flooding `alert.json`:

```bash
# du -sh /var/ossec/logs/alerts/alerts.json
4.0K	/var/ossec/logs/alerts/alerts.json
# /var/ossec/wodles/aws/aws-s3 --bucket wazuh-aws-wodle --aws_profile default --trail_prefix kms_compress_encrypted --type custom --debug 1 --skip_on_error
DEBUG: +++ Debug mode on - Level: 1
DEBUG: +++ Table does not exist; create
DEBUG: +++ DB Maintenance
DEBUG: +++ DB Maintenance
# du -sh /var/ossec/logs/alerts/alerts.json
105M	/var/ossec/logs/alerts/alerts.json
```

After update rules:

```bash
# rm /var/ossec/wodles/aws/s3_cloudtrail.db
]# du -sh /var/ossec/logs/alerts/alerts.json
4.0K	/var/ossec/logs/alerts/alerts.json
# /var/ossec/wodles/aws/aws-s3 --bucket wazuh-aws-wodle --aws_profile default --trail_prefix kms_compress_encrypted --type custom --debug 1 --skip_on_error
DEBUG: +++ Debug mode on - Level: 1
DEBUG: +++ Table does not exist; create
DEBUG: +++ DB Maintenance
DEBUG: +++ DB Maintenance
# du -sh /var/ossec/logs/alerts/alerts.json
576K	/var/ossec/logs/alerts/alerts.json
```

Example of an event with this field in `logtest`:

```bash
# /var/ossec/bin/ossec-logtest 
2019/04/15 14:59:18 ossec-testrule: INFO: Started (pid: 10414).
ossec-testrule: Type one log per line.

{"integration": "aws", "aws": {"log_info": {"aws_account_alias": "", "log_file": "kms_compress_encrypted/2019/04/15/14/firehose_kms-1-2019-04-15-14-23-26-0c.zip", "s3bucket": "wazuh"}, "eventVersion": "1.05", "userIdentity": {"type": "IAMUser", "principalId": "XXXXXX", "arn": "arn:aws:iam::XXXXXXX:user/wazuh-cloudtrail", "accountId": "XXXXXXX", "accessKeyId": "XXXXXX", "userName": "wazuh", "sessionContext": {"attributes": {"mfaAuthenticated": "false", "creationDate": "2019-04-15T14:26:51Z"}}, "invokedBy": "AWS Internal"}, "eventTime": "2019-04-15T14:27:18Z", "eventSource": "kms.amazonaws.com", "eventName": "Decrypt", "awsRegion": "us-east-1", "sourceIPAddress": "AWS Internal", "userAgent": "AWS Internal", "requestParameters": {"encryptionContext": {"aws:s3:arn": "arn:aws:s3:::kms/2019/04/15/14/firehose_kms-1-2019-04-15-14-17-52-31f2f-c644-40e9-9948-5f79e5.zip"}}, "requestID": "0dbfd77e-ca3f-4cc0-9042-7a86c384", "eventID": "563-b4c6-493d-956-982c26a7f", "readOnly": true, "resources": {"ARN": "arn:aws:kms:us-east-1:XXXXXXX:key/XXXXXXf", "accountId": "XXXXXXX", "type": "AWS::KMS::Key"}, "eventType": "AwsApiCall", "source": "kms"}}


**Phase 1: Completed pre-decoding.
       full event: '{"integration": "aws", "aws": {"log_info": {"aws_account_alias": "", "log_file": "kms_compress_encrypted/2019/04/15/14/firehose_kms-1-2019-04-15-14-23-26-0c.zip", "s3bucket": "wazuh"}, "eventVersion": "1.05", "userIdentity": {"type": "IAMUser", "principalId": "XXXXXX", "arn": "arn:aws:iam::XXXXXXX:user/wazuh-cloudtrail", "accountId": "XXXXXXX", "accessKeyId": "XXXXXX", "userName": "wazuh", "sessionContext": {"attributes": {"mfaAuthenticated": "false", "creationDate": "2019-04-15T14:26:51Z"}}, "invokedBy": "AWS Internal"}, "eventTime": "2019-04-15T14:27:18Z", "eventSource": "kms.amazonaws.com", "eventName": "Decrypt", "awsRegion": "us-east-1", "sourceIPAddress": "AWS Internal", "userAgent": "AWS Internal", "requestParameters": {"encryptionContext": {"aws:s3:arn": "arn:aws:s3:::kms/2019/04/15/14/firehose_kms-1-2019-04-15-14-17-52-31f2f-c644-40e9-9948-5f79e5.zip"}}, "requestID": "0dbfd77e-ca3f-4cc0-9042-7a86c384", "eventID": "563-b4c6-493d-956-982c26a7f", "readOnly": true, "resources": {"ARN": "arn:aws:kms:us-east-1:XXXXXXX:key/XXXXXXf", "accountId": "XXXXXXX", "type": "AWS::KMS::Key"}, "eventType": "AwsApiCall", "source": "kms"}}'
       timestamp: '(null)'
       hostname: 'splunk'
       program_name: '(null)'
       log: '{"integration": "aws", "aws": {"log_info": {"aws_account_alias": "", "log_file": "kms_compress_encrypted/2019/04/15/14/firehose_kms-1-2019-04-15-14-23-26-0c.zip", "s3bucket": "wazuh"}, "eventVersion": "1.05", "userIdentity": {"type": "IAMUser", "principalId": "XXXXXX", "arn": "arn:aws:iam::XXXXXXX:user/wazuh-cloudtrail", "accountId": "XXXXXXX", "accessKeyId": "XXXXXX", "userName": "wazuh", "sessionContext": {"attributes": {"mfaAuthenticated": "false", "creationDate": "2019-04-15T14:26:51Z"}}, "invokedBy": "AWS Internal"}, "eventTime": "2019-04-15T14:27:18Z", "eventSource": "kms.amazonaws.com", "eventName": "Decrypt", "awsRegion": "us-east-1", "sourceIPAddress": "AWS Internal", "userAgent": "AWS Internal", "requestParameters": {"encryptionContext": {"aws:s3:arn": "arn:aws:s3:::kms/2019/04/15/14/firehose_kms-1-2019-04-15-14-17-52-31f2f-c644-40e9-9948-5f79e5.zip"}}, "requestID": "0dbfd77e-ca3f-4cc0-9042-7a86c384", "eventID": "563-b4c6-493d-956-982c26a7f", "readOnly": true, "resources": {"ARN": "arn:aws:kms:us-east-1:XXXXXXX:key/XXXXXXf", "accountId": "XXXXXXX", "type": "AWS::KMS::Key"}, "eventType": "AwsApiCall", "source": "kms"}}'

**Phase 2: Completed decoding.
       decoder: 'json'
       integration: 'aws'
       aws.log_info.aws_account_alias: ''
       aws.log_info.log_file: 'kms_compress_encrypted/2019/04/15/14/firehose_kms-1-2019-04-15-14-23-26-0c.zip'
       aws.log_info.s3bucket: 'wazuh'
       aws.eventVersion: '1.05'
       aws.userIdentity.type: 'IAMUser'
       aws.userIdentity.principalId: 'XXXXXX'
       aws.userIdentity.arn: 'arn:aws:iam::XXXXXXX:user/wazuh-cloudtrail'
       aws.userIdentity.accountId: 'XXXXXXX'
       aws.userIdentity.accessKeyId: 'XXXXXX'
       aws.userIdentity.userName: 'wazuh'
       aws.userIdentity.sessionContext.attributes.mfaAuthenticated: 'false'
       aws.userIdentity.sessionContext.attributes.creationDate: '2019-04-15T14:26:51Z'
       aws.userIdentity.invokedBy: 'AWS Internal'
       aws.eventTime: '2019-04-15T14:27:18Z'
       aws.eventSource: 'kms.amazonaws.com'
       aws.eventName: 'Decrypt'
       aws.awsRegion: 'us-east-1'
       aws.sourceIPAddress: 'AWS Internal'
       aws.userAgent: 'AWS Internal'
       aws.requestParameters.encryptionContext.aws:s3:arn: 'arn:aws:s3:::kms/2019/04/15/14/firehose_kms-1-2019-04-15-14-17-52-31f2f-c644-40e9-9948-5f79e5.zip'
       aws.requestID: '0dbfd77e-ca3f-4cc0-9042-7a86c384'
       aws.eventID: '563-b4c6-493d-956-982c26a7f'
       aws.readOnly: 'true'
       aws.resources.ARN: 'arn:aws:kms:us-east-1:XXXXXXX:key/XXXXXXf'
       aws.resources.accountId: 'XXXXXXX'
       aws.resources.type: 'AWS::KMS::Key'
       aws.eventType: 'AwsApiCall'
       aws.source: 'kms'

**Phase 3: Completed filtering (rules).
       Rule id: '80493'
       Level: '0'
       Description: 'AWS KMS: [Decrypt] IAMUser'
```

Best regards,

Demetrio.