### PR TITLE
Add SCA new status and reason rules

### DIFF
--- a/rules/0570-sca_rules.xml
+++ b/rules/0570-sca_rules.xml
@@ -91,14 +91,14 @@
     <description>$(sca.policy): $(sca.check.title): Status changed from passed to failed</description>
   </rule>
 
-  <rule id="19012" level="7">
+  <rule id="19012" level="5">
     <if_sid>19009</if_sid>
     <field name="sca.check.previous_result">^passed</field>
     <options>no_full_log</options>
     <description>$(sca.policy): $(sca.check.title): Status changed from passed to 'not applicable'. Reason: $(sca.check.reason)</description>
   </rule>
 
-  <rule id="19013" level="7">
+  <rule id="19013" level="5">
     <if_sid>19009</if_sid>
     <field name="sca.check.previous_result">^failed</field>
     <options>no_full_log</options>

--- a/rules/0570-sca_rules.xml
+++ b/rules/0570-sca_rules.xml
@@ -74,7 +74,7 @@
     <if_sid>19006</if_sid>
     <field name="sca.check.status">^Not applicable</field>
     <options>no_full_log</options>
-    <description>$(sca.policy): $(sca.check.title). Reason: $(sca.check.reason)</description>
+    <description>$(sca.policy): $(sca.check.title). Not applicable. Reason: $(sca.check.reason)</description>
   </rule>
 
   <rule id="19010" level="3">

--- a/rules/0570-sca_rules.xml
+++ b/rules/0570-sca_rules.xml
@@ -74,7 +74,7 @@
     <if_sid>19006</if_sid>
     <field name="sca.check.status">^Not applicable</field>
     <options>no_full_log</options>
-    <description>$(sca.policy): $(sca.check.title). Not applicable. Reason: $(sca.check.reason)</description>
+    <description>$(sca.policy): $(sca.check.title)</description>
   </rule>
 
   <rule id="19010" level="3">
@@ -95,14 +95,14 @@
     <if_sid>19009</if_sid>
     <field name="sca.check.previous_result">^passed</field>
     <options>no_full_log</options>
-    <description>$(sca.policy): $(sca.check.title): Status changed from passed to 'not applicable'. Reason: $(sca.check.reason)</description>
+    <description>$(sca.policy): $(sca.check.title): Status changed from passed to 'not applicable'</description>
   </rule>
 
   <rule id="19013" level="5">
     <if_sid>19009</if_sid>
     <field name="sca.check.previous_result">^failed</field>
     <options>no_full_log</options>
-    <description>$(sca.policy): $(sca.check.title): Status changed from failed to 'not applicable'. Reason: $(sca.check.reason)</description>
+    <description>$(sca.policy): $(sca.check.title): Status changed from failed to 'not applicable'</description>
   </rule>
 
   <rule id="19014" level="9">

--- a/rules/0570-sca_rules.xml
+++ b/rules/0570-sca_rules.xml
@@ -71,16 +71,51 @@
   </rule>
 
   <rule id="19009" level="3">
+    <if_sid>19006</if_sid>
+    <field name="sca.check.status">^Not applicable</field>
+    <options>no_full_log</options>
+    <description>$(sca.policy): $(sca.check.title). Reason: $(sca.check.reason)</description>
+  </rule>
+
+  <rule id="19010" level="3">
     <if_sid>19008</if_sid>
     <field name="sca.check.previous_result">^failed</field>
     <options>no_full_log</options>
     <description>$(sca.policy): $(sca.check.title): Status changed from failed to passed</description>
   </rule>
 
-  <rule id="19010" level="9">
+  <rule id="19011" level="9">
     <if_sid>19007</if_sid>
     <field name="sca.check.previous_result">^passed</field>
     <options>no_full_log</options>
     <description>$(sca.policy): $(sca.check.title): Status changed from passed to failed</description>
+  </rule>
+
+  <rule id="19012" level="7">
+    <if_sid>19009</if_sid>
+    <field name="sca.check.previous_result">^passed</field>
+    <options>no_full_log</options>
+    <description>$(sca.policy): $(sca.check.title): Status changed from passed to 'not applicable'. Reason: $(sca.check.reason)</description>
+  </rule>
+
+  <rule id="19013" level="7">
+    <if_sid>19009</if_sid>
+    <field name="sca.check.previous_result">^failed</field>
+    <options>no_full_log</options>
+    <description>$(sca.policy): $(sca.check.title): Status changed from failed to 'not applicable'. Reason: $(sca.check.reason)</description>
+  </rule>
+
+  <rule id="19014" level="9">
+    <if_sid>19007</if_sid>
+    <field name="sca.check.previous_result">^Not applicable</field>
+    <options>no_full_log</options>
+    <description>$(sca.policy): $(sca.check.title): Status changed from 'not applicable' to failed</description>
+  </rule>
+
+  <rule id="19015" level="3">
+    <if_sid>19008</if_sid>
+    <field name="sca.check.previous_result">^Not applicable</field>
+    <options>no_full_log</options>
+    <description>$(sca.policy): $(sca.check.title): Status changed from 'not applicable' to passed</description>
   </rule>
 </group>


### PR DESCRIPTION
This PR adds the rules for SCA new status, `not applicable`.
Related PR: https://github.com/wazuh/wazuh/pull/3122

The new rules cover non-applicable checks and changes of a check's status from `passed` or `failed` to `not applicable`.