### PR TITLE
Add new field sshd-success decoder

### DIFF
--- a/decoders/0310-ssh_decoders.xml
+++ b/decoders/0310-ssh_decoders.xml
@@ -64,7 +64,7 @@
   <parent>sshd</parent>
   <prematch>^Accepted</prematch>
   <regex offset="after_prematch">^ \S+ for (\S+) from (\S+) port (\S+) (\S+)</regex>
-  <order>user, srcip, port, protocol</order>
+  <order>user, srcip, srcport, protocol</order>
   <fts>name, user, location</fts>
 </decoder>
 

--- a/decoders/0310-ssh_decoders.xml
+++ b/decoders/0310-ssh_decoders.xml
@@ -63,8 +63,8 @@
 <decoder name="sshd-success">
   <parent>sshd</parent>
   <prematch>^Accepted</prematch>
-  <regex offset="after_prematch">^ \S+ for (\S+) from (\S+) port </regex>
-  <order>user, srcip</order>
+  <regex offset="after_prematch">^ \S+ for (\S+) from (\S+) port (\S+) (\S+)</regex>
+  <order>user, srcip, port, protocol</order>
   <fts>name, user, location</fts>
 </decoder>
 


### PR DESCRIPTION
Adding new fields in sshd-success decoder. New the decoder obtains the port and the protocol. For example:
```
Feb 14 12:19:04 localhost sshd[25474]: Accepted password for rromero from 192.168.1.133 port 49765 ssh2

**Phase 1: Completed pre-decoding.
       full event: 'Feb 14 12:19:04 localhost sshd[25474]: Accepted password for rromero from 192.168.1.133 port 49765 ssh2'
       timestamp: 'Feb 14 12:19:04'
       hostname: 'localhost'
       program_name: 'sshd'
       log: 'Accepted password for rromero from 192.168.1.133 port 49765 ssh2'

**Phase 2: Completed decoding.
       decoder: 'sshd'
       dstuser: 'rromero'
       srcip: '192.168.1.133'
       port: '49765'
       protocol: 'ssh2'

**Phase 3: Completed filtering (rules).
       Rule id: '5715'
       Level: '3'
       Description: 'sshd: authentication success.'
**Alert to be generated.

```

The issue number [367](https://github.com/wazuh/wazuh-ruleset/issues/367) describes this case.