### PR TITLE
Improve cisco-ios decoders

### DIFF
--- a/decoders/0065-cisco-ios_decoders.xml
+++ b/decoders/0065-cisco-ios_decoders.xml
@@ -31,7 +31,7 @@
 -->
 
 <decoder name="cisco-ios">
-  <prematch>^\d+:\d+:\d+:\s+%</prematch>
+  <prematch>\d+:\d+:\d+:\s+%\w+-\d-\w+:</prematch>
 </decoder>
 
 <!--
@@ -40,7 +40,7 @@
   - Mar  1 18:46:11: %SYS-5-CONFIG_I: Configured from console by vty2 (10.34.195.36)
 -->
 <decoder name="cisco-ios">
-  <prematch>^\p*\w+\s+\d*\s+\d+:\d+:\d+:\s+%</prematch>
+  <prematch>\p*\w+\s+\d*\s+\d+:\d+:\d+:\s+%\w+-\d-\w+:</prematch>
 </decoder>
 
 <!--
@@ -48,7 +48,7 @@
   - *Mar  1 18:48:50.483 UTC: %SYS-5-CONFIG_I: Configured from console by vty2 (10.34.195.36)
 -->
 <decoder name="cisco-ios">
-  <prematch>^\p*\w+\s+\d*\s+\d+:\d+:\d+.\d+\s+\w+:\s+%</prematch>
+  <prematch>\p*\w+\s+\d*\s+\d+:\d+:\d+.\d+\s+\w+:\s+%\w+-\d-\w+:</prematch>
 </decoder>
 
 
@@ -58,7 +58,7 @@
 -->
 
 <decoder name="cisco-ios">
-  <prematch>^\d+: %</prematch>
+  <prematch>\d+: %\w+-\d-\w+:</prematch>
 </decoder>
 
 <!--
@@ -70,7 +70,7 @@
 -->
 
 <decoder name="cisco-ios">
-  <prematch>^\d+:\s+\p*\w+\s+\d+\s+\S+\s+\w+:\s+%</prematch>
+  <prematch>\d+:\s+\p*\w+\s+\d+\s+\S+\s+\w+:\s+%\w+-\d-\w+:</prematch>
 </decoder>
 
 


### PR DESCRIPTION
This PR is related to issue [379](https://github.com/wazuh/wazuh-ruleset/issues/379).
A user report that the following log doesn't match rule 4715.
>Apr 30 15:10:58: %DOT1X-5-FAIL: Authentication failed for client (Unknown MAC) on Interface Fa0/3 AuditSessionID 

This event is comunicated from agent by syslog. And its full log could be:
>2019 May 06 09:28:12 vm-ubuntu16->10.0.0.16 May 6 07:28:11 vm-ubuntu16 cisco Apr 30 15:10:58: %DOT1X-5-FAIL: Authentication failed for client (Unknown MAC) on Interface Fa0/3 AuditSessionID 

cisco-ios decoders have been modified to match full event.

Analysisd output:

```
** Alert 1557135117.102931: - syslog,cisco_ios,
2019 May 06 11:31:57 vm-ubuntu16->10.0.0.16
Rule: 4715 (level 6) -> 'Cisco IOS notification message.'
May  6 09:31:55 vm-ubuntu16 fortinet Apr 30 15:10:58: %DOT1X-5-FAIL: Authentication failed for client (Unknown MAC) on Interface Fa0/3 AuditSessionID
```
