### PR TITLE
Removed duplicated rule for check 11018

### DIFF
--- a/sca/debian/cis_debianlinux7-8_L1_rcl.yml
+++ b/sca/debian/cis_debianlinux7-8_L1_rcl.yml
@@ -31,7 +31,6 @@ variables:
  $rc_dirs: /etc/rc0.d,/etc/rc1.d,/etc/rc2.d,/etc/rc3.d,/etc/rc4.d,/etc/rc5.d,/etc/rc6.d,/etc/rc7.d,/etc/rc8.d,/etc/rc9.d,/etc/rca.d,/etc/rcb.d,/etc/rcc.d,/etc/rcs.d,/etc/rcS.d;
  $rsyslog_files: /etc/rsyslog.conf,/etc/rsyslog.d/*;
  $profiledfiles: /etc/profile.d/*;
-
  $home_dirs: /usr2/home/*,/home/*,/home,/*/home/*,/*/home,/;
 
 checks:
@@ -920,8 +919,7 @@ checks:
     - cis: "9.3.1"
    condition: any
    rules:
-     - 'f:/etc/ssh/sshd_config -> IN !r:^# && r:protocol 1;'
-     - 'f:/etc/ssh/sshd_config -> !r:^protocol 2$;'
+     - 'f:/etc/ssh/sshd_config -> NIN !r:^# && r:Protocol\.+2;'
  - id: 10578
    title: "Set LogLevel to INFO"
    description: "The INFO parameter specifices that record login and logout activity will be logged."

--- a/sca/debian/cis_debianlinux7-8_L2_rcl.yml
+++ b/sca/debian/cis_debianlinux7-8_L2_rcl.yml
@@ -284,7 +284,6 @@ checks:
      - 'f:!/etc/audit/audit.rules;'
      - 'f:/etc/audit/audit.rules -> !r:^-a always,exit -F arch=b32 -S creat -S open -S openat -S truncate -S ftruncate \\;'
      - 'f:/etc/audit/audit.rules -> !r:^-F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -k access;'
-     - 'f:/etc/audit/audit.rules -> !r:^-a always,exit -F arch=b32 -S creat -S open -S openat -S truncate -S ftruncate \\;'
      - 'f:/etc/audit/audit.rules -> !r:^-F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -k access;'
  - id: 11020
    title: "Collect Successful File System Mounts"

--- a/sca/debian/cis_debianlinux7-8_L2_rcl.yml
+++ b/sca/debian/cis_debianlinux7-8_L2_rcl.yml
@@ -269,7 +269,6 @@ checks:
      - 'f:/etc/audit/audit.rules -> !r:^-a always,exit -F arch=b32 -S chmod -S fchmod -S fchmodat -F auid>=1000 \\;'
      - 'f:/etc/audit/audit.rules -> !r:^-F auid!=4294967295 -k perm_mod;'
      - 'f:/etc/audit/audit.rules -> !r:^-a always,exit -F arch=b32 -S chown -S fchown -S fchownat -S lchown -F auid>=1000 \\;'
-     - 'f:/etc/audit/audit.rules -> !r:^-F auid!=4294967295 -k perm_mod;'
      - 'f:/etc/audit/audit.rules -> !r:^-a always,exit -F arch=b32 -S setxattr -S lsetxattr -S fsetxattr -S removexattr -S \\;'
      - 'f:/etc/audit/audit.rules -> !r:^lremovexattr -S fremovexattr -F auid>=1000 -F auid!=4294967295 -k perm_mod;'
  - id: 11019


### PR DESCRIPTION
### Duplicated rule

As explained on this issue https://github.com/wazuh/wazuh-ruleset/issues/371 the duplicated rule caused the primary key uniqueness to fail.

### Remediation

Removed the duplicated rule.