### PR TITLE
Fixed requirements and rules for macOS

### DIFF
--- a/sca/darwin/15/cis_apple_macOS_10.11.yml
+++ b/sca/darwin/15/cis_apple_macOS_10.11.yml
@@ -23,9 +23,9 @@ requirements:
   description: "Requirements for running the SCA scan against MacOS 10.11 (El Capitan)."
   condition: "any required"
   rules:
-    - 'c:defaults read loginwindow SystemVersionStampAsString -> r:^\s*10.11;'
-    - 'c:sw_vers -> r:^ProductVersion:\s*10.11;'
-    - 'c:system_profiler SPSoftwareDataType -> r:^\s*System Version:.*10.11;'
+    - 'c:defaults read loginwindow SystemVersionStampAsString -> r:^\s*10\p11;'
+    - 'c:sw_vers -> r:^ProductVersion:\t*10\p11;'
+    - 'c:system_profiler SPSoftwareDataType -> r:^\s*System Version:.*10\p11;'
 
 checks:
 # 1.1 Verify all Apple provided software is current (Scored)
@@ -38,7 +38,7 @@ checks:
      - cis: "1.1"
    condition: any
    rules:
-     - 'c:softwareupdate -l -> !r:^\s*Now new software available;'
+     - 'c:softwareupdate -l -> !r:^\s*No new software available;'
 # 1.2 Enable Auto Update (Scored)
  - id: 3001
    title: "Enable Auto Update (Scored)"
@@ -52,7 +52,7 @@ checks:
      - https://derflounder.wordpress.com/2014/12/17/forcing-xprotect-blacklist-updates-on-mavericks-and-yosemite/
    condition: any
    rules:
-     - 'c:defaults read /Library/Preferences/com.apple.SoftwareUpdate AutomaticCheckEnabled -> !r:^\s*1;'
+     - 'c:defaults read /Library/Preferences/com.apple.SoftwareUpdate AutomaticCheckEnabled -> r:^\s*0$;'
 # 1.3 Enable app update installs (Scored)
  - id: 3002
    title: "Enable app update installs (Scored)"
@@ -63,7 +63,7 @@ checks:
      - cis: "1.3"
    condition: any
    rules:
-     - 'c:defaults read /Library/Preferences/com.apple.commerce AutoUpdate -> !r:^\s*1;'
+     - 'c:defaults read /Library/Preferences/com.apple.commerce AutoUpdate -> r:^\s*0$;'
 # 1.4 Enable system data files and security update installs (Scored)
  - id: 3003
    title: "Enable system data files and security update installs (Scored)"
@@ -89,7 +89,7 @@ checks:
      - cis: "1.5"
    condition: any
    rules:
-     - 'c:defaults read /Library/Preferences/com.apple.commerce AutoUpdateRestartRequired -> !r:^\s*1;'
+     - 'c:defaults read /Library/Preferences/com.apple.commerce AutoUpdateRestartRequired -> r:^\s*0$;'
 # 2.1.2 Turn off Bluetooth "Discoverable" mode when not pairing devices (Scored)
  - id: 3005
    title: "Turn off Bluetooth \"Discoverable\" mode when not pairing devices (Scored)"
@@ -155,7 +155,7 @@ checks:
      - cis: "2.4.5"
    condition: any
    rules:
-     - 'c:systemsetup -getremotelogin -> !r:^Remote Login:\s*Off;'
+     - 'c:systemsetup -getremotelogin -> r:^Remote Login:\s*On;'
 # 2.4.8 Disable File Sharing (Scored)
  - id: 3011
    title: "Disable File Sharing (Scored)"
@@ -178,8 +178,8 @@ checks:
      - cis: "2.5.1"
    condition: any
    rules:
-     - 'c:pmset -c -g -> !r:^\s*womp\s+0;'
-     - 'c:pmset -b -g -> !r:^\s*womp\s+0;'
+     - 'c:pmset -g -> r:^\s*womp\s+1$;'
+     - 'c:pmset -b -g -> r:^\s*womp\s+1$;'
 # 2.6.1 Enable FileVault (Scored)
  - id: 3013
    title: "Enable FileVault (Scored)"
@@ -215,8 +215,8 @@ checks:
      - https://support.apple.com/en-us/HT201642
    condition: all
    rules:
-     - 'c:defaults read /Library/Preferences/com.apple.alf globalstate -> !r:^\s*1;'
-     - 'c:defaults read /Library/Preferences/com.apple.alf globalstate -> !r:^\s*2;'
+     - 'c:defaults read /Library/Preferences/com.apple.alf globalstate -> !r:^\s*1$;'
+     - 'c:defaults read /Library/Preferences/com.apple.alf globalstate -> !r:^\s*2$;'
 # 2.6.4 Enable Firewall Stealth Mode (Scored)
  - id: 3016
    title: "Enable Firewall Stealth Mode (Scored)"
@@ -240,7 +240,7 @@ checks:
      - cis: "2.10"
    condition: any
    rules:
-     - 'c:defaults read -app Terminal SecureKeyboardEntry -> !r:^\s*1;'
+     - 'c:defaults read -app Terminal SecureKeyboardEntry -> r:^\s*0$;'
 # 2.11 Java 6 is not the default Java runtime (Scored)
  - id: 3018
    title: "Java 6 is not the default Java runtime (Scored)"
@@ -289,7 +289,7 @@ checks:
      - cis: "4.1"
    condition: any
    rules:
-     - 'c:defaults read /Library/Preferences/com.apple.mDNSResponder.plist NoMulticastAdvertisements -> !r:^\s*1;'
+     - 'c:defaults read /Library/Preferences/com.apple.mDNSResponder.plist NoMulticastAdvertisements -> !r:^\s*1$;'
 # 4.4 Ensure http server is not running (Scored)
  - id: 3022
    title: "Ensure http server is not running (Scored)"
@@ -301,6 +301,8 @@ checks:
    condition: any
    rules:
      - 'p:httpd;'
+     - 'p:/usr/sbin/httpd;'
+     - 'p:/usr/sbin/httpd -D FOREGROUND;'
 # 4.5 Ensure ftp server is not running (Scored)
  - id: 3023
    title: "Ensure ftp server is not running (Scored)"
@@ -389,7 +391,7 @@ checks:
      - cis: "6.1.3"
    condition: any
    rules:
-     - 'c:defaults read /Library/Preferences/com.apple.loginwindow.plist GuestEnabled -> !r:^\s*0;'
+     - 'c:defaults read /Library/Preferences/com.apple.loginwindow.plist GuestEnabled -> !r:^\s*0$;'
 # 6.1.5 Remove Guest home folder (Scored)
  - id: 3031
    title: "Remove Guest home folder (Scored)"
@@ -411,7 +413,7 @@ checks:
      - cis: "6.2"
    condition: any
    rules:
-     - 'c:defaults read NSGlobalDomain AppleShowAllExtensions -> !r:^\s*1;'
+     - 'c:defaults read NSGlobalDomain AppleShowAllExtensions -> !r:^\s*1$;'
 # 6.3 Disable the automatic run of safe files in Safari (Scored)
  - id: 3033
    title: "Disable the automatic run of safe files in Safari (Scored)"
@@ -422,5 +424,5 @@ checks:
      - cis: "6.3"
    condition: any
    rules:
-     - 'c:defaults read com.apple.Safari AutoOpenSafeDownloads -> !r:^0;'
+     - 'c:defaults read com.apple.Safari AutoOpenSafeDownloads -> r:^1$;'
 

--- a/sca/darwin/15/cis_apple_macOS_10.11.yml
+++ b/sca/darwin/15/cis_apple_macOS_10.11.yml
@@ -167,7 +167,6 @@ checks:
    condition: any
    rules:
      - 'c:launchctl list -> r:AppleFileServer;'
-     - 'f:/Library/Preferences/SystemConfiguration/com.apple.smb.server.plist -> r:[Aa][Rr][Rr][Aa][Yy];'
 # 2.5.1 Disable "Wake for network access" (Scored)
  - id: 3012
    title: "Disable \"Wake for network access\" (Scored)"
@@ -289,7 +288,7 @@ checks:
      - cis: "4.1"
    condition: any
    rules:
-     - 'c:defaults read /Library/Preferences/com.apple.mDNSResponder.plist NoMulticastAdvertisements -> !r:^\s*1$;'
+     - 'c:defaults read /Library/Preferences/com.apple.mDNSResponder.plist NoMulticastAdvertisements -> r:^\s*0$;'
 # 4.4 Ensure http server is not running (Scored)
  - id: 3022
    title: "Ensure http server is not running (Scored)"
@@ -358,7 +357,7 @@ checks:
      - cis: "5.9"
    condition: any
    rules:
-     - 'c:defaults read com.apple.screensaver askForPassword -> !r:^\s*1;'
+     - 'c:defaults read com.apple.screensaver askForPassword -> r:^\s*0$;'
 # 5.11 Disable ability to login to another user's active and locked session (Scored)
  - id: 3028
    title: "Disable ability to login to another user's active and locked session (Scored)"
@@ -413,7 +412,7 @@ checks:
      - cis: "6.2"
    condition: any
    rules:
-     - 'c:defaults read NSGlobalDomain AppleShowAllExtensions -> !r:^\s*1$;'
+     - 'c:defaults read NSGlobalDomain AppleShowAllExtensions -> r:^\s*0$;'
 # 6.3 Disable the automatic run of safe files in Safari (Scored)
  - id: 3033
    title: "Disable the automatic run of safe files in Safari (Scored)"

--- a/sca/darwin/15/cis_apple_macOS_10.11.yml
+++ b/sca/darwin/15/cis_apple_macOS_10.11.yml
@@ -14,7 +14,7 @@ policy:
   id: "cis_apple_macos_10_11"
   file: "cis_apple_macOS_10.11.yml"
   name: "CIS Apple OSX 10.11 Benchmark"
-  description: "This document, CIS Apple OSX 10.11 Benchmark, provides prescriptive guidance for establishing a secure configuration posture for Apple OSX 10.11. This guide was tested against Apple OSX 10.11. To obtain the latest version of this guide, please visit http://benchmarks.cisecurity.org. If you have questions, comments, or have identified ways to improve this guide, please write us at feedback@cisecurity.org."
+  description: "This document, CIS Apple OSX 10.11 Benchmark, provides prescriptive guidance for establishing a secure configuration posture for Apple OSX 10.11. This guide was tested against Apple OSX 10.11. To obtain the latest version of this guide, please visit https://benchmarks.cisecurity.org. If you have questions, comments, or have identified ways to improve this guide, please write us at feedback@cisecurity.org."
   references:
     - https://www.cisecurity.org/cis-benchmarks/
 
@@ -48,7 +48,7 @@ checks:
    compliance:
      - cis: "1.2"
    references:
-     - http://macops.ca/os-x-admins-your-clients-are-not-getting-background-security-updates/
+     - https://macops.ca/os-x-admins-your-clients-are-not-getting-background-security-updates/
      - https://derflounder.wordpress.com/2014/12/17/forcing-xprotect-blacklist-updates-on-mavericks-and-yosemite/
    condition: any
    rules:
@@ -73,12 +73,12 @@ checks:
    compliance:
      - cis: "1.4"
    references:
-     - http://www.thesafemac.com/tag/xprotect/
+     - https://www.thesafemac.com/tag/xprotect/
      - https://support.apple.com/en-us/HT202491
    condition: any
    rules:
-     - 'c:defaults read /Library/Preferences/com.apple.SoftwareUpdate -> IN r:^\s*ConfigDataInstall\s*= && !r:\s*1;;'
-     - 'c:defaults read /Library/Preferences/com.apple.SoftwareUpdate -> IN r:^\s*CriticalUpdateInstall\s*= && !r:\s*1;;'
+     - 'c:defaults read /Library/Preferences/com.apple.SoftwareUpdate -> IN r:^\s*ConfigDataInstall\s*= && !r:\s*1;'
+     - 'c:defaults read /Library/Preferences/com.apple.SoftwareUpdate -> IN r:^\s*CriticalUpdateInstall\s*= && !r:\s*1;'
 # 1.5 Enable OS X update installs (Scored)
  - id: 3004
    title: "Enable OS X update installs (Scored)"
@@ -161,7 +161,7 @@ checks:
    title: "Disable File Sharing (Scored)"
    description: "Apple's File Sharing uses a combination of SMB (Windows sharing) and AFP (Mac sharing)"
    rationale: "By disabling file sharing, the remote attack surface and risk of unauthorized access to files stored on the system is reduced."
-   remediation: "Run the following command in Terminal to turn off AFP from the command line: sudo launchctl unload -w /System/Library/LaunchDaemons/com.apple.AppleFileServer.plist   Run the following command in Terminal to turn off SMB sharing from the CLI:  sudo launchctl unload -w /System/Library/LaunchDaemons/com.apple.smbd.plist"
+   remediation: "Run the following command in Terminal to turn off AFP from the command line: sudo launchctl unload -w /System/Library/LaunchDaemons/com.apple.AppleFileServer.plist  - Run the following command in Terminal to turn off SMB sharing from the CLI:  sudo launchctl unload -w /System/Library/LaunchDaemons/com.apple.smbd.plist"
    compliance:
      - cis: "2.4.8"
    condition: any

--- a/sca/darwin/16/cis_apple_macOS_10.12.yml
+++ b/sca/darwin/16/cis_apple_macOS_10.12.yml
@@ -23,9 +23,9 @@ requirements:
   description: "Requirements for running the SCA scan against MacOS 10.12 (Sierra)."
   condition: "any required"
   rules:
-    - 'c:defaults read loginwindow SystemVersionStampAsString -> r:^\s*10.12;'
-    - 'c:sw_vers -> r:^ProductVersion:\s*10.12;'
-    - 'c:system_profiler SPSoftwareDataType -> r:^\s*System Version:.*10.12;'
+    - 'c:defaults read loginwindow SystemVersionStampAsString -> r:^\s*10\p12;'
+    - 'c:sw_vers -> r:^ProductVersion:\t*10\p12;'
+    - 'c:system_profiler SPSoftwareDataType -> r:^\s*System Version:\.*10\p12;'
 
 checks:
 # 1.1 Verify all Apple provided software is current (Scored)
@@ -38,7 +38,7 @@ checks:
      - cis: "1.1"
    condition: any
    rules:
-     - 'c:softwareupdate -l -> !r:^\s*Now new software available;'
+     - 'c:softwareupdate -l -> !r:^\s*No new software available;'
 # 1.2 Enable Auto Update (Scored)
  - id: 13501
    title: "Enable Auto Update (Scored)"
@@ -63,7 +63,7 @@ checks:
      - cis: "1.3"
    condition: any
    rules:
-     - 'c:defaults read /Library/Preferences/com.apple.commerce AutoUpdate -> !r:^\s*1;'
+     - 'c:defaults read /Library/Preferences/com.apple.commerce AutoUpdate -> r:^\s*0$;'
 # 1.4 Enable system data files and security update installs (Scored)
  - id: 13503
    title: "Enable system data files and security update installs (Scored)"
@@ -89,7 +89,7 @@ checks:
      - cis: "1.5"
    condition: any
    rules:
-     - 'c:defaults read /Library/Preferences/com.apple.commerce AutoUpdateRestartRequired -> !r:^\s*1;'
+     - 'c:defaults read /Library/Preferences/com.apple.commerce AutoUpdateRestartRequired -> r:^\s*0$;'
 # 2.1.2 Turn off Bluetooth "Discoverable" mode when not pairing devices (Scored)
  - id: 13505
    title: "Turn off Bluetooth \"Discoverable\" mode when not pairing devices (Scored)"
@@ -144,7 +144,7 @@ checks:
      - cis: "2.4.5"
    condition: any
    rules:
-     - 'c:systemsetup -getremotelogin -> !r:^Remote Login:\s*Off;'
+     - 'c:systemsetup -getremotelogin -> r:^Remote Login:\s*On;'
 # 2.4.8 Disable File Sharing (Scored)
  - id: 13510
    title: "Disable File Sharing (Scored)"
@@ -167,7 +167,7 @@ checks:
      - cis: "2.5.1"
    condition: any
    rules:
-     - 'c:pmset -g -> !r:^\s*womp\s+0;'
+     - 'c:pmset -g -> r:^\s*womp\s+1$;'
 # 2.6.1.1 Enable FileVault (Scored)
  - id: 13512
    title: "Enable FileVault (Scored)"
@@ -178,7 +178,7 @@ checks:
      - cis: "2.6.1.1"
    condition: any
    rules:
-     - 'c:fdesetup status -> !r:^FileVault is\s*On.;'
+     - 'c:fdesetup status -> r:^FileVault is\s*Off\p;'
 # 2.6.2 Enable Gatekeeper (Scored)
  - id: 13513
    title: "Enable Gatekeeper (Scored)"
@@ -202,8 +202,8 @@ checks:
      - https://support.apple.com/en-us/HT201642
    condition: all
    rules:
-     - 'c:defaults read /Library/Preferences/com.apple.alf globalstate -> !r:^\s*1;'
-     - 'c:defaults read /Library/Preferences/com.apple.alf globalstate -> !r:^\s*2;'
+     - 'c:defaults read /Library/Preferences/com.apple.alf globalstate -> !r:^\s*1$;'
+     - 'c:defaults read /Library/Preferences/com.apple.alf globalstate -> !r:^\s*2$;'
 # 2.6.4 Enable Firewall Stealth Mode (Scored)
  - id: 13515
    title: "Enable Firewall Stealth Mode (Scored)"
@@ -227,7 +227,7 @@ checks:
      - cis: "2.10"
    condition: any
    rules:
-     - 'c:defaults read -app Terminal SecureKeyboardEntry -> !r:^\s*1;'
+     - 'c:defaults read -app Terminal SecureKeyboardEntry -> r:^\s*0$;'
 # 2.11 Java 6 is not the default Java runtime (Scored)
  - id: 13517
    title: "Java 6 is not the default Java runtime (Scored)"
@@ -276,7 +276,7 @@ checks:
      - cis: "4.1"
    condition: any
    rules:
-     - 'c:defaults read /Library/Preferences/com.apple.mDNSResponder.plist NoMulticastAdvertisements -> !r:^\s*1;'
+     - 'c:defaults read /Library/Preferences/com.apple.mDNSResponder.plist NoMulticastAdvertisements -> !r:^\s*1$;'
 # 4.4 Ensure http server is not running (Scored)
  - id: 13521
    title: "Ensure http server is not running (Scored)"
@@ -288,6 +288,8 @@ checks:
    condition: any
    rules:
      - 'p:httpd;'
+     - 'p:/usr/sbin/httpd;'
+     - 'p:/usr/sbin/httpd -D FOREGROUND;'
 # 4.5 Ensure FTP server is not running (Scored)
  - id: 13522
    title: "Ensure FTP server is not running (Scored)"
@@ -354,7 +356,7 @@ checks:
      - cis: "6.1.3"
    condition: any
    rules:
-     - 'c:defaults read /Library/Preferences/com.apple.loginwindow.plist GuestEnabled -> !r:^\s*0;'
+     - 'c:defaults read /Library/Preferences/com.apple.loginwindow.plist GuestEnabled -> !r:^\s*0$;'
 # 6.1.5 Remove Guest home folder (Scored)
  - id: 13528
    title: "Remove Guest home folder (Scored)"
@@ -376,7 +378,7 @@ checks:
      - cis: "6.2"
    condition: any
    rules:
-     - 'c:defaults read NSGlobalDomain AppleShowAllExtensions -> !r:^\s*1;'
+     - 'c:defaults read NSGlobalDomain AppleShowAllExtensions -> !r:^\s*1$;'
 # 6.3 Disable the automatic run of safe files in Safari (Scored)
  - id: 13530
    title: "Disable the automatic run of safe files in Safari (Scored)"
@@ -387,5 +389,5 @@ checks:
      - cis: "6.3"
    condition: any
    rules:
-     - 'c:defaults read com.apple.Safari AutoOpenSafeDownloads -> !r:^0;'
+     - 'c:defaults read com.apple.Safari AutoOpenSafeDownloads -> r:^1$;'
 

--- a/sca/darwin/16/cis_apple_macOS_10.12.yml
+++ b/sca/darwin/16/cis_apple_macOS_10.12.yml
@@ -14,7 +14,7 @@ policy:
   id: "cis_apple_macos_10_12"
   file: "cis_apple_macOS_10.12.yml"
   name: "CIS Apple macOS 10.12 Benchmark"
-  description: "This document, CIS Apple macOS 10.12 Benchmark, provides prescriptive guidance for establishing a secure configuration posture for Apple macOS 10.12. This guide was tested against Apple macOS 10.12. To obtain the latest version of this guide, please visit http://benchmarks.cisecurity.org. If you have questions, comments, or have identified ways to improve this guide, please write us at feedback@cisecurity.org."
+  description: "This document, CIS Apple macOS 10.12 Benchmark, provides prescriptive guidance for establishing a secure configuration posture for Apple macOS 10.12. This guide was tested against Apple macOS 10.12. To obtain the latest version of this guide, please visit https://benchmarks.cisecurity.org. If you have questions, comments, or have identified ways to improve this guide, please write us at feedback@cisecurity.org."
   references:
     - https://www.cisecurity.org/cis-benchmarks/
 
@@ -48,7 +48,7 @@ checks:
    compliance:
      - cis: "1.2"
    references:
-     - http://macops.ca/os-x-admins-your-clients-are-not-getting-background-security-updates/
+     - https://macops.ca/os-x-admins-your-clients-are-not-getting-background-security-updates/
      - https://derflounder.wordpress.com/2014/12/17/forcing-xprotect-blacklist-updates-on-mavericks-and-yosemite/
    condition: any
    rules:
@@ -73,7 +73,7 @@ checks:
    compliance:
      - cis: "1.4"
    references:
-     - http://www.thesafemac.com/tag/xprotect/
+     - https://www.thesafemac.com/tag/xprotect/
      - https://support.apple.com/en-us/HT202491
    condition: any
    rules:
@@ -150,7 +150,7 @@ checks:
    title: "Disable File Sharing (Scored)"
    description: "Apple's File Sharing uses a combination of SMB (Windows sharing) and AFP (Mac sharing)"
    rationale: "By disabling file sharing, the remote attack surface and risk of unauthorized access to files stored on the system is reduced."
-   remediation: "Run the following command in Terminal to turn off AFP from the command line: sudo launchctl unload -w /System/Library/LaunchDaemons/com.apple.AppleFileServer.plist   Run the following command in Terminal to turn off SMB sharing from the CLI: sudo launchctl unload -w /System/Library/LaunchDaemons/com.apple.smbd.plist"
+   remediation: "Run the following command in Terminal to turn off AFP from the command line: sudo launchctl unload -w /System/Library/LaunchDaemons/com.apple.AppleFileServer.plist  - Run the following command in Terminal to turn off SMB sharing from the CLI: sudo launchctl unload -w /System/Library/LaunchDaemons/com.apple.smbd.plist"
    compliance:
      - cis: "2.4.8"
    condition: any
@@ -194,7 +194,7 @@ checks:
    title: "Enable Firewall (Scored)"
    description: "A firewall is a piece of software that blocks unwanted incoming connections to a system.  Apple has posted general documentation about the application firewall."
    rationale: "A firewall minimizes the threat of unauthorized users from gaining access to your system while connected to a network or the Internet."
-   remediation: "Run the following command in Terminal: defaults write /Library/Preferences/com.apple.alf globalstate - int <value>    Where <value> is:  1 = on for specific services  2 = on for essential services"
+   remediation: "Run the following command in Terminal: defaults write /Library/Preferences/com.apple.alf globalstate - int <value>    Where <value> is: - 1 = on for specific services - 2 = on for essential services"
    compliance:
      - cis: "2.6.3"
    references:

--- a/sca/darwin/16/cis_apple_macOS_10.12.yml
+++ b/sca/darwin/16/cis_apple_macOS_10.12.yml
@@ -77,8 +77,8 @@ checks:
      - https://support.apple.com/en-us/HT202491
    condition: any
    rules:
-     - 'c:defaults read /Library/Preferences/com.apple.SoftwareUpdate -> NIN r:^\s*ConfigDataInstall\s*= && r\s*1;;'
-     - 'c:defaults read /Library/Preferences/com.apple.SoftwareUpdate -> NIN r:^\s*CriticalUpdateInstall\s*= && r\s*1;;'
+     - 'c:defaults read /Library/Preferences/com.apple.SoftwareUpdate -> NIN r:^\s*ConfigDataInstall\s*= && r:\s*1;'
+     - 'c:defaults read /Library/Preferences/com.apple.SoftwareUpdate -> NIN r:^\s*CriticalUpdateInstall\s*= && r:\s*1;'
 # 1.5 Enable macOS update installs (Scored)
  - id: 13504
    title: "Enable macOS update installs (Scored)"
@@ -156,7 +156,6 @@ checks:
    condition: any
    rules:
      - 'c:launchctl list -> r:AppleFileServer;'
-     - 'f:/Library/Preferences/SystemConfiguration/com.apple.smb.server.plist -> r:[Aa][Rr][Rr][Aa][Yy];'
 # 2.5.1 Disable "Wake for network access" (Scored)
  - id: 13511
    title: "Disable \"Wake for network access\" (Scored)"
@@ -276,7 +275,7 @@ checks:
      - cis: "4.1"
    condition: any
    rules:
-     - 'c:defaults read /Library/Preferences/com.apple.mDNSResponder.plist NoMulticastAdvertisements -> !r:^\s*1$;'
+     - 'c:defaults read /Library/Preferences/com.apple.mDNSResponder.plist NoMulticastAdvertisements -> r:^\s*0$;'
 # 4.4 Ensure http server is not running (Scored)
  - id: 13521
    title: "Ensure http server is not running (Scored)"
@@ -378,7 +377,7 @@ checks:
      - cis: "6.2"
    condition: any
    rules:
-     - 'c:defaults read NSGlobalDomain AppleShowAllExtensions -> !r:^\s*1$;'
+     - 'c:defaults read NSGlobalDomain AppleShowAllExtensions -> r:^\s*0$;'
 # 6.3 Disable the automatic run of safe files in Safari (Scored)
  - id: 13530
    title: "Disable the automatic run of safe files in Safari (Scored)"

--- a/sca/darwin/17/cis_apple_macOS_10.13.yml
+++ b/sca/darwin/17/cis_apple_macOS_10.13.yml
@@ -77,8 +77,8 @@ checks:
      - https://support.apple.com/en-us/HT202491
    condition: any
    rules:
-     - 'c:defaults read /Library/Preferences/com.apple.SoftwareUpdate -> NIN r:^\s*ConfigDataInstall\s*= && r\s*1;;'
-     - 'c:defaults read /Library/Preferences/com.apple.SoftwareUpdate -> NIN r:^\s*CriticalUpdateInstall\s*= && r\s*1;;'
+     - 'c:defaults read /Library/Preferences/com.apple.SoftwareUpdate -> NIN r:^\s*ConfigDataInstall\s*= && r:\s*1;'
+     - 'c:defaults read /Library/Preferences/com.apple.SoftwareUpdate -> NIN r:^\s*CriticalUpdateInstall\s*= && r:\s*1;'
 # 1.5 Enable macOS update installs (Scored)
  - id: 14004
    title: "Enable macOS update installs (Scored)"
@@ -145,7 +145,6 @@ checks:
    condition: any
    rules:
      - 'c:launchctl list -> r:AppleFileServer;'
-     - 'f:/Library/Preferences/SystemConfiguration/com.apple.smb.server.plist -> r:[Aa][Rr][Rr][Aa][Yy];'
 # 2.5.1 Disable "Wake for network access" (Scored)
  - id: 14010
    title: "Disable \"Wake for network access\" (Scored)"
@@ -277,7 +276,7 @@ checks:
      - cis: "4.1"
    condition: any
    rules:
-     - 'c:defaults read /Library/Preferences/com.apple.mDNSResponder.plist NoMulticastAdvertisements -> !r:^\s*1$;'
+     - 'c:defaults read /Library/Preferences/com.apple.mDNSResponder.plist NoMulticastAdvertisements -> r:^\s*0$;'
 # 4.4 Ensure http server is not running (Scored)
  - id: 14021
    title: "Ensure http server is not running (Scored)"

--- a/sca/darwin/17/cis_apple_macOS_10.13.yml
+++ b/sca/darwin/17/cis_apple_macOS_10.13.yml
@@ -14,7 +14,7 @@ policy:
   id: "cis_apple_macos_10_13"
   file: "cis_apple_macOS_10.13.yml"
   name: "CIS Apple macOS 10.13 Benchmark"
-  description: "This document, CIS Apple macOS 10.13 Benchmark, provides prescriptive guidance for establishing a secure configuration posture for Apple macOS 10.13. This guide was tested against Apple macOS 10.13. To obtain the latest version of this guide, please visit http://benchmarks.cisecurity.org. If you have questions, comments, or have identified ways to improve this guide, please write us at feedback@cisecurity.org"
+  description: "This document, CIS Apple macOS 10.13 Benchmark, provides prescriptive guidance for establishing a secure configuration posture for Apple macOS 10.13. This guide was tested against Apple macOS 10.13. To obtain the latest version of this guide, please visit https://benchmarks.cisecurity.org. If you have questions, comments, or have identified ways to improve this guide, please write us at feedback@cisecurity.org"
   references:
     - https://www.cisecurity.org/cis-benchmarks/
 
@@ -48,7 +48,7 @@ checks:
    compliance:
      - cis: "1.2"
    references:
-     - http://macops.ca/os-x-admins-your-clients-are-not-getting-background-security-updates/
+     - https://macops.ca/os-x-admins-your-clients-are-not-getting-background-security-updates/
      - https://derflounder.wordpress.com/2014/12/17/forcing-xprotect-blacklist-updates-on-mavericks-and-yosemite/
    condition: any
    rules:
@@ -73,7 +73,7 @@ checks:
    compliance:
      - cis: "1.4"
    references:
-     - http://www.thesafemac.com/tag/xprotect/
+     - https://www.thesafemac.com/tag/xprotect/
      - https://support.apple.com/en-us/HT202491
    condition: any
    rules:
@@ -139,7 +139,7 @@ checks:
    title: "Disable File Sharing (Scored)"
    description: "Apple's File Sharing uses a combination of SMB (Windows sharing) and AFP (Mac sharing)"
    rationale: "By disabling file sharing, the remote attack surface and risk of unauthorized access to files stored on the system is reduced."
-   remediation: "Run the following command in Terminal to turn off AFP from the command line: sudo launchctl unload -w /System/Library/LaunchDaemons/com.apple.AppleFileServer.plist   Run the following command in Terminal to turn off SMB sharing from the CLI: sudo launchctl unload -w /System/Library/LaunchDaemons/com.apple.smbd.plist"
+   remediation: "Run the following command in Terminal to turn off AFP from the command line: sudo launchctl unload -w /System/Library/LaunchDaemons/com.apple.AppleFileServer.plist  - Run the following command in Terminal to turn off SMB sharing from the CLI: sudo launchctl unload -w /System/Library/LaunchDaemons/com.apple.smbd.plist"
    compliance:
      - cis: "2.4.8"
    condition: any
@@ -183,7 +183,7 @@ checks:
    title: "Enable Firewall (Scored)"
    description: "A firewall is a piece of software that blocks unwanted incoming connections to a system.  Apple has posted general documentation about the application firewall."
    rationale: "A firewall minimizes the threat of unauthorized users from gaining access to your system while connected to a network or the Internet."
-   remediation: "Run the following command in Terminal: defaults write /Library/Preferences/com.apple.alf globalstate - int <value>    Where <value> is:  1 = on for specific services  2 = on for essential services "
+   remediation: "Run the following command in Terminal: defaults write /Library/Preferences/com.apple.alf globalstate - int <value>    Where <value> is: - 1 = on for specific services - 2 = on for essential services "
    compliance:
      - cis: "2.6.3"
    references:

--- a/sca/darwin/17/cis_apple_macOS_10.13.yml
+++ b/sca/darwin/17/cis_apple_macOS_10.13.yml
@@ -23,9 +23,9 @@ requirements:
   description: "Requirements for running the SCA scan against MacOS 10.13 (High Sierra)."
   condition: "any required"
   rules:
-    - 'c:defaults read loginwindow SystemVersionStampAsString -> r:^\s*10.13;'
-    - 'c:sw_vers -> r:^ProductVersion:\s*10.13;'
-    - 'c:system_profiler SPSoftwareDataType -> r:^\s*System Version:.*10.13;'
+    - 'c:defaults read loginwindow SystemVersionStampAsString -> r:^\s*10\p13;'
+    - 'c:sw_vers -> r:^ProductVersion:\t*10\p13;'
+    - 'c:system_profiler SPSoftwareDataType -> r:^\s*System Version:\.*10\p13;'
 
 checks:
 # 1.1 Verify all Apple provided software is current (Scored)
@@ -38,7 +38,7 @@ checks:
      - cis: "1.1"
    condition: any
    rules:
-     - 'c:softwareupdate -l -> !r:^\s*Now new software available;'
+     - 'c:softwareupdate -l -> !r:^\s*No new software available;'
 # 1.2 Enable Auto Update (Scored)
  - id: 14001
    title: "Enable Auto Update (Scored)"
@@ -52,7 +52,7 @@ checks:
      - https://derflounder.wordpress.com/2014/12/17/forcing-xprotect-blacklist-updates-on-mavericks-and-yosemite/
    condition: any
    rules:
-     - 'c:defaults read /Library/Preferences/com.apple.SoftwareUpdate AutomaticCheckEnabled -> !r:^\s*1;'
+     - 'c:defaults read /Library/Preferences/com.apple.SoftwareUpdate AutomaticCheckEnabled -> r:^\s*0$;'
 # 1.3 Enable app update installs (Scored)
  - id: 14002
    title: "Enable app update installs (Scored)"
@@ -63,7 +63,7 @@ checks:
      - cis: "1.3"
    condition: any
    rules:
-     - 'c:defaults read /Library/Preferences/com.apple.commerce AutoUpdate -> !r:^\s*1;'
+     - 'c:defaults read /Library/Preferences/com.apple.commerce AutoUpdate -> r:^\s*0$;'
 # 1.4 Enable system data files and security update installs (Scored)
  - id: 14003
    title: "Enable system data files and security update installs (Scored)"
@@ -89,7 +89,7 @@ checks:
      - cis: "1.5"
    condition: any
    rules:
-     - 'c:defaults read /Library/Preferences/com.apple.commerce AutoUpdateRestartRequired -> !r:^\s*1;'
+     - 'c:defaults read /Library/Preferences/com.apple.commerce AutoUpdateRestartRequired -> r:^\s*0$;'
 # 2.2.1 Enable "Set time and date automatically" (Scored)
  - id: 14005
    title: "Enable \"Set time and date automatically\" (Scored)"
@@ -133,7 +133,7 @@ checks:
      - cis: "2.4.5"
    condition: any
    rules:
-     - 'c:systemsetup -getremotelogin -> !r:^Remote Login:\s*Off;'
+     - 'c:systemsetup -getremotelogin -> r:^Remote Login:\s*On;'
 # 2.4.8 Disable File Sharing (Scored)
  - id: 14009
    title: "Disable File Sharing (Scored)"
@@ -156,7 +156,7 @@ checks:
      - cis: "2.5.1"
    condition: any
    rules:
-     - 'c:pmset -g -> !r:^\s*womp\s+0;'
+     - 'c:pmset -g -> r:^\s*womp\s+1$;'
 # 2.6.1.1 Enable FileVault (Scored)
  - id: 14011
    title: "Enable FileVault (Scored)"
@@ -167,7 +167,7 @@ checks:
      - cis: "2.6.1.1"
    condition: any
    rules:
-     - 'c:fdesetup status -> !r:^FileVault is\s*On.;'
+     - 'c:fdesetup status -> r:^FileVault is\s*Off\p;'
 # 2.6.2 Enable Gatekeeper (Scored)
  - id: 14012
    title: "Enable Gatekeeper (Scored)"
@@ -191,8 +191,8 @@ checks:
      - https://support.apple.com/en-us/HT201642
    condition: all
    rules:
-     - 'c:defaults read /Library/Preferences/com.apple.alf globalstate -> !r:^\s*1;'
-     - 'c:defaults read /Library/Preferences/com.apple.alf globalstate -> !r:^\s*2;'
+     - 'c:defaults read /Library/Preferences/com.apple.alf globalstate -> !r:^\s*1$;'
+     - 'c:defaults read /Library/Preferences/com.apple.alf globalstate -> !r:^\s*2$;'
 # 2.6.4 Enable Firewall Stealth Mode (Scored)
  - id: 14014
    title: "Enable Firewall Stealth Mode (Scored)"
@@ -216,7 +216,7 @@ checks:
      - cis: "2.10"
    condition: any
    rules:
-     - 'c:defaults read -app Terminal SecureKeyboardEntry -> !r:^\s*1;'
+     - 'c:defaults read -app Terminal SecureKeyboardEntry -> r:^\s*0$;'
 # 2.11 Java 6 is not the default Java runtime (Scored)
  - id: 14016
    title: "Java 6 is not the default Java runtime (Scored)"
@@ -240,7 +240,7 @@ checks:
    condition: any
    rules:
      - 'c:/usr/libexec/firmwarecheckers/eficheck/eficheck --integrity-check -> !r:Primary allowlist version match found\. No changes detected in primary hashes\.;'
-     - 'c:launchctl list -> !r:-\s*0\s*com.apple.driver.eficheck;'
+     - 'c:launchctl list -> !r:-\t*0\t*com.apple.driver.eficheck;'
 # 3.1 Enable security auditing (Scored)
  - id: 14018
    title: "Enable security auditing (Scored)"
@@ -277,7 +277,7 @@ checks:
      - cis: "4.1"
    condition: any
    rules:
-     - 'c:defaults read /Library/Preferences/com.apple.mDNSResponder.plist NoMulticastAdvertisements -> !r:^\s*1;'
+     - 'c:defaults read /Library/Preferences/com.apple.mDNSResponder.plist NoMulticastAdvertisements -> !r:^\s*1$;'
 # 4.4 Ensure http server is not running (Scored)
  - id: 14021
    title: "Ensure http server is not running (Scored)"
@@ -289,6 +289,8 @@ checks:
    condition: any
    rules:
      - 'p:httpd;'
+     - 'p:/usr/sbin/httpd;'
+     - 'p:/usr/sbin/httpd -D FOREGROUND;'
 # 4.5 Ensure nfs server is not running (Scored)
  - id: 14022
    title: "Ensure nfs server is not running (Scored)"
@@ -344,7 +346,7 @@ checks:
      - cis: "6.1.3"
    condition: any
    rules:
-     - 'c:defaults read /Library/Preferences/com.apple.loginwindow.plist GuestEnabled -> !r:^\s*0;'
+     - 'c:defaults read /Library/Preferences/com.apple.loginwindow.plist GuestEnabled -> !r:^\s*0$;'
 # 6.1.5 Remove Guest home folder (Scored)
  - id: 14027
    title: "Remove Guest home folder (Scored)"
@@ -366,7 +368,7 @@ checks:
      - cis: "6.2"
    condition: any
    rules:
-     - 'c:defaults read NSGlobalDomain AppleShowAllExtensions -> !r:^\s*1;'
+     - 'c:defaults read NSGlobalDomain AppleShowAllExtensions -> !r:^\s*1$;'
 # 6.3 Disable the automatic run of safe files in Safari (Scored)
  - id: 14029
    title: "Disable the automatic run of safe files in Safari (Scored)"
@@ -377,5 +379,4 @@ checks:
      - cis: "6.3"
    condition: any
    rules:
-     - 'c:defaults read com.apple.Safari AutoOpenSafeDownloads -> !r:^0;'
-
+     - 'c:defaults read com.apple.Safari AutoOpenSafeDownloads -> r:^1$;'


### PR DESCRIPTION
### Requirements and rules

Requirements for macOS policies didn't match and got never scanned. Also some rules have been fixed as explained on this issue https://github.com/wazuh/wazuh-ruleset/issues/382

## Test 10.13

After fixing SCA command execution these are the results:

```
** Alert 1557484246.235669: - sca,gdpr_IV_35.7.d
2019 May 10 12:30:46 (macos) any->sca
Rule: 19009 (level 3) -> 'CIS Apple macOS 10.13 Benchmark: Verify all Apple provided software is current (Scored)'
{"type":"check","id":296411784,"policy":"CIS Apple macOS 10.13 Benchmark","policy_id":"cis_apple_macos_10_13","check":{"id":14000,"title":"Verify all Apple provided software is current (Scored)","description":"Software vendors release security patches and software updates for their products when security vulnerabilities are discovered. There is no simple way to complete this action without a network connection to an Apple software repository. Please ensure appropriate access for this control. This check is only for what Apple provides through software update.","rationale":"It is important that these updates be applied in a timely manner to prevent unauthorized persons from exploiting the identified vulnerabilities.","remediation":"1. In Terminal, run the following: softwareupdate -l    2. In Terminal, run the following for any packages that show up in step 1: sudo softwareupdate -i packagename","compliance":{"cis":"1.1"},"rules":["c:softwareupdate -l -> !r:^\\s*No new software available;"],"command":"softwareupdate -l","status":"Not applicable","reason":"Timeout overtaken running command 'softwareupdate -l'"}}
sca.type: check
sca.scan_id: 296411784
sca.policy: CIS Apple macOS 10.13 Benchmark
sca.check.id: 14000
sca.check.title: Verify all Apple provided software is current (Scored)
sca.check.description: Software vendors release security patches and software updates for their products when security vulnerabilities are discovered. There is no simple way to complete this action without a network connection to an Apple software repository. Please ensure appropriate access for this control. This check is only for what Apple provides through software update.
sca.check.rationale: It is important that these updates be applied in a timely manner to prevent unauthorized persons from exploiting the identified vulnerabilities.
sca.check.remediation: 1. In Terminal, run the following: softwareupdate -l    2. In Terminal, run the following for any packages that show up in step 1: sudo softwareupdate -i packagename
sca.check.compliance.cis: 1.1
sca.check.command: ["softwareupdate -l"]
sca.check.status: Not applicable
sca.check.reason: Timeout overtaken running command 'softwareupdate -l'

** Alert 1557484246.238085: - sca,gdpr_IV_35.7.d
2019 May 10 12:30:46 (macos) any->sca
Rule: 19007 (level 7) -> 'CIS Apple macOS 10.13 Benchmark: Enable Auto Update (Scored)'
{"type":"check","id":296411784,"policy":"CIS Apple macOS 10.13 Benchmark","policy_id":"cis_apple_macos_10_13","check":{"id":14001,"title":"Enable Auto Update (Scored)","description":"Auto Update verifies that your system has the newest security patches and software updates. If \"Automatically check for updates\" is not selected background updates for new malware definition files from Apple for XProtect and Gatekeeper will not occur.","rationale":"It is important that a system has the newest updates applied so as to prevent unauthorized persons from exploiting identified vulnerabilities.","remediation":"Open a terminal session and enter the following command to enable the auto update feature: sudo defaults write /Library/Preferences/com.apple.SoftwareUpdate AutomaticCheckEnabled -int 1","compliance":{"cis":"1.2"},"rules":["c:defaults read /Library/Preferences/com.apple.SoftwareUpdate AutomaticCheckEnabled -> r:^\\s*0$;"],"references":"https://macops.ca/os-x-admins-your-clients-are-not-getting-background-security-updates/,https://derflounder.wordpress.com/2014/12/17/forcing-xprotect-blacklist-updates-on-mavericks-and-yosemite/","command":"defaults read /Library/Preferences/com.apple.SoftwareUpdate AutomaticCheckEnabled","result":"failed"}}
sca.type: check
sca.scan_id: 296411784
sca.policy: CIS Apple macOS 10.13 Benchmark
sca.check.id: 14001
sca.check.title: Enable Auto Update (Scored)
sca.check.description: Auto Update verifies that your system has the newest security patches and software updates. If "Automatically check for updates" is not selected background updates for new malware definition files from Apple for XProtect and Gatekeeper will not occur.
sca.check.rationale: It is important that a system has the newest updates applied so as to prevent unauthorized persons from exploiting identified vulnerabilities.
sca.check.remediation: Open a terminal session and enter the following command to enable the auto update feature: sudo defaults write /Library/Preferences/com.apple.SoftwareUpdate AutomaticCheckEnabled -int 1
sca.check.compliance.cis: 1.2
sca.check.references: https://macops.ca/os-x-admins-your-clients-are-not-getting-background-security-updates/,https://derflounder.wordpress.com/2014/12/17/forcing-xprotect-blacklist-updates-on-mavericks-and-yosemite/
sca.check.command: ["defaults read /Library/Preferences/com.apple.SoftwareUpdate AutomaticCheckEnabled"]
sca.check.result: failed

** Alert 1557484246.240692: - sca,gdpr_IV_35.7.d
2019 May 10 12:30:46 (macos) any->sca
Rule: 19007 (level 7) -> 'CIS Apple macOS 10.13 Benchmark: Enable app update installs (Scored)'
{"type":"check","id":296411784,"policy":"CIS Apple macOS 10.13 Benchmark","policy_id":"cis_apple_macos_10_13","check":{"id":14002,"title":"Enable app update installs (Scored)","description":"Ensure that application updates are installed after they are available from Apple. These updates do not require reboots or admin privileges for end users.","rationale":"Patches need to be applied in a timely manner to reduce the risk of vulnerabilities being exploited","remediation":"Open a terminal session and enter the following command to enable the auto update feature: sudo defaults write /Library/Preferences/com.apple.commerce AutoUpdate -bool TRUE    The remediation requires a log out and log in to show in the GUI. Please note that.","compliance":{"cis":"1.3"},"rules":["c:defaults read /Library/Preferences/com.apple.commerce AutoUpdate -> r:^\\s*0$;"],"command":"defaults read /Library/Preferences/com.apple.commerce AutoUpdate","result":"failed"}}
sca.type: check
sca.scan_id: 296411784
sca.policy: CIS Apple macOS 10.13 Benchmark
sca.check.id: 14002
sca.check.title: Enable app update installs (Scored)
sca.check.description: Ensure that application updates are installed after they are available from Apple. These updates do not require reboots or admin privileges for end users.
sca.check.rationale: Patches need to be applied in a timely manner to reduce the risk of vulnerabilities being exploited
sca.check.remediation: Open a terminal session and enter the following command to enable the auto update feature: sudo defaults write /Library/Preferences/com.apple.commerce AutoUpdate -bool TRUE    The remediation requires a log out and log in to show in the GUI. Please note that.
sca.check.compliance.cis: 1.3
sca.check.command: ["defaults read /Library/Preferences/com.apple.commerce AutoUpdate"]
sca.check.result: failed

** Alert 1557484246.242711: - sca,gdpr_IV_35.7.d
2019 May 10 12:30:46 (macos) any->sca
Rule: 19007 (level 7) -> 'CIS Apple macOS 10.13 Benchmark: Enable system data files and security update installs (Scored)'
{"type":"check","id":296411784,"policy":"CIS Apple macOS 10.13 Benchmark","policy_id":"cis_apple_macos_10_13","check":{"id":14003,"title":"Enable system data files and security update installs (Scored)","description":"Ensure that system and security updates are installed after they are available from Apple.  This setting enables definition updates for XProtect and Gatekeeper, with this setting in place new malware and adware that Apple has added to the list of malware or untrusted software will not execute. These updates do not require reboots or end user admin rights.","rationale":"Patches need to be applied in a timely manner to reduce the risk of vulnerabilities being exploited","remediation":"Open a terminal session and enter the following command to enable install system data files and security updates: sudo defaults write /Library/Preferences/com.apple.SoftwareUpdate ConfigDataInstall -bool true && sudo defaults write /Library/Preferences/com.apple.SoftwareUpdate CriticalUpdateInstall -bool true","compliance":{"cis":"1.4"},"rules":["c:defaults read /Library/Preferences/com.apple.SoftwareUpdate -> NIN r:^\\s*ConfigDataInstall\\s*= && r:\\s*1;","c:defaults read /Library/Preferences/com.apple.SoftwareUpdate -> NIN r:^\\s*CriticalUpdateInstall\\s*= && r:\\s*1;"],"references":"https://www.thesafemac.com/tag/xprotect/,https://support.apple.com/en-us/HT202491","command":"defaults read /Library/Preferences/com.apple.SoftwareUpdate","result":"failed"}}
sca.type: check
sca.scan_id: 296411784
sca.policy: CIS Apple macOS 10.13 Benchmark
sca.check.id: 14003
sca.check.title: Enable system data files and security update installs (Scored)
sca.check.description: Ensure that system and security updates are installed after they are available from Apple.  This setting enables definition updates for XProtect and Gatekeeper, with this setting in place new malware and adware that Apple has added to the list of malware or untrusted software will not execute. These updates do not require reboots or end user admin rights.
sca.check.rationale: Patches need to be applied in a timely manner to reduce the risk of vulnerabilities being exploited
sca.check.remediation: Open a terminal session and enter the following command to enable install system data files and security updates: sudo defaults write /Library/Preferences/com.apple.SoftwareUpdate ConfigDataInstall -bool true && sudo defaults write /Library/Preferences/com.apple.SoftwareUpdate CriticalUpdateInstall -bool true
sca.check.compliance.cis: 1.4
sca.check.references: https://www.thesafemac.com/tag/xprotect/,https://support.apple.com/en-us/HT202491
sca.check.command: ["defaults read /Library/Preferences/com.apple.SoftwareUpdate"]
sca.check.result: failed

** Alert 1557484246.245657: - sca,gdpr_IV_35.7.d
2019 May 10 12:30:46 (macos) any->sca
Rule: 19007 (level 7) -> 'CIS Apple macOS 10.13 Benchmark: Enable macOS update installs (Scored)'
{"type":"check","id":296411784,"policy":"CIS Apple macOS 10.13 Benchmark","policy_id":"cis_apple_macos_10_13","check":{"id":14004,"title":"Enable macOS update installs (Scored)","description":"Ensure that macOS updates are installed after they are available from Apple. This setting enables macOS updates to be automatically installed. Some environments will want to approve and test updates before they are delivered. It is best practice to test first where updates can and have caused disruptions to operations. Automatic updates should be turned off where changes are tightly controlled and there are mature testing and approval processes. Automatic updates should not be turned off so the admin can call the users first to let them know it's ok to install. A dependable repeatable process involving a patch agent or remote management tool should be in place before auto-updates are turned off.","rationale":"Patches need to be applied in a timely manner to reduce the risk of vulnerabilities being exploited","remediation":"Open a terminal session and enter the following command to enable install system data files and security updates: sudo defaults write /Library/Preferences/com.apple.commerce AutoUpdateRestartRequired -bool TRUE","compliance":{"cis":"1.5"},"rules":["c:defaults read /Library/Preferences/com.apple.commerce AutoUpdateRestartRequired -> r:^\\s*0$;"],"command":"defaults read /Library/Preferences/com.apple.commerce AutoUpdateRestartRequired","result":"failed"}}
sca.type: check
sca.scan_id: 296411784
sca.policy: CIS Apple macOS 10.13 Benchmark
sca.check.id: 14004
sca.check.title: Enable macOS update installs (Scored)
sca.check.description: Ensure that macOS updates are installed after they are available from Apple. This setting enables macOS updates to be automatically installed. Some environments will want to approve and test updates before they are delivered. It is best practice to test first where updates can and have caused disruptions to operations. Automatic updates should be turned off where changes are tightly controlled and there are mature testing and approval processes. Automatic updates should not be turned off so the admin can call the users first to let them know it's ok to install. A dependable repeatable process involving a patch agent or remote management tool should be in place before auto-updates are turned off.
sca.check.rationale: Patches need to be applied in a timely manner to reduce the risk of vulnerabilities being exploited
sca.check.remediation: Open a terminal session and enter the following command to enable install system data files and security updates: sudo defaults write /Library/Preferences/com.apple.commerce AutoUpdateRestartRequired -bool TRUE
sca.check.compliance.cis: 1.5
sca.check.command: ["defaults read /Library/Preferences/com.apple.commerce AutoUpdateRestartRequired"]
sca.check.result: failed

** Alert 1557484246.248729: - sca,gdpr_IV_35.7.d
2019 May 10 12:30:46 (macos) any->sca
Rule: 19008 (level 3) -> 'CIS Apple macOS 10.13 Benchmark: Enable "Set time and date automatically" (Scored)'
{"type":"check","id":296411784,"policy":"CIS Apple macOS 10.13 Benchmark","policy_id":"cis_apple_macos_10_13","check":{"id":14005,"title":"Enable \"Set time and date automatically\" (Scored)","description":"Correct date and time settings are required for authentication protocols, file creation, modification dates and log entries.","rationale":"Kerberos may not operate correctly if the time on the Mac is off by more than 5 minutes.  This in turn can affect Apple's single sign-on feature, Active Directory logons, and other features.","remediation":"Run the following commands: sudo systemsetup -setnetworktimeserver <timeserver>    sudo systemsetup -setusingnetworktime on","compliance":{"cis":"2.2.1"},"rules":["c:systemsetup -getusingnetworktime -> !r:^\\s*Network Time:\\s*On;"],"command":"systemsetup -getusingnetworktime","result":"passed"}}
sca.type: check
sca.scan_id: 296411784
sca.policy: CIS Apple macOS 10.13 Benchmark
sca.check.id: 14005
sca.check.title: Enable "Set time and date automatically" (Scored)
sca.check.description: Correct date and time settings are required for authentication protocols, file creation, modification dates and log entries.
sca.check.rationale: Kerberos may not operate correctly if the time on the Mac is off by more than 5 minutes.  This in turn can affect Apple's single sign-on feature, Active Directory logons, and other features.
sca.check.remediation: Run the following commands: sudo systemsetup -setnetworktimeserver <timeserver>    sudo systemsetup -setusingnetworktime on
sca.check.compliance.cis: 2.2.1
sca.check.command: ["systemsetup -getusingnetworktime"]
sca.check.result: passed

** Alert 1557484246.250568: - sca,gdpr_IV_35.7.d
2019 May 10 12:30:46 (macos) any->sca
Rule: 19008 (level 3) -> 'CIS Apple macOS 10.13 Benchmark: Disable Remote Apple Events (Scored)'
{"type":"check","id":296411784,"policy":"CIS Apple macOS 10.13 Benchmark","policy_id":"cis_apple_macos_10_13","check":{"id":14006,"title":"Disable Remote Apple Events (Scored)","description":"Apple Events is a technology that allows one program to communicate with other programs. Remote Apple Events allows a program on one computer to communicate with a program on a different computer.","rationale":"Disabling Remote Apple Events mitigates the risk of an unauthorized program gaining access to the system.","remediation":"Run the following command in Terminal: sudo systemsetup -setremoteappleevents off","compliance":{"cis":"2.4.1"},"rules":["c:systemsetup -getremoteappleevents -> !r:^Remote Apple Events:\\s*Off;"],"command":"systemsetup -getremoteappleevents","result":"passed"}}
sca.type: check
sca.scan_id: 296411784
sca.policy: CIS Apple macOS 10.13 Benchmark
sca.check.id: 14006
sca.check.title: Disable Remote Apple Events (Scored)
sca.check.description: Apple Events is a technology that allows one program to communicate with other programs. Remote Apple Events allows a program on one computer to communicate with a program on a different computer.
sca.check.rationale: Disabling Remote Apple Events mitigates the risk of an unauthorized program gaining access to the system.
sca.check.remediation: Run the following command in Terminal: sudo systemsetup -setremoteappleevents off
sca.check.compliance.cis: 2.4.1
sca.check.command: ["systemsetup -getremoteappleevents"]
sca.check.result: passed

** Alert 1557484246.252263: - sca,gdpr_IV_35.7.d
2019 May 10 12:30:46 (macos) any->sca
Rule: 19008 (level 3) -> 'CIS Apple macOS 10.13 Benchmark: Disable Printer Sharing (Scored)'
{"type":"check","id":296411784,"policy":"CIS Apple macOS 10.13 Benchmark","policy_id":"cis_apple_macos_10_13","check":{"id":14007,"title":"Disable Printer Sharing (Scored)","description":"y enabling Printer sharing the computer is set up as a print server to accept print jobs from other computers. Dedicated print servers or direct IP printing should be used instead.","rationale":"Disabling Printer Sharing mitigates the risk of attackers attempting to exploit the print server to gain access to the system.","remediation":"Perform the following to implement the prescribed state: 1. Open System Preferences 2. Select Sharing 3. Uncheck Printer Sharing","compliance":{"cis":"2.4.4"},"rules":["c:system_profiler SPPrintersDataType -> r:Shared:\\s*Yes;"],"command":"system_profiler SPPrintersDataType","result":"passed"}}
sca.type: check
sca.scan_id: 296411784
sca.policy: CIS Apple macOS 10.13 Benchmark
sca.check.id: 14007
sca.check.title: Disable Printer Sharing (Scored)
sca.check.description: y enabling Printer sharing the computer is set up as a print server to accept print jobs from other computers. Dedicated print servers or direct IP printing should be used instead.
sca.check.rationale: Disabling Printer Sharing mitigates the risk of attackers attempting to exploit the print server to gain access to the system.
sca.check.remediation: Perform the following to implement the prescribed state: 1. Open System Preferences 2. Select Sharing 3. Uncheck Printer Sharing
sca.check.compliance.cis: 2.4.4
sca.check.command: ["system_profiler SPPrintersDataType"]
sca.check.result: passed

** Alert 1557484246.254038: - sca,gdpr_IV_35.7.d
2019 May 10 12:30:46 (macos) any->sca
Rule: 19007 (level 7) -> 'CIS Apple macOS 10.13 Benchmark: Disable Remote Login (Scored)'
{"type":"check","id":296411784,"policy":"CIS Apple macOS 10.13 Benchmark","policy_id":"cis_apple_macos_10_13","check":{"id":14008,"title":"Disable Remote Login (Scored)","description":"Remote Login allows an interactive terminal connection to a computer.","rationale":"Disabling Remote Login mitigates the risk of an unauthorized person gaining access to the system via Secure Shell (SSH). While SSH is an industry standard to connect to posix servers, the scope of the benchmark is for Apple macOS clients, not servers.","remediation":"Run the following command in Terminal: sudo systemsetup -setremotelogin off","compliance":{"cis":"2.4.5"},"rules":["c:systemsetup -getremotelogin -> r:^Remote Login:\\s*On;"],"command":"systemsetup -getremotelogin","result":"failed"}}
sca.type: check
sca.scan_id: 296411784
sca.policy: CIS Apple macOS 10.13 Benchmark
sca.check.id: 14008
sca.check.title: Disable Remote Login (Scored)
sca.check.description: Remote Login allows an interactive terminal connection to a computer.
sca.check.rationale: Disabling Remote Login mitigates the risk of an unauthorized person gaining access to the system via Secure Shell (SSH). While SSH is an industry standard to connect to posix servers, the scope of the benchmark is for Apple macOS clients, not servers.
sca.check.remediation: Run the following command in Terminal: sudo systemsetup -setremotelogin off
sca.check.compliance.cis: 2.4.5
sca.check.command: ["systemsetup -getremotelogin"]
sca.check.result: failed

** Alert 1557484246.255711: - sca,gdpr_IV_35.7.d
2019 May 10 12:30:46 (macos) any->sca
Rule: 19008 (level 3) -> 'CIS Apple macOS 10.13 Benchmark: Disable File Sharing (Scored)'
{"type":"check","id":296411784,"policy":"CIS Apple macOS 10.13 Benchmark","policy_id":"cis_apple_macos_10_13","check":{"id":14009,"title":"Disable File Sharing (Scored)","description":"Apple's File Sharing uses a combination of SMB (Windows sharing) and AFP (Mac sharing)","rationale":"By disabling file sharing, the remote attack surface and risk of unauthorized access to files stored on the system is reduced.","remediation":"Run the following command in Terminal to turn off AFP from the command line: sudo launchctl unload -w /System/Library/LaunchDaemons/com.apple.AppleFileServer.plist  - Run the following command in Terminal to turn off SMB sharing from the CLI: sudo launchctl unload -w /System/Library/LaunchDaemons/com.apple.smbd.plist","compliance":{"cis":"2.4.8"},"rules":["c:launchctl list -> r:AppleFileServer;"],"command":"launchctl list","result":"passed"}}
sca.type: check
sca.scan_id: 296411784
sca.policy: CIS Apple macOS 10.13 Benchmark
sca.check.id: 14009
sca.check.title: Disable File Sharing (Scored)
sca.check.description: Apple's File Sharing uses a combination of SMB (Windows sharing) and AFP (Mac sharing)
sca.check.rationale: By disabling file sharing, the remote attack surface and risk of unauthorized access to files stored on the system is reduced.
sca.check.remediation: Run the following command in Terminal to turn off AFP from the command line: sudo launchctl unload -w /System/Library/LaunchDaemons/com.apple.AppleFileServer.plist  - Run the following command in Terminal to turn off SMB sharing from the CLI: sudo launchctl unload -w /System/Library/LaunchDaemons/com.apple.smbd.plist
sca.check.compliance.cis: 2.4.8
sca.check.command: ["launchctl list"]
sca.check.result: passed

** Alert 1557484246.257610: - sca,gdpr_IV_35.7.d
2019 May 10 12:30:46 (macos) any->sca
Rule: 19007 (level 7) -> 'CIS Apple macOS 10.13 Benchmark: Disable "Wake for network access" (Scored)'
{"type":"check","id":296411784,"policy":"CIS Apple macOS 10.13 Benchmark","policy_id":"cis_apple_macos_10_13","check":{"id":14010,"title":"Disable \"Wake for network access\" (Scored)","description":"This feature allows other users to be able to access your computer’s shared resources, such as shared printers or iTunes playlists, even when your computer is in sleep mode. In a closed network when only authorized devices could wake a computer it could be valuable to wake computers in order to do management push activity. Where mobile workstations and agents exist the device will more likely check in to receive updates when already awake. Mobile devices should not be listening for signals on unmanaged network where untrusted devices could send wake signals.","rationale":"Disabling this feature mitigates the risk of an attacker remotely waking the system and gaining access.","remediation":"Run the following command in Terminal: sudo pmset -a womp 0","compliance":{"cis":"2.5.1"},"rules":["c:pmset -g -> r:^\\s*womp\\s+1$;"],"command":"pmset -g","result":"failed"}}
sca.type: check
sca.scan_id: 296411784
sca.policy: CIS Apple macOS 10.13 Benchmark
sca.check.id: 14010
sca.check.title: Disable "Wake for network access" (Scored)
sca.check.description: This feature allows other users to be able to access your computer’s shared resources, such as shared printers or iTunes playlists, even when your computer is in sleep mode. In a closed network when only authorized devices could wake a computer it could be valuable to wake computers in order to do management push activity. Where mobile workstations and agents exist the device will more likely check in to receive updates when already awake. Mobile devices should not be listening for signals on unmanaged network where untrusted devices could send wake signals.
sca.check.rationale: Disabling this feature mitigates the risk of an attacker remotely waking the system and gaining access.
sca.check.remediation: Run the following command in Terminal: sudo pmset -a womp 0
sca.check.compliance.cis: 2.5.1
sca.check.command: ["pmset -g"]
sca.check.result: failed

** Alert 1557484246.259928: - sca,gdpr_IV_35.7.d
2019 May 10 12:30:46 (macos) any->sca
Rule: 19007 (level 7) -> 'CIS Apple macOS 10.13 Benchmark: Enable FileVault (Scored)'
{"type":"check","id":296411784,"policy":"CIS Apple macOS 10.13 Benchmark","policy_id":"cis_apple_macos_10_13","check":{"id":14011,"title":"Enable FileVault (Scored)","description":"FileVault secures a system's data by automatically encrypting its boot volume and requiring a password or recovery key to access it.","rationale":"Encrypting sensitive data minimizes the likelihood of unauthorized users gaining access to it.","remediation":"1. Open System Preferences 2. Select Security & Privacy 3. Select FileVault 4. Select Turn on FileVault","compliance":{"cis":"2.6.1.1"},"rules":["c:fdesetup status -> r:^FileVault is\\s*Off\\p;"],"command":"fdesetup status","result":"failed"}}
sca.type: check
sca.scan_id: 296411784
sca.policy: CIS Apple macOS 10.13 Benchmark
sca.check.id: 14011
sca.check.title: Enable FileVault (Scored)
sca.check.description: FileVault secures a system's data by automatically encrypting its boot volume and requiring a password or recovery key to access it.
sca.check.rationale: Encrypting sensitive data minimizes the likelihood of unauthorized users gaining access to it.
sca.check.remediation: 1. Open System Preferences 2. Select Security & Privacy 3. Select FileVault 4. Select Turn on FileVault
sca.check.compliance.cis: 2.6.1.1
sca.check.command: ["fdesetup status"]
sca.check.result: failed

** Alert 1557484246.261428: - sca,gdpr_IV_35.7.d
2019 May 10 12:30:46 (macos) any->sca
Rule: 19008 (level 3) -> 'CIS Apple macOS 10.13 Benchmark: Enable Gatekeeper (Scored)'
{"type":"check","id":296411784,"policy":"CIS Apple macOS 10.13 Benchmark","policy_id":"cis_apple_macos_10_13","check":{"id":14012,"title":"Enable Gatekeeper (Scored)","description":"Gatekeeper is Apple's application white-listing control that restricts downloaded applications from launching. It functions as a control to limit applications from unverified sources from running without authorization.","rationale":"Disallowing unsigned software will reduce the risk of unauthorized or malicious applications from running on the system.","remediation":"Run the following command in Terminal: sudo spctl --master-enable","compliance":{"cis":"2.6.2"},"rules":["c:spctl --status -> !r:^assessments enabled;"],"command":"spctl --status","result":"passed"}}
sca.type: check
sca.scan_id: 296411784
sca.policy: CIS Apple macOS 10.13 Benchmark
sca.check.id: 14012
sca.check.title: Enable Gatekeeper (Scored)
sca.check.description: Gatekeeper is Apple's application white-listing control that restricts downloaded applications from launching. It functions as a control to limit applications from unverified sources from running without authorization.
sca.check.rationale: Disallowing unsigned software will reduce the risk of unauthorized or malicious applications from running on the system.
sca.check.remediation: Run the following command in Terminal: sudo spctl --master-enable
sca.check.compliance.cis: 2.6.2
sca.check.command: ["spctl --status"]
sca.check.result: passed

** Alert 1557484246.263070: - sca,gdpr_IV_35.7.d
2019 May 10 12:30:46 (macos) any->sca
Rule: 19007 (level 7) -> 'CIS Apple macOS 10.13 Benchmark: Enable Firewall (Scored)'
{"type":"check","id":296411784,"policy":"CIS Apple macOS 10.13 Benchmark","policy_id":"cis_apple_macos_10_13","check":{"id":14013,"title":"Enable Firewall (Scored)","description":"A firewall is a piece of software that blocks unwanted incoming connections to a system.  Apple has posted general documentation about the application firewall.","rationale":"A firewall minimizes the threat of unauthorized users from gaining access to your system while connected to a network or the Internet.","remediation":"Run the following command in Terminal: defaults write /Library/Preferences/com.apple.alf globalstate - int <value>    Where <value> is: - 1 = on for specific services - 2 = on for essential services ","compliance":{"cis":"2.6.3"},"rules":["c:defaults read /Library/Preferences/com.apple.alf globalstate -> !r:^\\s*1$;","c:defaults read /Library/Preferences/com.apple.alf globalstate -> !r:^\\s*2$;"],"references":"https://support.apple.com/en-us/HT201642","command":"defaults read /Library/Preferences/com.apple.alf globalstate","result":"failed"}}
sca.type: check
sca.scan_id: 296411784
sca.policy: CIS Apple macOS 10.13 Benchmark
sca.check.id: 14013
sca.check.title: Enable Firewall (Scored)
sca.check.description: A firewall is a piece of software that blocks unwanted incoming connections to a system.  Apple has posted general documentation about the application firewall.
sca.check.rationale: A firewall minimizes the threat of unauthorized users from gaining access to your system while connected to a network or the Internet.
sca.check.remediation: Run the following command in Terminal: defaults write /Library/Preferences/com.apple.alf globalstate - int <value>    Where <value> is: - 1 = on for specific services - 2 = on for essential services 
sca.check.compliance.cis: 2.6.3
sca.check.references: https://support.apple.com/en-us/HT201642
sca.check.command: ["defaults read /Library/Preferences/com.apple.alf globalstate"]
sca.check.result: failed

** Alert 1557484246.265210: - sca,gdpr_IV_35.7.d
2019 May 10 12:30:46 (macos) any->sca
Rule: 19007 (level 7) -> 'CIS Apple macOS 10.13 Benchmark: Enable Firewall Stealth Mode (Scored)'
{"type":"check","id":296411784,"policy":"CIS Apple macOS 10.13 Benchmark","policy_id":"cis_apple_macos_10_13","check":{"id":14014,"title":"Enable Firewall Stealth Mode (Scored)","description":"While in Stealth mode the computer will not respond to unsolicited probes, dropping that traffic.","rationale":"Stealth mode on the firewall minimizes the threat of system discovery tools while connected to a network or the Internet.","remediation":"Run the following command in Terminal: sudo /usr/libexec/ApplicationFirewall/socketfilterfw --setstealthmode on","compliance":{"cis":"2.6.4"},"rules":["c:/usr/libexec/ApplicationFirewall/socketfilterfw --getstealthmode -> !r:^\\s*Stealth mode enabled;"],"references":"https://support.apple.com/en-us/HT201642","command":"/usr/libexec/ApplicationFirewall/socketfilterfw --getstealthmode","result":"failed"}}
sca.type: check
sca.scan_id: 296411784
sca.policy: CIS Apple macOS 10.13 Benchmark
sca.check.id: 14014
sca.check.title: Enable Firewall Stealth Mode (Scored)
sca.check.description: While in Stealth mode the computer will not respond to unsolicited probes, dropping that traffic.
sca.check.rationale: Stealth mode on the firewall minimizes the threat of system discovery tools while connected to a network or the Internet.
sca.check.remediation: Run the following command in Terminal: sudo /usr/libexec/ApplicationFirewall/socketfilterfw --setstealthmode on
sca.check.compliance.cis: 2.6.4
sca.check.references: https://support.apple.com/en-us/HT201642
sca.check.command: ["/usr/libexec/ApplicationFirewall/socketfilterfw --getstealthmode"]
sca.check.result: failed

** Alert 1557484246.267011: - sca,gdpr_IV_35.7.d
2019 May 10 12:30:46 (macos) any->sca
Rule: 19009 (level 3) -> 'CIS Apple macOS 10.13 Benchmark: Enable Secure Keyboard Entry in terminal.app (Scored)'
{"type":"check","id":296411784,"policy":"CIS Apple macOS 10.13 Benchmark","policy_id":"cis_apple_macos_10_13","check":{"id":14015,"title":"Enable Secure Keyboard Entry in terminal.app (Scored)","description":"Secure Keyboard Entry prevents other applications on the system and/or network from detecting and recording what is typed into Terminal.","rationale":"Enabling Secure Keyboard Entry minimizes the risk of a key logger from detecting what is entered in Terminal.","remediation":"Perform the following to implement the prescribed state: 1. Open Terminal 2. Select Terminal 3. Select Secure Keyboard Entry","compliance":{"cis":"2.10"},"rules":["c:defaults read -app Terminal SecureKeyboardEntry -> r:^\\s*0$;"],"command":"defaults read -app Terminal SecureKeyboardEntry","status":"Not applicable","reason":"Internal error running command 'defaults read -app Terminal SecureKeyboardEntry'"}}
sca.type: check
sca.scan_id: 296411784
sca.policy: CIS Apple macOS 10.13 Benchmark
sca.check.id: 14015
sca.check.title: Enable Secure Keyboard Entry in terminal.app (Scored)
sca.check.description: Secure Keyboard Entry prevents other applications on the system and/or network from detecting and recording what is typed into Terminal.
sca.check.rationale: Enabling Secure Keyboard Entry minimizes the risk of a key logger from detecting what is entered in Terminal.
sca.check.remediation: Perform the following to implement the prescribed state: 1. Open Terminal 2. Select Terminal 3. Select Secure Keyboard Entry
sca.check.compliance.cis: 2.10
sca.check.command: ["defaults read -app Terminal SecureKeyboardEntry"]
sca.check.status: Not applicable
sca.check.reason: Internal error running command 'defaults read -app Terminal SecureKeyboardEntry'

** Alert 1557484246.268956: - sca,gdpr_IV_35.7.d
2019 May 10 12:30:46 (macos) any->sca
Rule: 19008 (level 3) -> 'CIS Apple macOS 10.13 Benchmark: Java 6 is not the default Java runtime (Scored)'
{"type":"check","id":296411784,"policy":"CIS Apple macOS 10.13 Benchmark","policy_id":"cis_apple_macos_10_13","check":{"id":14016,"title":"Java 6 is not the default Java runtime (Scored)","description":"Apple had made Java part of the core Operating System for macOS. Apple is no longer providing Java updates for macOS and updated JREs and JDK are made available by Oracle.  The latest version of Java 6 made available by Apple has many unpatched vulnerabilities and should not be the default runtime for Java applets that request one from the Operating System","rationale":"Java has been one of the most exploited environments and Java 6, which was provided as an OS component by Apple, is no longer maintained by Apple or Oracle. The old versions provided by Apple are both unsupported and missing the more modern security controls that have limited current exploits. The EOL version may still be installed and should be removed from the computer or not be in the default path.","remediation":"Java 6 can be removed completely or, if required Java applications will only work with Java 6, a custom path can be used. Apple is likely to finally pull the plug on Java 6 in upcoming MacOS versions so any applications that still require Java 6 will likely soon be unavailable.","compliance":{"cis":"2.11"},"rules":["c:java -version -> r:version.*1.6.0;","c:java -version -> r:Runtime Environment.*build.*1.6.0;"],"command":"java -version","result":"passed"}}
sca.type: check
sca.scan_id: 296411784
sca.policy: CIS Apple macOS 10.13 Benchmark
sca.check.id: 14016
sca.check.title: Java 6 is not the default Java runtime (Scored)
sca.check.description: Apple had made Java part of the core Operating System for macOS. Apple is no longer providing Java updates for macOS and updated JREs and JDK are made available by Oracle.  The latest version of Java 6 made available by Apple has many unpatched vulnerabilities and should not be the default runtime for Java applets that request one from the Operating System
sca.check.rationale: Java has been one of the most exploited environments and Java 6, which was provided as an OS component by Apple, is no longer maintained by Apple or Oracle. The old versions provided by Apple are both unsupported and missing the more modern security controls that have limited current exploits. The EOL version may still be installed and should be removed from the computer or not be in the default path.
sca.check.remediation: Java 6 can be removed completely or, if required Java applications will only work with Java 6, a custom path can be used. Apple is likely to finally pull the plug on Java 6 in upcoming MacOS versions so any applications that still require Java 6 will likely soon be unavailable.
sca.check.compliance.cis: 2.11
sca.check.command: ["java -version"]
sca.check.result: passed

** Alert 1557484246.271981: - sca,gdpr_IV_35.7.d
2019 May 10 12:30:46 (macos) any->sca
Rule: 19008 (level 3) -> 'CIS Apple macOS 10.13 Benchmark: Ensure EFI version is valid and being regularly checked (Scored)'
{"type":"check","id":296411784,"policy":"CIS Apple macOS 10.13 Benchmark","policy_id":"cis_apple_macos_10_13","check":{"id":14017,"title":"Ensure EFI version is valid and being regularly checked (Scored)","description":"In order to mitigate firmware attacks Apple has created a automated Firmware check to ensure that the EFI version running is a known good version from Apple. There is also an automated process to check it every seven days.","rationale":"If the Firmware of a computer has been compromised the Operating System that the Firmware loads cannot be trusted either.","remediation":"If EFI does not pass the integrity check you may send a report to Apple. Backing up files and clean installing a known good Operating System and Firmware is recommended.","compliance":{"cis":"2.13"},"rules":["c:/usr/libexec/firmwarecheckers/eficheck/eficheck --integrity-check -> !r:Primary allowlist version match found\\. No changes detected in primary hashes\\.;","c:launchctl list -> !r:-\\t*0\\t*com.apple.driver.eficheck;"],"command":"/usr/libexec/firmwarecheckers/eficheck/eficheck --integrity-check,launchctl list","result":"passed"}}
sca.type: check
sca.scan_id: 296411784
sca.policy: CIS Apple macOS 10.13 Benchmark
sca.check.id: 14017
sca.check.title: Ensure EFI version is valid and being regularly checked (Scored)
sca.check.description: In order to mitigate firmware attacks Apple has created a automated Firmware check to ensure that the EFI version running is a known good version from Apple. There is also an automated process to check it every seven days.
sca.check.rationale: If the Firmware of a computer has been compromised the Operating System that the Firmware loads cannot be trusted either.
sca.check.remediation: If EFI does not pass the integrity check you may send a report to Apple. Backing up files and clean installing a known good Operating System and Firmware is recommended.
sca.check.compliance.cis: 2.13
sca.check.command: ["/usr/libexec/firmwarecheckers/eficheck/eficheck --integrity-check", "launchctl list"]
sca.check.result: passed

** Alert 1557484246.274262: - sca,gdpr_IV_35.7.d
2019 May 10 12:30:46 (macos) any->sca
Rule: 19008 (level 3) -> 'CIS Apple macOS 10.13 Benchmark: Enable security auditing (Scored)'
{"type":"check","id":296411784,"policy":"CIS Apple macOS 10.13 Benchmark","policy_id":"cis_apple_macos_10_13","check":{"id":14018,"title":"Enable security auditing (Scored)","description":"macOS's audit facility, auditd, receives notifications from the kernel when certain system calls, such as open, fork, and exit, are made. These notifications are captured and written to an audit log.","rationale":"Logs generated by auditd may be useful when investigating a security incident as they may help reveal the vulnerable application and the actions taken by a malicious actor.","remediation":"Run the following command in Terminal: sudo launchctl load -w /System/Library/LaunchDaemons/com.apple.auditd.plist","compliance":{"cis":"3.1"},"rules":["c:launchctl list -> !r:com.apple.auditd;"],"command":"launchctl list","result":"passed"}}
sca.type: check
sca.scan_id: 296411784
sca.policy: CIS Apple macOS 10.13 Benchmark
sca.check.id: 14018
sca.check.title: Enable security auditing (Scored)
sca.check.description: macOS's audit facility, auditd, receives notifications from the kernel when certain system calls, such as open, fork, and exit, are made. These notifications are captured and written to an audit log.
sca.check.rationale: Logs generated by auditd may be useful when investigating a security incident as they may help reveal the vulnerable application and the actions taken by a malicious actor.
sca.check.remediation: Run the following command in Terminal: sudo launchctl load -w /System/Library/LaunchDaemons/com.apple.auditd.plist
sca.check.compliance.cis: 3.1
sca.check.command: ["launchctl list"]
sca.check.result: passed

** Alert 1557484246.276081: - sca,gdpr_IV_35.7.d
2019 May 10 12:30:46 (macos) any->sca
Rule: 19007 (level 7) -> 'CIS Apple macOS 10.13 Benchmark: Configure Security Auditing Flags (Scored)'
{"type":"check","id":296411784,"policy":"CIS Apple macOS 10.13 Benchmark","policy_id":"cis_apple_macos_10_13","check":{"id":14019,"title":"Configure Security Auditing Flags (Scored)","description":"Auditing is the capture and maintenance of information about security-related events.","rationale":"Maintaining an audit trail of system activity logs can help identify configuration errors, troubleshoot service disruptions, and analyze compromises or attacks that have occurred, have begun, or are about to begin. Audit logs are necessary to provide a trail of evidence in case the system or network is compromised.","remediation":"1. Open a terminal session and edit the /etc/security/audit_control file  2. Find the line beginning with \"flags\"  3. Add the following flags: lo, ad, fd, fm, -all.  4. Save the file.","compliance":{"cis":"3.2"},"rules":["f:/etc/security/audit_control -> NIN r:^flags && r:lo;","f:/etc/security/audit_control -> NIN r:^flags && r:ad;","f:/etc/security/audit_control -> NIN r:^flags && r:fd;","f:/etc/security/audit_control -> NIN r:^flags && r:fm;","f:/etc/security/audit_control -> NIN r:^flags && r:-all;"],"file":"/etc/security/audit_control","result":"failed"}}
sca.type: check
sca.scan_id: 296411784
sca.policy: CIS Apple macOS 10.13 Benchmark
sca.check.id: 14019
sca.check.title: Configure Security Auditing Flags (Scored)
sca.check.description: Auditing is the capture and maintenance of information about security-related events.
sca.check.rationale: Maintaining an audit trail of system activity logs can help identify configuration errors, troubleshoot service disruptions, and analyze compromises or attacks that have occurred, have begun, or are about to begin. Audit logs are necessary to provide a trail of evidence in case the system or network is compromised.
sca.check.remediation: 1. Open a terminal session and edit the /etc/security/audit_control file  2. Find the line beginning with "flags"  3. Add the following flags: lo, ad, fd, fm, -all.  4. Save the file.
sca.check.compliance.cis: 3.2
sca.check.file: ["/etc/security/audit_control"]
sca.check.result: failed

** Alert 1557484246.278391: - sca,gdpr_IV_35.7.d
2019 May 10 12:30:46 (macos) any->sca
Rule: 19009 (level 3) -> 'CIS Apple macOS 10.13 Benchmark: Disable Bonjour advertising service (Scored)'
{"type":"check","id":296411784,"policy":"CIS Apple macOS 10.13 Benchmark","policy_id":"cis_apple_macos_10_13","check":{"id":14020,"title":"Disable Bonjour advertising service (Scored)","description":"Bonjour is an auto-discovery mechanism for TCP/IP devices which enumerate devices and services within a local subnet. DNS on macOS is integrated with Bonjour and should not be turned off, but the Bonjour advertising service can be disabled.","rationale":"Bonjour can simplify device discovery from an internal rogue or compromised host. An attacker could use Bonjour's multicast DNS feature to discover a vulnerable or poorly- configured service or additional information to aid a targeted attack. Implementing this control disables the continuous broadcasting of \"I'm here!\" messages. Typical end-user endpoints should not have to advertise services to other computers.","remediation":"Run the following command in Terminal: defaults write /Library/Preferences/com.apple.mDNSResponder.plist NoMulticastAdvertisements","compliance":{"cis":"4.1"},"rules":["c:defaults read /Library/Preferences/com.apple.mDNSResponder.plist NoMulticastAdvertisements -> r:^\\s*0$;"],"command":"defaults read /Library/Preferences/com.apple.mDNSResponder.plist NoMulticastAdvertisements","status":"Not applicable","reason":"Internal error running command 'defaults read /Library/Preferences/com.apple.mDNSResponder.plist NoMulticastAdvertisements'"}}
sca.type: check
sca.scan_id: 296411784
sca.policy: CIS Apple macOS 10.13 Benchmark
sca.check.id: 14020
sca.check.title: Disable Bonjour advertising service (Scored)
sca.check.description: Bonjour is an auto-discovery mechanism for TCP/IP devices which enumerate devices and services within a local subnet. DNS on macOS is integrated with Bonjour and should not be turned off, but the Bonjour advertising service can be disabled.
sca.check.rationale: Bonjour can simplify device discovery from an internal rogue or compromised host. An attacker could use Bonjour's multicast DNS feature to discover a vulnerable or poorly- configured service or additional information to aid a targeted attack. Implementing this control disables the continuous broadcasting of "I'm here!" messages. Typical end-user endpoints should not have to advertise services to other computers.
sca.check.remediation: Run the following command in Terminal: defaults write /Library/Preferences/com.apple.mDNSResponder.plist NoMulticastAdvertisements
sca.check.compliance.cis: 4.1
sca.check.command: ["defaults read /Library/Preferences/com.apple.mDNSResponder.plist NoMulticastAdvertisements"]
sca.check.status: Not applicable
sca.check.reason: Internal error running command 'defaults read /Library/Preferences/com.apple.mDNSResponder.plist NoMulticastAdvertisements'

** Alert 1557484246.281356: - sca,gdpr_IV_35.7.d
2019 May 10 12:30:46 (macos) any->sca
Rule: 19007 (level 7) -> 'CIS Apple macOS 10.13 Benchmark: Ensure http server is not running (Scored)'
{"type":"check","id":296411784,"policy":"CIS Apple macOS 10.13 Benchmark","policy_id":"cis_apple_macos_10_13","check":{"id":14021,"title":"Ensure http server is not running (Scored)","description":"macOS used to have a graphical front-end to the embedded Apache web server in the Operating System. Personal web sharing could be enabled to allow someone on another computer to download files or information from the user's computer. Personal web sharing from a user endpoint has long been considered questionable and Apple has removed that capability from the GUI. Apache however is still part of the Operating System and can be easily turned on to share files and provide remote connectivity to an end user computer.  Web sharing should only be done through hardened web servers and appropriate cloud services.","rationale":"Web serving should not be done from a user desktop. Dedicated webservers or appropriate cloud storage should be used. Open ports make it easier to exploit the computer.","remediation":"Ensure that the Web Server is not running and is not set to start at boot Stop the Web Server: sudo apachectl stop    Ensure that the web server will not auto-start at boot sudo: defaults write /System/Library/LaunchDaemons/org.apache.httpd Disabled - bool true","compliance":{"cis":"4.4"},"rules":["p:httpd;","p:/usr/sbin/httpd;","p:/usr/sbin/httpd -D FOREGROUND;"],"process":"httpd,/usr/sbin/httpd,/usr/sbin/httpd -D FOREGROUND","result":"failed"}}
sca.type: check
sca.scan_id: 296411784
sca.policy: CIS Apple macOS 10.13 Benchmark
sca.check.id: 14021
sca.check.title: Ensure http server is not running (Scored)
sca.check.description: macOS used to have a graphical front-end to the embedded Apache web server in the Operating System. Personal web sharing could be enabled to allow someone on another computer to download files or information from the user's computer. Personal web sharing from a user endpoint has long been considered questionable and Apple has removed that capability from the GUI. Apache however is still part of the Operating System and can be easily turned on to share files and provide remote connectivity to an end user computer.  Web sharing should only be done through hardened web servers and appropriate cloud services.
sca.check.rationale: Web serving should not be done from a user desktop. Dedicated webservers or appropriate cloud storage should be used. Open ports make it easier to exploit the computer.
sca.check.remediation: Ensure that the Web Server is not running and is not set to start at boot Stop the Web Server: sudo apachectl stop    Ensure that the web server will not auto-start at boot sudo: defaults write /System/Library/LaunchDaemons/org.apache.httpd Disabled - bool true
sca.check.compliance.cis: 4.4
sca.check.process: ["httpd", "/usr/sbin/httpd", "/usr/sbin/httpd -D FOREGROUND"]
sca.check.result: failed

** Alert 1557484246.284418: - sca,gdpr_IV_35.7.d
2019 May 10 12:30:46 (macos) any->sca
Rule: 19008 (level 3) -> 'CIS Apple macOS 10.13 Benchmark: Ensure nfs server is not running (Scored)'
{"type":"check","id":296411784,"policy":"CIS Apple macOS 10.13 Benchmark","policy_id":"cis_apple_macos_10_13","check":{"id":14022,"title":"Ensure nfs server is not running (Scored)","description":"macOS can act as an NFS fileserver. NFS sharing could be enabled to allow someone on another computer to mount shares and gain access to information from the user's computer. File sharing from a user endpoint has long been considered questionable and Apple has removed that capability from the GUI. NFSD is still part of the Operating System and can be easily turned on to export shares and provide remote connectivity to an end user computer.","rationale":"File serving should not be done from a user desktop, dedicated servers should be used.  Open ports make it easier to exploit the computer.","remediation":"Ensure that the NFS Server is not running and is not set to start at boot Stop the NFS Server: sudo nfsd disable    Remove the exported Directory listing: rm /etc/export","compliance":{"cis":"4.5"},"rules":["p:nfsd;","f:/etc/exports;"],"file":"/etc/exports","process":"nfsd","result":"passed"}}
sca.type: check
sca.scan_id: 296411784
sca.policy: CIS Apple macOS 10.13 Benchmark
sca.check.id: 14022
sca.check.title: Ensure nfs server is not running (Scored)
sca.check.description: macOS can act as an NFS fileserver. NFS sharing could be enabled to allow someone on another computer to mount shares and gain access to information from the user's computer. File sharing from a user endpoint has long been considered questionable and Apple has removed that capability from the GUI. NFSD is still part of the Operating System and can be easily turned on to export shares and provide remote connectivity to an end user computer.
sca.check.rationale: File serving should not be done from a user desktop, dedicated servers should be used.  Open ports make it easier to exploit the computer.
sca.check.remediation: Ensure that the NFS Server is not running and is not set to start at boot Stop the NFS Server: sudo nfsd disable    Remove the exported Directory listing: rm /etc/export
sca.check.compliance.cis: 4.5
sca.check.file: ["/etc/exports"]
sca.check.process: ["nfsd"]
sca.check.result: passed

** Alert 1557484246.286811: - sca,gdpr_IV_35.7.d
2019 May 10 12:30:46 (macos) any->sca
Rule: 19008 (level 3) -> 'CIS Apple macOS 10.13 Benchmark: Do not enable the "root" account (Scored)'
{"type":"check","id":296411784,"policy":"CIS Apple macOS 10.13 Benchmark","policy_id":"cis_apple_macos_10_13","check":{"id":14023,"title":"Do not enable the \"root\" account (Scored)","description":"The root account is a superuser account that has access privileges to perform any actions and read/write to any file on the computer. With some Linux distros the system administrator may commonly uses the root account to perform administrative functions.","rationale":"Enabling and using the root account puts the system at risk since any successful exploit or mistake while the root account is in use could have unlimited access privileges within the system. Using the sudo command allows users to perform functions as a root user while limiting and password protecting the access privileges. By default the root account is not enabled on a macOS computer. An administrator can escalate privileges using the sudo command (use -s or -i to get a root shell).","remediation":"Open System Preferences, Uses & Groups. Click the lock icon to unlock it. In the Network Account Server section, click Join or Edit. Click Open Directory Utility. Click the lock icon to unlock it. Select the Edit menu > Disable Root User.","compliance":{"cis":"5.11"},"rules":["c:dscl . -read /Users/root AuthenticationAuthority -> !r:^No such key: AuthenticationAuthority;"],"command":"dscl . -read /Users/root AuthenticationAuthority","result":"passed"}}
sca.type: check
sca.scan_id: 296411784
sca.policy: CIS Apple macOS 10.13 Benchmark
sca.check.id: 14023
sca.check.title: Do not enable the "root" account (Scored)
sca.check.description: The root account is a superuser account that has access privileges to perform any actions and read/write to any file on the computer. With some Linux distros the system administrator may commonly uses the root account to perform administrative functions.
sca.check.rationale: Enabling and using the root account puts the system at risk since any successful exploit or mistake while the root account is in use could have unlimited access privileges within the system. Using the sudo command allows users to perform functions as a root user while limiting and password protecting the access privileges. By default the root account is not enabled on a macOS computer. An administrator can escalate privileges using the sudo command (use -s or -i to get a root shell).
sca.check.remediation: Open System Preferences, Uses & Groups. Click the lock icon to unlock it. In the Network Account Server section, click Join or Edit. Click Open Directory Utility. Click the lock icon to unlock it. Select the Edit menu > Disable Root User.
sca.check.compliance.cis: 5.11
sca.check.command: ["dscl . -read /Users/root AuthenticationAuthority"]
sca.check.result: passed

** Alert 1557484246.289771: - sca,gdpr_IV_35.7.d
2019 May 10 12:30:46 (macos) any->sca
Rule: 19008 (level 3) -> 'CIS Apple macOS 10.13 Benchmark: Disable automatic login (Scored)'
{"type":"check","id":296411784,"policy":"CIS Apple macOS 10.13 Benchmark","policy_id":"cis_apple_macos_10_13","check":{"id":14024,"title":"Disable automatic login (Scored)","description":"The automatic login feature saves a user's system access credentials and bypasses the login screen, instead the system automatically loads to the user's desktop screen.","rationale":"Disabling automatic login decreases the likelihood of an unauthorized person gaining access to a system.","remediation":"Run the following command in Terminal: sudo defaults delete /Library/Preferences/com.apple.loginwindow autoLoginUser","compliance":{"cis":"5.12"},"rules":["c:defaults read /Library/Preferences/com.apple.loginwindow -> r:autoLoginUser;"],"command":"defaults read /Library/Preferences/com.apple.loginwindow","result":"passed"}}
sca.type: check
sca.scan_id: 296411784
sca.policy: CIS Apple macOS 10.13 Benchmark
sca.check.id: 14024
sca.check.title: Disable automatic login (Scored)
sca.check.description: The automatic login feature saves a user's system access credentials and bypasses the login screen, instead the system automatically loads to the user's desktop screen.
sca.check.rationale: Disabling automatic login decreases the likelihood of an unauthorized person gaining access to a system.
sca.check.remediation: Run the following command in Terminal: sudo defaults delete /Library/Preferences/com.apple.loginwindow autoLoginUser
sca.check.compliance.cis: 5.12
sca.check.command: ["defaults read /Library/Preferences/com.apple.loginwindow"]
sca.check.result: passed

** Alert 1557484246.291517: - sca,gdpr_IV_35.7.d
2019 May 10 12:30:46 (macos) any->sca
Rule: 19008 (level 3) -> 'CIS Apple macOS 10.13 Benchmark: System Integrity Protection status (Scored)'
{"type":"check","id":296411784,"policy":"CIS Apple macOS 10.13 Benchmark","policy_id":"cis_apple_macos_10_13","check":{"id":14025,"title":"System Integrity Protection status (Scored)","description":"System Integrity Protection is a security feature introduced in OS X 10.11 El Capitan.  System Integrity Protection restricts access to System domain locations and restricts runtime attachment to system processes. Any attempt to attempt to inspect or attach to a system process will fail. Kernel Extensions are now restricted to /Library/Extensions and are required to be signed with a Developer ID.","rationale":"Running without System Integrity Protection on a production system runs the risk of the modification of system binaries or code injection of system processes that would otherwise be protected by SIP.","remediation":"Perform the following while booted in macOS Recovery Partition.  1. Select Terminal from the Utilities menu    2. Run the following command in Terminal: /usr/bin/csrutil enable    3. The output should be: Successfully enabled System Integrity Protection. Please restart the machine for the changes to take effect.    4. Reboot.","compliance":{"cis":"5.23"},"rules":["c:/usr/bin/csrutil status -> !r:^\\s*System Integrity Protection status: enabled;"],"command":"/usr/bin/csrutil status","result":"passed"}}
sca.type: check
sca.scan_id: 296411784
sca.policy: CIS Apple macOS 10.13 Benchmark
sca.check.id: 14025
sca.check.title: System Integrity Protection status (Scored)
sca.check.description: System Integrity Protection is a security feature introduced in OS X 10.11 El Capitan.  System Integrity Protection restricts access to System domain locations and restricts runtime attachment to system processes. Any attempt to attempt to inspect or attach to a system process will fail. Kernel Extensions are now restricted to /Library/Extensions and are required to be signed with a Developer ID.
sca.check.rationale: Running without System Integrity Protection on a production system runs the risk of the modification of system binaries or code injection of system processes that would otherwise be protected by SIP.
sca.check.remediation: Perform the following while booted in macOS Recovery Partition.  1. Select Terminal from the Utilities menu    2. Run the following command in Terminal: /usr/bin/csrutil enable    3. The output should be: Successfully enabled System Integrity Protection. Please restart the machine for the changes to take effect.    4. Reboot.
sca.check.compliance.cis: 5.23
sca.check.command: ["/usr/bin/csrutil status"]
sca.check.result: passed

** Alert 1557484246.294307: - sca,gdpr_IV_35.7.d
2019 May 10 12:30:46 (macos) any->sca
Rule: 19007 (level 7) -> 'CIS Apple macOS 10.13 Benchmark: Disable guest account login (Scored)'
{"type":"check","id":296411784,"policy":"CIS Apple macOS 10.13 Benchmark","policy_id":"cis_apple_macos_10_13","check":{"id":14026,"title":"Disable guest account login (Scored)","description":"The guest account allows users access to the system without having to create an account or password. Guest users are unable to make setting changes, cannot remotely login to the system and all created files, caches, and passwords are deleted upon logging out.","rationale":"Disabling the guest account mitigates the risk of an untrusted user doing basic reconnaissance and possibly using privilege escalation attacks to take control of the system.","remediation":"Run the following command in Terminal: sudo defaults write /Library/Preferences/com.apple.loginwindow GuestEnabled - bool NO","compliance":{"cis":"6.1.3"},"rules":["c:defaults read /Library/Preferences/com.apple.loginwindow.plist GuestEnabled -> !r:^\\s*0$;"],"command":"defaults read /Library/Preferences/com.apple.loginwindow.plist GuestEnabled","result":"failed"}}
sca.type: check
sca.scan_id: 296411784
sca.policy: CIS Apple macOS 10.13 Benchmark
sca.check.id: 14026
sca.check.title: Disable guest account login (Scored)
sca.check.description: The guest account allows users access to the system without having to create an account or password. Guest users are unable to make setting changes, cannot remotely login to the system and all created files, caches, and passwords are deleted upon logging out.
sca.check.rationale: Disabling the guest account mitigates the risk of an untrusted user doing basic reconnaissance and possibly using privilege escalation attacks to take control of the system.
sca.check.remediation: Run the following command in Terminal: sudo defaults write /Library/Preferences/com.apple.loginwindow GuestEnabled - bool NO
sca.check.compliance.cis: 6.1.3
sca.check.command: ["defaults read /Library/Preferences/com.apple.loginwindow.plist GuestEnabled"]
sca.check.result: failed

** Alert 1557484246.296455: - sca,gdpr_IV_35.7.d
2019 May 10 12:30:46 (macos) any->sca
Rule: 19008 (level 3) -> 'CIS Apple macOS 10.13 Benchmark: Remove Guest home folder (Scored)'
{"type":"check","id":296411784,"policy":"CIS Apple macOS 10.13 Benchmark","policy_id":"cis_apple_macos_10_13","check":{"id":14027,"title":"Remove Guest home folder (Scored)","description":"The guest account login should have been disabled, so there is no need for the legacy Guest home folder to remain in the file system. When normal user accounts are removed you have the option to archive it, leave it in place or delete. In the case of the guest folder the folder remains in place without a GUI option to remove it. If at some point in the future a Guest account is needed it will be re-created. The presence of the Guest home folder can cause automated audits to fail when looking for compliant settings within all User folders as well. Rather than ignoring the folders continued existence it is best removed.","rationale":"The Guest home folders are unneeded after the Guest account is disabled and could be used inappropriately.","remediation":"1. Run the following command in Terminal: rm -R /Users/Guest  2. Make sure there is no output","compliance":{"cis":"6.1.5"},"rules":["d:/Users/Guest;"],"result":"passed"}}
sca.type: check
sca.scan_id: 296411784
sca.policy: CIS Apple macOS 10.13 Benchmark
sca.check.id: 14027
sca.check.title: Remove Guest home folder (Scored)
sca.check.description: The guest account login should have been disabled, so there is no need for the legacy Guest home folder to remain in the file system. When normal user accounts are removed you have the option to archive it, leave it in place or delete. In the case of the guest folder the folder remains in place without a GUI option to remove it. If at some point in the future a Guest account is needed it will be re-created. The presence of the Guest home folder can cause automated audits to fail when looking for compliant settings within all User folders as well. Rather than ignoring the folders continued existence it is best removed.
sca.check.rationale: The Guest home folders are unneeded after the Guest account is disabled and could be used inappropriately.
sca.check.remediation: 1. Run the following command in Terminal: rm -R /Users/Guest  2. Make sure there is no output
sca.check.compliance.cis: 6.1.5
sca.check.result: passed

** Alert 1557484246.298866: - sca,gdpr_IV_35.7.d
2019 May 10 12:30:46 (macos) any->sca
Rule: 19009 (level 3) -> 'CIS Apple macOS 10.13 Benchmark: Turn on filename extensions (Scored)'
{"type":"check","id":296411784,"policy":"CIS Apple macOS 10.13 Benchmark","policy_id":"cis_apple_macos_10_13","check":{"id":14028,"title":"Turn on filename extensions (Scored)","description":"A filename extension is a suffix added to a base filename that indicates the base filename's file format.","rationale":"Visible filename extensions allows the user to identify the file type and the application it is associated with which leads to quick identification of misrepresented malicious files.","remediation":"Perform the following to implement the prescribed state: 1. Select Finder 2. Select Preferences 3. Check Show all filename extensions    Alternatively, use the following command: defaults write NSGlobalDomain AppleShowAllExtensions -bool true","compliance":{"cis":"6.2"},"rules":["c:defaults read NSGlobalDomain AppleShowAllExtensions -> !r:^\\s*1$;"],"command":"defaults read NSGlobalDomain AppleShowAllExtensions","status":"Not applicable","reason":"Internal error running command 'defaults read NSGlobalDomain AppleShowAllExtensions'"}}
sca.type: check
sca.scan_id: 296411784
sca.policy: CIS Apple macOS 10.13 Benchmark
sca.check.id: 14028
sca.check.title: Turn on filename extensions (Scored)
sca.check.description: A filename extension is a suffix added to a base filename that indicates the base filename's file format.
sca.check.rationale: Visible filename extensions allows the user to identify the file type and the application it is associated with which leads to quick identification of misrepresented malicious files.
sca.check.remediation: Perform the following to implement the prescribed state: 1. Select Finder 2. Select Preferences 3. Check Show all filename extensions    Alternatively, use the following command: defaults write NSGlobalDomain AppleShowAllExtensions -bool true
sca.check.compliance.cis: 6.2
sca.check.command: ["defaults read NSGlobalDomain AppleShowAllExtensions"]
sca.check.status: Not applicable
sca.check.reason: Internal error running command 'defaults read NSGlobalDomain AppleShowAllExtensions'

** Alert 1557484246.301099: - sca,gdpr_IV_35.7.d
2019 May 10 12:30:46 (macos) any->sca
Rule: 19009 (level 3) -> 'CIS Apple macOS 10.13 Benchmark: Disable the automatic run of safe files in Safari (Scored)'
{"type":"check","id":296411784,"policy":"CIS Apple macOS 10.13 Benchmark","policy_id":"cis_apple_macos_10_13","check":{"id":14029,"title":"Disable the automatic run of safe files in Safari (Scored)","description":"Safari will automatically run or execute what it considers safe files. This can include installers and other files that execute on the operating system. Safari bases file safety by using a list of filetypes maintained by Apple. The list of files include text, image, video and archive formats that would be run in the context of the OS rather than the browser.","rationale":"Hackers have taken advantage of this setting via drive-by attacks. These attacks occur when a user visits a legitimate website that has been corrupted. The user unknowingly downloads a malicious file either by closing an infected pop-up or hovering over a malicious banner. An attacker can create a malicious file that will fall within Safari's safe file list that will download and execute without user input.","remediation":"Perform the following to implement the prescribed state: 1. Open Safari 2. Select Safari from the menu bar 3. Select Preferences 4. Select General 5. Uncheck Open \"safe\" files after downloading    Alternatively run the following command in Terminal: defaults write com.apple.Safari AutoOpenSafeDownloads -boolean no","compliance":{"cis":"6.3"},"rules":["c:defaults read com.apple.Safari AutoOpenSafeDownloads -> r:^1$;"],"command":"defaults read com.apple.Safari AutoOpenSafeDownloads","status":"Not applicable","reason":"Internal error running command 'defaults read com.apple.Safari AutoOpenSafeDownloads'"}}
sca.type: check
sca.scan_id: 296411784
sca.policy: CIS Apple macOS 10.13 Benchmark
sca.check.id: 14029
sca.check.title: Disable the automatic run of safe files in Safari (Scored)
sca.check.description: Safari will automatically run or execute what it considers safe files. This can include installers and other files that execute on the operating system. Safari bases file safety by using a list of filetypes maintained by Apple. The list of files include text, image, video and archive formats that would be run in the context of the OS rather than the browser.
sca.check.rationale: Hackers have taken advantage of this setting via drive-by attacks. These attacks occur when a user visits a legitimate website that has been corrupted. The user unknowingly downloads a malicious file either by closing an infected pop-up or hovering over a malicious banner. An attacker can create a malicious file that will fall within Safari's safe file list that will download and execute without user input.
sca.check.remediation: Perform the following to implement the prescribed state: 1. Open Safari 2. Select Safari from the menu bar 3. Select Preferences 4. Select General 5. Uncheck Open "safe" files after downloading    Alternatively run the following command in Terminal: defaults write com.apple.Safari AutoOpenSafeDownloads -boolean no
sca.check.compliance.cis: 6.3
sca.check.command: ["defaults read com.apple.Safari AutoOpenSafeDownloads"]
sca.check.status: Not applicable
sca.check.reason: Internal error running command 'defaults read com.apple.Safari AutoOpenSafeDownloads'

** Alert 1557484253.304512: - sca,gdpr_IV_35.7.d
2019 May 10 12:30:53 (macos) any->sca
Rule: 19003 (level 5) -> 'SCA summary: CIS Apple macOS 10.13 Benchmark: Score less than 80% (52)'
{"type":"summary","scan_id":296411784,"name":"CIS Apple macOS 10.13 Benchmark","policy_id":"cis_apple_macos_10_13","file":"cis_apple_macOS_10.13.yml","description":"This document, CIS Apple macOS 10.13 Benchmark, provides prescriptive guidance for establishing a secure configuration posture for Apple macOS 10.13. This guide was tested against Apple macOS 10.13. To obtain the latest version of this guide, please visit https://benchmarks.cisecurity.org. If you have questions, comments, or have identified ways to improve this guide, please write us at feedback@cisecurity.org","references":"https://www.cisecurity.org/cis-benchmarks/","passed":13,"failed":12,"invalid":5,"total_checks":30,"score":52,"start_time":1557484204,"end_time":1557484241,"hash":"64ca6c477c402e3d05527f9417234d94719be269caf9b54c07f75d79c2a31fa8","hash_file":"643d6a12be1ddeb0edbd528f204135d5f2e7fb0cdbe9db850d815b51ac8d60f5","force_alert":"1"}
sca.type: summary
sca.scan_id: 296411784
sca.policy: CIS Apple macOS 10.13 Benchmark
sca.description: This document, CIS Apple macOS 10.13 Benchmark, provides prescriptive guidance for establishing a secure configuration posture for Apple macOS 10.13. This guide was tested against Apple macOS 10.13. To obtain the latest version of this guide, please visit https://benchmarks.cisecurity.org. If you have questions, comments, or have identified ways to improve this guide, please write us at feedback@cisecurity.org
sca.policy_id: cis_apple_macos_10_13
sca.passed: 13
sca.failed: 12
sca.invalid: 5
sca.total_checks: 30
sca.score: 52
sca.file: cis_apple_macOS_10.13.yml
```

SQL DB:

```
select id,result,reason,status from sca_check;
14000||Timeout overtaken running command 'softwareupdate -l'|Not applicable
14001|failed||
14002|failed||
14003|failed||
14004|failed||
14005|passed||
14006|passed||
14007|passed||
14008|failed||
14009|passed||
14010|failed||
14011|failed||
14012|passed||
14013|failed||
14014|failed||
14015||Internal error running command 'defaults read -app Terminal SecureKeyboardEntry'|Not applicable
14016|passed||
14017|passed||
14018|passed||
14019|failed||
14020||Internal error running command 'defaults read /Library/Preferences/com.apple.mDNSResponder.plist NoMulticastAdvertisements'|Not applicable
14021|failed||
14022|passed||
14023|passed||
14024|passed||
14025|passed||
14026|failed||
14027|passed||
14028||Internal error running command 'defaults read NSGlobalDomain AppleShowAllExtensions'|Not applicable
14029||Internal error running command 'defaults read com.apple.Safari AutoOpenSafeDownloads'|Not applicable
```

## Test 10.12

```
** Alert 1557493213.500425: - ossec,rootcheck,gdpr_IV_35.7.d,
2019 May 10 15:00:13 (macos10.12) any->rootcheck
Rule: 510 (level 7) -> 'Host-based anomaly detection event (rootcheck).'
Files hidden inside directory '/var/tmp'. Link count does not match number of files (3,4).
title: Files hidden inside directory '/var/tmp'.

** Alert 1557493221.500750: - sca,gdpr_IV_35.7.d
2019 May 10 15:00:21 (macos10.12) any->sca
Rule: 19007 (level 7) -> 'CIS Apple macOS 10.12 Benchmark: Verify all Apple provided software is current (Scored)'
{"type":"check","id":1023940218,"policy":"CIS Apple macOS 10.12 Benchmark","policy_id":"cis_apple_macos_10_12","check":{"id":13500,"title":"Verify all Apple provided software is current (Scored)","description":"Software vendors release security patches and software updates for their products when security vulnerabilities are discovered. There is no simple way to complete this action without a network connection to an Apple software repository. Please ensure appropriate access for this control. This check is only for what Apple provides through software update.","rationale":"It is important that these updates be applied in a timely manner to prevent unauthorized persons from exploiting the identified vulnerabilities.","remediation":"1. In Terminal, run the following: softwareupdate -l    2. In Terminal, run the following for any packages that show up in step 1: sudo softwareupdate -i <packagename>","compliance":{"cis":"1.1"},"rules":["c:softwareupdate -l -> !r:^\\s*No new software available;"],"command":"softwareupdate -l","result":"failed"}}
sca.type: check
sca.scan_id: 1023940218
sca.policy: CIS Apple macOS 10.12 Benchmark
sca.check.id: 13500
sca.check.title: Verify all Apple provided software is current (Scored)
sca.check.description: Software vendors release security patches and software updates for their products when security vulnerabilities are discovered. There is no simple way to complete this action without a network connection to an Apple software repository. Please ensure appropriate access for this control. This check is only for what Apple provides through software update.
sca.check.rationale: It is important that these updates be applied in a timely manner to prevent unauthorized persons from exploiting the identified vulnerabilities.
sca.check.remediation: 1. In Terminal, run the following: softwareupdate -l    2. In Terminal, run the following for any packages that show up in step 1: sudo softwareupdate -i <packagename>
sca.check.compliance.cis: 1.1
sca.check.command: ["softwareupdate -l"]
sca.check.result: failed

** Alert 1557493221.503024: - sca,gdpr_IV_35.7.d
2019 May 10 15:00:21 (macos10.12) any->sca
Rule: 19009 (level 3) -> 'CIS Apple macOS 10.12 Benchmark: Enable Auto Update (Scored)'
{"type":"check","id":1023940218,"policy":"CIS Apple macOS 10.12 Benchmark","policy_id":"cis_apple_macos_10_12","check":{"id":13501,"title":"Enable Auto Update (Scored)","description":"Auto Update verifies that your system has the newest security patches and software updates. If \"Automatically check for updates\" is not selected background updates for new malware definition files from Apple for XProtect and Gatekeeper will not occur.","rationale":"It is important that a system has the newest updates applied so as to prevent unauthorized persons from exploiting identified vulnerabilities.","remediation":"Open a terminal session and enter the following command to enable the auto update feature: sudo defaults write /Library/Preferences/com.apple.SoftwareUpdate AutomaticCheckEnabled -int 1","compliance":{"cis":"1.2"},"rules":["c:defaults read /Library/Preferences/com.apple.SoftwareUpdate AutomaticCheckEnabled -> !r:^\\s*1;"],"references":"https://macops.ca/os-x-admins-your-clients-are-not-getting-background-security-updates/,https://derflounder.wordpress.com/2014/12/17/forcing-xprotect-blacklist-updates-on-mavericks-and-yosemite/","command":"defaults read /Library/Preferences/com.apple.SoftwareUpdate AutomaticCheckEnabled","status":"Not applicable","reason":"Internal error running command 'defaults read /Library/Preferences/com.apple.SoftwareUpdate AutomaticCheckEnabled'"}}
sca.type: check
sca.scan_id: 1023940218
sca.policy: CIS Apple macOS 10.12 Benchmark
sca.check.id: 13501
sca.check.title: Enable Auto Update (Scored)
sca.check.description: Auto Update verifies that your system has the newest security patches and software updates. If "Automatically check for updates" is not selected background updates for new malware definition files from Apple for XProtect and Gatekeeper will not occur.
sca.check.rationale: It is important that a system has the newest updates applied so as to prevent unauthorized persons from exploiting identified vulnerabilities.
sca.check.remediation: Open a terminal session and enter the following command to enable the auto update feature: sudo defaults write /Library/Preferences/com.apple.SoftwareUpdate AutomaticCheckEnabled -int 1
sca.check.compliance.cis: 1.2
sca.check.references: https://macops.ca/os-x-admins-your-clients-are-not-getting-background-security-updates/,https://derflounder.wordpress.com/2014/12/17/forcing-xprotect-blacklist-updates-on-mavericks-and-yosemite/
sca.check.command: ["defaults read /Library/Preferences/com.apple.SoftwareUpdate AutomaticCheckEnabled"]
sca.check.status: Not applicable
sca.check.reason: Internal error running command 'defaults read /Library/Preferences/com.apple.SoftwareUpdate AutomaticCheckEnabled'

** Alert 1557493221.505913: - sca,gdpr_IV_35.7.d
2019 May 10 15:00:21 (macos10.12) any->sca
Rule: 19007 (level 7) -> 'CIS Apple macOS 10.12 Benchmark: Enable app update installs (Scored)'
{"type":"check","id":1023940218,"policy":"CIS Apple macOS 10.12 Benchmark","policy_id":"cis_apple_macos_10_12","check":{"id":13502,"title":"Enable app update installs (Scored)","description":"Ensure that application updates are installed after they are available from Apple. These updates do not require reboots or admin privileges for end users.","rationale":"Patches need to be applied in a timely manner to reduce the risk of vulnerabilities being exploited","remediation":"Open a terminal session and enter the following command to enable the auto update feature: sudo defaults write /Library/Preferences/com.apple.commerce AutoUpdate -bool TRUE    The remediation requires a log out and log in to show in the GUI. Please note that.","compliance":{"cis":"1.3"},"rules":["c:defaults read /Library/Preferences/com.apple.commerce AutoUpdate -> r:^\\s*0$;"],"command":"defaults read /Library/Preferences/com.apple.commerce AutoUpdate","result":"failed"}}
sca.type: check
sca.scan_id: 1023940218
sca.policy: CIS Apple macOS 10.12 Benchmark
sca.check.id: 13502
sca.check.title: Enable app update installs (Scored)
sca.check.description: Ensure that application updates are installed after they are available from Apple. These updates do not require reboots or admin privileges for end users.
sca.check.rationale: Patches need to be applied in a timely manner to reduce the risk of vulnerabilities being exploited
sca.check.remediation: Open a terminal session and enter the following command to enable the auto update feature: sudo defaults write /Library/Preferences/com.apple.commerce AutoUpdate -bool TRUE    The remediation requires a log out and log in to show in the GUI. Please note that.
sca.check.compliance.cis: 1.3
sca.check.command: ["defaults read /Library/Preferences/com.apple.commerce AutoUpdate"]
sca.check.result: failed

** Alert 1557493221.507939: - sca,gdpr_IV_35.7.d
2019 May 10 15:00:21 (macos10.12) any->sca
Rule: 19007 (level 7) -> 'CIS Apple macOS 10.12 Benchmark: Enable system data files and security update installs (Scored)'
{"type":"check","id":1023940218,"policy":"CIS Apple macOS 10.12 Benchmark","policy_id":"cis_apple_macos_10_12","check":{"id":13503,"title":"Enable system data files and security update installs (Scored)","description":"Ensure that system and security updates are installed after they are available from Apple.  This setting enables definition updates for XProtect and Gatekeeper, with this setting in place new malware and adware that Apple has added to the list of malware or untrusted software will not execute. These updates do not require reboots or end user admin rights.","rationale":"Patches need to be applied in a timely manner to reduce the risk of vulnerabilities being exploited","remediation":"Open a terminal session and enter the following command to enable install system data files and security updates: sudo defaults write /Library/Preferences/com.apple.SoftwareUpdate ConfigDataInstall -bool true && sudo defaults write /Library/Preferences/com.apple.SoftwareUpdate CriticalUpdateInstall -bool true","compliance":{"cis":"1.4"},"rules":["c:defaults read /Library/Preferences/com.apple.SoftwareUpdate -> NIN r:^\\s*ConfigDataInstall\\s*= && r:\\s*1;","c:defaults read /Library/Preferences/com.apple.SoftwareUpdate -> NIN r:^\\s*CriticalUpdateInstall\\s*= && r:\\s*1;"],"references":"https://www.thesafemac.com/tag/xprotect/,https://support.apple.com/en-us/HT202491","command":"defaults read /Library/Preferences/com.apple.SoftwareUpdate","result":"failed"}}
sca.type: check
sca.scan_id: 1023940218
sca.policy: CIS Apple macOS 10.12 Benchmark
sca.check.id: 13503
sca.check.title: Enable system data files and security update installs (Scored)
sca.check.description: Ensure that system and security updates are installed after they are available from Apple.  This setting enables definition updates for XProtect and Gatekeeper, with this setting in place new malware and adware that Apple has added to the list of malware or untrusted software will not execute. These updates do not require reboots or end user admin rights.
sca.check.rationale: Patches need to be applied in a timely manner to reduce the risk of vulnerabilities being exploited
sca.check.remediation: Open a terminal session and enter the following command to enable install system data files and security updates: sudo defaults write /Library/Preferences/com.apple.SoftwareUpdate ConfigDataInstall -bool true && sudo defaults write /Library/Preferences/com.apple.SoftwareUpdate CriticalUpdateInstall -bool true
sca.check.compliance.cis: 1.4
sca.check.references: https://www.thesafemac.com/tag/xprotect/,https://support.apple.com/en-us/HT202491
sca.check.command: ["defaults read /Library/Preferences/com.apple.SoftwareUpdate"]
sca.check.result: failed

** Alert 1557493221.510892: - sca,gdpr_IV_35.7.d
2019 May 10 15:00:21 (macos10.12) any->sca
Rule: 19007 (level 7) -> 'CIS Apple macOS 10.12 Benchmark: Enable macOS update installs (Scored)'
{"type":"check","id":1023940218,"policy":"CIS Apple macOS 10.12 Benchmark","policy_id":"cis_apple_macos_10_12","check":{"id":13504,"title":"Enable macOS update installs (Scored)","description":"Ensure that macOS updates are installed after they are available from Apple. This setting enables macOS updates to be automatically installed. Some environments will want to approve and test updates before they are delivered. It is best practice to test first where updates can and have caused disruptions to operations. Automatic updates should be turned off where changes are tightly controlled and there are mature testing and approval processes. Automatic updates should not be turned off so the admin can call the users first to let them know it's ok to install. A dependable repeatable process involving a patch agent or remote management tool should be in place before auto-updates are turned off.","rationale":"Patches need to be applied in a timely manner to reduce the risk of vulnerabilities being exploited","remediation":"Open a terminal session and enter the following command to enable install system data files and security updates: sudo defaults write /Library/Preferences/com.apple.commerce AutoUpdateRestartRequired -bool TRUE","compliance":{"cis":"1.5"},"rules":["c:defaults read /Library/Preferences/com.apple.commerce AutoUpdateRestartRequired -> r:^\\s*0$;"],"command":"defaults read /Library/Preferences/com.apple.commerce AutoUpdateRestartRequired","result":"failed"}}
sca.type: check
sca.scan_id: 1023940218
sca.policy: CIS Apple macOS 10.12 Benchmark
sca.check.id: 13504
sca.check.title: Enable macOS update installs (Scored)
sca.check.description: Ensure that macOS updates are installed after they are available from Apple. This setting enables macOS updates to be automatically installed. Some environments will want to approve and test updates before they are delivered. It is best practice to test first where updates can and have caused disruptions to operations. Automatic updates should be turned off where changes are tightly controlled and there are mature testing and approval processes. Automatic updates should not be turned off so the admin can call the users first to let them know it's ok to install. A dependable repeatable process involving a patch agent or remote management tool should be in place before auto-updates are turned off.
sca.check.rationale: Patches need to be applied in a timely manner to reduce the risk of vulnerabilities being exploited
sca.check.remediation: Open a terminal session and enter the following command to enable install system data files and security updates: sudo defaults write /Library/Preferences/com.apple.commerce AutoUpdateRestartRequired -bool TRUE
sca.check.compliance.cis: 1.5
sca.check.command: ["defaults read /Library/Preferences/com.apple.commerce AutoUpdateRestartRequired"]
sca.check.result: failed

** Alert 1557493221.513971: - sca,gdpr_IV_35.7.d
2019 May 10 15:00:21 (macos10.12) any->sca
Rule: 19007 (level 7) -> 'CIS Apple macOS 10.12 Benchmark: Turn off Bluetooth "Discoverable" mode when not pairing devices (Scored)'
{"type":"check","id":1023940218,"policy":"CIS Apple macOS 10.12 Benchmark","policy_id":"cis_apple_macos_10_12","check":{"id":13505,"title":"Turn off Bluetooth \"Discoverable\" mode when not pairing devices (Scored)","description":"When Bluetooth is set to discoverable mode, the Mac sends a signal indicating that it's available to pair with another Bluetooth device. When a device is \"discoverable\" it broadcasts information about itself and its location. Starting with OS X 10.9 Discoverable mode is enabled while the Bluetooth System Preference is open and turned off once closed.  Systems that have the Bluetooth System Preference open at the time of audit will show as Discoverable","rationale":"When in the discoverable state an unauthorized user could gain access to the system by pairing it with a remote device.","remediation":"Starting with OS X (10.9) Bluetooth is only set to Discoverable when the Bluetooth System Preference is selected. To ensure that the computer is not Discoverable do not leave that preference open.","compliance":{"cis":"2.1.2"},"rules":["c:/usr/sbin/system_profiler SPBluetoothDataType -> !r:^\\s*[Dd]iscoverable:\\s*Off;"],"command":"/usr/sbin/system_profiler SPBluetoothDataType","result":"failed"}}
sca.type: check
sca.scan_id: 1023940218
sca.policy: CIS Apple macOS 10.12 Benchmark
sca.check.id: 13505
sca.check.title: Turn off Bluetooth "Discoverable" mode when not pairing devices (Scored)
sca.check.description: When Bluetooth is set to discoverable mode, the Mac sends a signal indicating that it's available to pair with another Bluetooth device. When a device is "discoverable" it broadcasts information about itself and its location. Starting with OS X 10.9 Discoverable mode is enabled while the Bluetooth System Preference is open and turned off once closed.  Systems that have the Bluetooth System Preference open at the time of audit will show as Discoverable
sca.check.rationale: When in the discoverable state an unauthorized user could gain access to the system by pairing it with a remote device.
sca.check.remediation: Starting with OS X (10.9) Bluetooth is only set to Discoverable when the Bluetooth System Preference is selected. To ensure that the computer is not Discoverable do not leave that preference open.
sca.check.compliance.cis: 2.1.2
sca.check.command: ["/usr/sbin/system_profiler SPBluetoothDataType"]
sca.check.result: failed

** Alert 1557493221.516597: - sca,gdpr_IV_35.7.d
2019 May 10 15:00:21 (macos10.12) any->sca
Rule: 19008 (level 3) -> 'CIS Apple macOS 10.12 Benchmark: Enable "Set time and date automatically" (Scored)'
{"type":"check","id":1023940218,"policy":"CIS Apple macOS 10.12 Benchmark","policy_id":"cis_apple_macos_10_12","check":{"id":13506,"title":"Enable \"Set time and date automatically\" (Scored)","description":"Correct date and time settings are required for authentication protocols, file creation, modification dates and log entries.  Note: If your organization has internal time servers, enter them here. Enterprise mobile devices may need to use a mix of internal and external time servers. If multiple servers are required use the Date & Time System Preference with each server separated by a space.","rationale":"Kerberos may not operate correctly if the time on the Mac is off by more than 5 minutes.  This in turn can affect Apple's single sign-on feature, Active Directory logons, and other features.","remediation":"Run the following commands: sudo systemsetup -setnetworktimeserver <timeserver>    sudo systemsetup -setusingnetworktime on","compliance":{"cis":"2.2.1"},"rules":["c:systemsetup -getusingnetworktime -> !r:^\\s*Network Time:\\s*On;"],"command":"systemsetup -getusingnetworktime","result":"passed"}}
sca.type: check
sca.scan_id: 1023940218
sca.policy: CIS Apple macOS 10.12 Benchmark
sca.check.id: 13506
sca.check.title: Enable "Set time and date automatically" (Scored)
sca.check.description: Correct date and time settings are required for authentication protocols, file creation, modification dates and log entries.  Note: If your organization has internal time servers, enter them here. Enterprise mobile devices may need to use a mix of internal and external time servers. If multiple servers are required use the Date & Time System Preference with each server separated by a space.
sca.check.rationale: Kerberos may not operate correctly if the time on the Mac is off by more than 5 minutes.  This in turn can affect Apple's single sign-on feature, Active Directory logons, and other features.
sca.check.remediation: Run the following commands: sudo systemsetup -setnetworktimeserver <timeserver>    sudo systemsetup -setusingnetworktime on
sca.check.compliance.cis: 2.2.1
sca.check.command: ["systemsetup -getusingnetworktime"]
sca.check.result: passed

** Alert 1557493221.518981: - sca,gdpr_IV_35.7.d
2019 May 10 15:00:21 (macos10.12) any->sca
Rule: 19008 (level 3) -> 'CIS Apple macOS 10.12 Benchmark: Disable Remote Apple Events (Scored)'
{"type":"check","id":1023940218,"policy":"CIS Apple macOS 10.12 Benchmark","policy_id":"cis_apple_macos_10_12","check":{"id":13507,"title":"Disable Remote Apple Events (Scored)","description":"Apple Events is a technology that allows one program to communicate with other programs. Remote Apple Events allows a program on one computer to communicate with a program on a different computer.","rationale":"Disabling Remote Apple Events mitigates the risk of an unauthorized program gaining access to the system.","remediation":"Run the following command in Terminal: sudo systemsetup -setremoteappleevents off","compliance":{"cis":"2.4.1"},"rules":["c:systemsetup -getremoteappleevents -> !r:^Remote Apple Events:\\s*Off;"],"command":"systemsetup -getremoteappleevents","result":"passed"}}
sca.type: check
sca.scan_id: 1023940218
sca.policy: CIS Apple macOS 10.12 Benchmark
sca.check.id: 13507
sca.check.title: Disable Remote Apple Events (Scored)
sca.check.description: Apple Events is a technology that allows one program to communicate with other programs. Remote Apple Events allows a program on one computer to communicate with a program on a different computer.
sca.check.rationale: Disabling Remote Apple Events mitigates the risk of an unauthorized program gaining access to the system.
sca.check.remediation: Run the following command in Terminal: sudo systemsetup -setremoteappleevents off
sca.check.compliance.cis: 2.4.1
sca.check.command: ["systemsetup -getremoteappleevents"]
sca.check.result: passed

** Alert 1557493221.520683: - sca,gdpr_IV_35.7.d
2019 May 10 15:00:21 (macos10.12) any->sca
Rule: 19008 (level 3) -> 'CIS Apple macOS 10.12 Benchmark: Disable Printer Sharing (Scored)'
{"type":"check","id":1023940218,"policy":"CIS Apple macOS 10.12 Benchmark","policy_id":"cis_apple_macos_10_12","check":{"id":13508,"title":"Disable Printer Sharing (Scored)","description":"By enabling Printer sharing the computer is set up as a print server to accept print jobs from other computers. Dedicated print servers or direct IP printing should be used instead.","rationale":"Disabling Printer Sharing mitigates the risk of attackers attempting to exploit the print server to gain access to the system.","remediation":"Perform the following to implement the prescribed state: 1. Open System Preferences 2. Select Sharing 3. Uncheck Printer Sharing","compliance":{"cis":"2.4.4"},"rules":["c:system_profiler SPPrintersDataType -> r:Shared:\\s*Yes;"],"command":"system_profiler SPPrintersDataType","result":"passed"}}
sca.type: check
sca.scan_id: 1023940218
sca.policy: CIS Apple macOS 10.12 Benchmark
sca.check.id: 13508
sca.check.title: Disable Printer Sharing (Scored)
sca.check.description: By enabling Printer sharing the computer is set up as a print server to accept print jobs from other computers. Dedicated print servers or direct IP printing should be used instead.
sca.check.rationale: Disabling Printer Sharing mitigates the risk of attackers attempting to exploit the print server to gain access to the system.
sca.check.remediation: Perform the following to implement the prescribed state: 1. Open System Preferences 2. Select Sharing 3. Uncheck Printer Sharing
sca.check.compliance.cis: 2.4.4
sca.check.command: ["system_profiler SPPrintersDataType"]
sca.check.result: passed

** Alert 1557493221.522467: - sca,gdpr_IV_35.7.d
2019 May 10 15:00:21 (macos10.12) any->sca
Rule: 19007 (level 7) -> 'CIS Apple macOS 10.12 Benchmark: Disable Remote Login (Scored)'
{"type":"check","id":1023940218,"policy":"CIS Apple macOS 10.12 Benchmark","policy_id":"cis_apple_macos_10_12","check":{"id":13509,"title":"Disable Remote Login (Scored)","description":"Remote Login allows an interactive terminal connection to a computer.","rationale":"Disabling Remote Login mitigates the risk of an unauthorized person gaining access to the system via Secure Shell (SSH). While SSH is an industry standard to connect to posix servers, the scope of the benchmark is for Apple macOS clients, not servers.","remediation":"Run the following command in Terminal: sudo systemsetup -setremotelogin off","compliance":{"cis":"2.4.5"},"rules":["c:systemsetup -getremotelogin -> r:^Remote Login:\\s*On;"],"command":"systemsetup -getremotelogin","result":"failed"}}
sca.type: check
sca.scan_id: 1023940218
sca.policy: CIS Apple macOS 10.12 Benchmark
sca.check.id: 13509
sca.check.title: Disable Remote Login (Scored)
sca.check.description: Remote Login allows an interactive terminal connection to a computer.
sca.check.rationale: Disabling Remote Login mitigates the risk of an unauthorized person gaining access to the system via Secure Shell (SSH). While SSH is an industry standard to connect to posix servers, the scope of the benchmark is for Apple macOS clients, not servers.
sca.check.remediation: Run the following command in Terminal: sudo systemsetup -setremotelogin off
sca.check.compliance.cis: 2.4.5
sca.check.command: ["systemsetup -getremotelogin"]
sca.check.result: failed

** Alert 1557493221.524147: - sca,gdpr_IV_35.7.d
2019 May 10 15:00:21 (macos10.12) any->sca
Rule: 19008 (level 3) -> 'CIS Apple macOS 10.12 Benchmark: Disable File Sharing (Scored)'
{"type":"check","id":1023940218,"policy":"CIS Apple macOS 10.12 Benchmark","policy_id":"cis_apple_macos_10_12","check":{"id":13510,"title":"Disable File Sharing (Scored)","description":"Apple's File Sharing uses a combination of SMB (Windows sharing) and AFP (Mac sharing)","rationale":"By disabling file sharing, the remote attack surface and risk of unauthorized access to files stored on the system is reduced.","remediation":"Run the following command in Terminal to turn off AFP from the command line: sudo launchctl unload -w /System/Library/LaunchDaemons/com.apple.AppleFileServer.plist  - Run the following command in Terminal to turn off SMB sharing from the CLI: sudo launchctl unload -w /System/Library/LaunchDaemons/com.apple.smbd.plist","compliance":{"cis":"2.4.8"},"rules":["c:launchctl list -> r:AppleFileServer;"],"command":"launchctl list","result":"passed"}}
sca.type: check
sca.scan_id: 1023940218
sca.policy: CIS Apple macOS 10.12 Benchmark
sca.check.id: 13510
sca.check.title: Disable File Sharing (Scored)
sca.check.description: Apple's File Sharing uses a combination of SMB (Windows sharing) and AFP (Mac sharing)
sca.check.rationale: By disabling file sharing, the remote attack surface and risk of unauthorized access to files stored on the system is reduced.
sca.check.remediation: Run the following command in Terminal to turn off AFP from the command line: sudo launchctl unload -w /System/Library/LaunchDaemons/com.apple.AppleFileServer.plist  - Run the following command in Terminal to turn off SMB sharing from the CLI: sudo launchctl unload -w /System/Library/LaunchDaemons/com.apple.smbd.plist
sca.check.compliance.cis: 2.4.8
sca.check.command: ["launchctl list"]
sca.check.result: passed

** Alert 1557493221.526053: - sca,gdpr_IV_35.7.d
2019 May 10 15:00:21 (macos10.12) any->sca
Rule: 19008 (level 3) -> 'CIS Apple macOS 10.12 Benchmark: Disable "Wake for network access" (Scored)'
{"type":"check","id":1023940218,"policy":"CIS Apple macOS 10.12 Benchmark","policy_id":"cis_apple_macos_10_12","check":{"id":13511,"title":"Disable \"Wake for network access\" (Scored)","description":"This feature allows other users to be able to access your computer’s shared resources, such as shared printers or iTunes playlists, even when your computer is in sleep mode. In a closed network when only authorized devices could wake a computer it could be valuable to wake computers in order to do management push activity. Where mobile workstations and agents exist the device will more likely check in to receive updates when already awake. Mobile devices should not be listening for signals on unmanaged network where untrusted devices could send wake signals.","rationale":"Disabling this feature mitigates the risk of an attacker remotely waking the system and gaining access.","remediation":"Run the following command in Terminal: sudo pmset -a womp 0","compliance":{"cis":"2.5.1"},"rules":["c:pmset -g -> r:^\\s*womp\\s+1$;"],"command":"pmset -g","result":"passed"}}
sca.type: check
sca.scan_id: 1023940218
sca.policy: CIS Apple macOS 10.12 Benchmark
sca.check.id: 13511
sca.check.title: Disable "Wake for network access" (Scored)
sca.check.description: This feature allows other users to be able to access your computer’s shared resources, such as shared printers or iTunes playlists, even when your computer is in sleep mode. In a closed network when only authorized devices could wake a computer it could be valuable to wake computers in order to do management push activity. Where mobile workstations and agents exist the device will more likely check in to receive updates when already awake. Mobile devices should not be listening for signals on unmanaged network where untrusted devices could send wake signals.
sca.check.rationale: Disabling this feature mitigates the risk of an attacker remotely waking the system and gaining access.
sca.check.remediation: Run the following command in Terminal: sudo pmset -a womp 0
sca.check.compliance.cis: 2.5.1
sca.check.command: ["pmset -g"]
sca.check.result: passed

** Alert 1557493221.528378: - sca,gdpr_IV_35.7.d
2019 May 10 15:00:21 (macos10.12) any->sca
Rule: 19007 (level 7) -> 'CIS Apple macOS 10.12 Benchmark: Enable FileVault (Scored)'
{"type":"check","id":1023940218,"policy":"CIS Apple macOS 10.12 Benchmark","policy_id":"cis_apple_macos_10_12","check":{"id":13512,"title":"Enable FileVault (Scored)","description":"FileVault secures a system's data by automatically encrypting its boot volume and requiring a password or recovery key to access it.","rationale":"Encrypting sensitive data minimizes the likelihood of unauthorized users gaining access to it.","remediation":"Perform the following to implement the prescribed state: 1. Open System Preferences 2. Select Security & Privacy 3. Select FileVault 4. Select Turn on FileVault","compliance":{"cis":"2.6.1.1"},"rules":["c:fdesetup status -> r:^FileVault is\\s*Off\\p;"],"command":"fdesetup status","result":"failed"}}
sca.type: check
sca.scan_id: 1023940218
sca.policy: CIS Apple macOS 10.12 Benchmark
sca.check.id: 13512
sca.check.title: Enable FileVault (Scored)
sca.check.description: FileVault secures a system's data by automatically encrypting its boot volume and requiring a password or recovery key to access it.
sca.check.rationale: Encrypting sensitive data minimizes the likelihood of unauthorized users gaining access to it.
sca.check.remediation: Perform the following to implement the prescribed state: 1. Open System Preferences 2. Select Security & Privacy 3. Select FileVault 4. Select Turn on FileVault
sca.check.compliance.cis: 2.6.1.1
sca.check.command: ["fdesetup status"]
sca.check.result: failed

** Alert 1557493221.529999: - sca,gdpr_IV_35.7.d
2019 May 10 15:00:21 (macos10.12) any->sca
Rule: 19008 (level 3) -> 'CIS Apple macOS 10.12 Benchmark: Enable Gatekeeper (Scored)'
{"type":"check","id":1023940218,"policy":"CIS Apple macOS 10.12 Benchmark","policy_id":"cis_apple_macos_10_12","check":{"id":13513,"title":"Enable Gatekeeper (Scored)","description":"Gatekeeper is Apple's application white-listing control that restricts downloaded applications from launching. It functions as a control to limit applications from unverified sources from running without authorization.","rationale":"Disallowing unsigned software will reduce the risk of unauthorized or malicious applications from running on the system.","remediation":"Run the following command in Terminal: sudo spctl --master-enable","compliance":{"cis":"2.6.2"},"rules":["c:spctl --status -> !r:^assessments enabled;"],"command":"spctl --status","result":"passed"}}
sca.type: check
sca.scan_id: 1023940218
sca.policy: CIS Apple macOS 10.12 Benchmark
sca.check.id: 13513
sca.check.title: Enable Gatekeeper (Scored)
sca.check.description: Gatekeeper is Apple's application white-listing control that restricts downloaded applications from launching. It functions as a control to limit applications from unverified sources from running without authorization.
sca.check.rationale: Disallowing unsigned software will reduce the risk of unauthorized or malicious applications from running on the system.
sca.check.remediation: Run the following command in Terminal: sudo spctl --master-enable
sca.check.compliance.cis: 2.6.2
sca.check.command: ["spctl --status"]
sca.check.result: passed

** Alert 1557493221.531648: - sca,gdpr_IV_35.7.d
2019 May 10 15:00:21 (macos10.12) any->sca
Rule: 19007 (level 7) -> 'CIS Apple macOS 10.12 Benchmark: Enable Firewall (Scored)'
{"type":"check","id":1023940218,"policy":"CIS Apple macOS 10.12 Benchmark","policy_id":"cis_apple_macos_10_12","check":{"id":13514,"title":"Enable Firewall (Scored)","description":"A firewall is a piece of software that blocks unwanted incoming connections to a system.  Apple has posted general documentation about the application firewall.","rationale":"A firewall minimizes the threat of unauthorized users from gaining access to your system while connected to a network or the Internet.","remediation":"Run the following command in Terminal: defaults write /Library/Preferences/com.apple.alf globalstate - int <value>    Where <value> is: - 1 = on for specific services - 2 = on for essential services","compliance":{"cis":"2.6.3"},"rules":["c:defaults read /Library/Preferences/com.apple.alf globalstate -> !r:^\\s*1$;","c:defaults read /Library/Preferences/com.apple.alf globalstate -> !r:^\\s*2$;"],"references":"https://support.apple.com/en-us/HT201642","command":"defaults read /Library/Preferences/com.apple.alf globalstate","result":"failed"}}
sca.type: check
sca.scan_id: 1023940218
sca.policy: CIS Apple macOS 10.12 Benchmark
sca.check.id: 13514
sca.check.title: Enable Firewall (Scored)
sca.check.description: A firewall is a piece of software that blocks unwanted incoming connections to a system.  Apple has posted general documentation about the application firewall.
sca.check.rationale: A firewall minimizes the threat of unauthorized users from gaining access to your system while connected to a network or the Internet.
sca.check.remediation: Run the following command in Terminal: defaults write /Library/Preferences/com.apple.alf globalstate - int <value>    Where <value> is: - 1 = on for specific services - 2 = on for essential services
sca.check.compliance.cis: 2.6.3
sca.check.references: https://support.apple.com/en-us/HT201642
sca.check.command: ["defaults read /Library/Preferences/com.apple.alf globalstate"]
sca.check.result: failed

** Alert 1557493221.533793: - sca,gdpr_IV_35.7.d
2019 May 10 15:00:21 (macos10.12) any->sca
Rule: 19007 (level 7) -> 'CIS Apple macOS 10.12 Benchmark: Enable Firewall Stealth Mode (Scored)'
{"type":"check","id":1023940218,"policy":"CIS Apple macOS 10.12 Benchmark","policy_id":"cis_apple_macos_10_12","check":{"id":13515,"title":"Enable Firewall Stealth Mode (Scored)","description":"While in Stealth mode the computer will not respond to unsolicited probes, dropping that traffic.","rationale":"Stealth mode on the firewall minimizes the threat of system discovery tools while connected to a network or the Internet.","remediation":"Run the following command in Terminal: sudo /usr/libexec/ApplicationFirewall/socketfilterfw --setstealthmode on","compliance":{"cis":"2.6.4"},"rules":["c:/usr/libexec/ApplicationFirewall/socketfilterfw --getstealthmode -> !r:^\\s*Stealth mode enabled;"],"references":"https://support.apple.com/en-us/HT201642","command":"/usr/libexec/ApplicationFirewall/socketfilterfw --getstealthmode","result":"failed"}}
sca.type: check
sca.scan_id: 1023940218
sca.policy: CIS Apple macOS 10.12 Benchmark
sca.check.id: 13515
sca.check.title: Enable Firewall Stealth Mode (Scored)
sca.check.description: While in Stealth mode the computer will not respond to unsolicited probes, dropping that traffic.
sca.check.rationale: Stealth mode on the firewall minimizes the threat of system discovery tools while connected to a network or the Internet.
sca.check.remediation: Run the following command in Terminal: sudo /usr/libexec/ApplicationFirewall/socketfilterfw --setstealthmode on
sca.check.compliance.cis: 2.6.4
sca.check.references: https://support.apple.com/en-us/HT201642
sca.check.command: ["/usr/libexec/ApplicationFirewall/socketfilterfw --getstealthmode"]
sca.check.result: failed

** Alert 1557493221.535601: - sca,gdpr_IV_35.7.d
2019 May 10 15:00:21 (macos10.12) any->sca
Rule: 19009 (level 3) -> 'CIS Apple macOS 10.12 Benchmark: Enable Secure Keyboard Entry in terminal.app (Scored)'
{"type":"check","id":1023940218,"policy":"CIS Apple macOS 10.12 Benchmark","policy_id":"cis_apple_macos_10_12","check":{"id":13516,"title":"Enable Secure Keyboard Entry in terminal.app (Scored)","description":"Secure Keyboard Entry prevents other applications on the system and/or network from detecting and recording what is typed into Terminal.","rationale":"Enabling Secure Keyboard Entry minimizes the risk of a key logger from detecting what is entered in Terminal.","remediation":"Perform the following to implement the prescribed state: 1. Open Terminal 2. Select Terminal 3. Select Secure Keyboard Entry","compliance":{"cis":"2.10"},"rules":["c:defaults read -app Terminal SecureKeyboardEntry -> r:^\\s*0$;"],"command":"defaults read -app Terminal SecureKeyboardEntry","status":"Not applicable","reason":"Internal error running command 'defaults read -app Terminal SecureKeyboardEntry'"}}
sca.type: check
sca.scan_id: 1023940218
sca.policy: CIS Apple macOS 10.12 Benchmark
sca.check.id: 13516
sca.check.title: Enable Secure Keyboard Entry in terminal.app (Scored)
sca.check.description: Secure Keyboard Entry prevents other applications on the system and/or network from detecting and recording what is typed into Terminal.
sca.check.rationale: Enabling Secure Keyboard Entry minimizes the risk of a key logger from detecting what is entered in Terminal.
sca.check.remediation: Perform the following to implement the prescribed state: 1. Open Terminal 2. Select Terminal 3. Select Secure Keyboard Entry
sca.check.compliance.cis: 2.10
sca.check.command: ["defaults read -app Terminal SecureKeyboardEntry"]
sca.check.status: Not applicable
sca.check.reason: Internal error running command 'defaults read -app Terminal SecureKeyboardEntry'

** Alert 1557493221.537553: - sca,gdpr_IV_35.7.d
2019 May 10 15:00:21 (macos10.12) any->sca
Rule: 19009 (level 3) -> 'CIS Apple macOS 10.12 Benchmark: Java 6 is not the default Java runtime (Scored)'
{"type":"check","id":1023940218,"policy":"CIS Apple macOS 10.12 Benchmark","policy_id":"cis_apple_macos_10_12","check":{"id":13517,"title":"Java 6 is not the default Java runtime (Scored)","description":"Apple had made Java part of the core Operating System for macOS. Apple is no longer providing Java updates for macOS and updated JREs and JDK are made available by Oracle.  The latest version of Java 6 made available by Apple has many unpatched vulnerabilities and should not be the default runtime for Java applets that request one from the Operating System","rationale":"Java has been one of the most exploited environments and Java 6, which was provided as an OS component by Apple, is no longer maintained by Apple or Oracle. The old versions provided by Apple are both unsupported and missing the more modern security controls that have limited current exploits. The EOL version may still be installed and should be removed from the computer or not be in the default path.","remediation":"Java 6 can be removed completely or, if required Java applications will only work with Java 6, a custom path can be used. Apple is likely to finally pull the plug on Java 6 in upcoming macOS versions so any applications that still require Java 6 will likely soon be unavailable.","compliance":{"cis":"2.11"},"rules":["c:java -version -> r:version.*1.6.0;","c:java -version -> r:Runtime Environment.*build.*1.6.0;"],"command":"java -version","status":"Not applicable","reason":"Internal error running command 'java -version'"}}
sca.type: check
sca.scan_id: 1023940218
sca.policy: CIS Apple macOS 10.12 Benchmark
sca.check.id: 13517
sca.check.title: Java 6 is not the default Java runtime (Scored)
sca.check.description: Apple had made Java part of the core Operating System for macOS. Apple is no longer providing Java updates for macOS and updated JREs and JDK are made available by Oracle.  The latest version of Java 6 made available by Apple has many unpatched vulnerabilities and should not be the default runtime for Java applets that request one from the Operating System
sca.check.rationale: Java has been one of the most exploited environments and Java 6, which was provided as an OS component by Apple, is no longer maintained by Apple or Oracle. The old versions provided by Apple are both unsupported and missing the more modern security controls that have limited current exploits. The EOL version may still be installed and should be removed from the computer or not be in the default path.
sca.check.remediation: Java 6 can be removed completely or, if required Java applications will only work with Java 6, a custom path can be used. Apple is likely to finally pull the plug on Java 6 in upcoming macOS versions so any applications that still require Java 6 will likely soon be unavailable.
sca.check.compliance.cis: 2.11
sca.check.command: ["java -version"]
sca.check.status: Not applicable
sca.check.reason: Internal error running command 'java -version'

** Alert 1557493221.540724: - sca,gdpr_IV_35.7.d
2019 May 10 15:00:21 (macos10.12) any->sca
Rule: 19008 (level 3) -> 'CIS Apple macOS 10.12 Benchmark: Enable security auditing (Scored)'
{"type":"check","id":1023940218,"policy":"CIS Apple macOS 10.12 Benchmark","policy_id":"cis_apple_macos_10_12","check":{"id":13518,"title":"Enable security auditing (Scored)","description":"macOS's audit facility, auditd, receives notifications from the kernel when certain system calls, such as open, fork, and exit, are made. These notifications are captured and written to an audit log.","rationale":"Logs generated by auditd may be useful when investigating a security incident as they may help reveal the vulnerable application and the actions taken by a malicious actor.","remediation":"Run the following command in Terminal: sudo launchctl load -w /System/Library/LaunchDaemons/com.apple.auditd.plist","compliance":{"cis":"3.1"},"rules":["c:launchctl list -> !r:com.apple.auditd;"],"command":"launchctl list","result":"passed"}}
sca.type: check
sca.scan_id: 1023940218
sca.policy: CIS Apple macOS 10.12 Benchmark
sca.check.id: 13518
sca.check.title: Enable security auditing (Scored)
sca.check.description: macOS's audit facility, auditd, receives notifications from the kernel when certain system calls, such as open, fork, and exit, are made. These notifications are captured and written to an audit log.
sca.check.rationale: Logs generated by auditd may be useful when investigating a security incident as they may help reveal the vulnerable application and the actions taken by a malicious actor.
sca.check.remediation: Run the following command in Terminal: sudo launchctl load -w /System/Library/LaunchDaemons/com.apple.auditd.plist
sca.check.compliance.cis: 3.1
sca.check.command: ["launchctl list"]
sca.check.result: passed

** Alert 1557493221.542550: - sca,gdpr_IV_35.7.d
2019 May 10 15:00:21 (macos10.12) any->sca
Rule: 19007 (level 7) -> 'CIS Apple macOS 10.12 Benchmark: Configure Security Auditing Flags (Scored)'
{"type":"check","id":1023940218,"policy":"CIS Apple macOS 10.12 Benchmark","policy_id":"cis_apple_macos_10_12","check":{"id":13519,"title":"Configure Security Auditing Flags (Scored)","description":"Auditing is the capture and maintenance of information about security-related events.","rationale":"Maintaining an audit trail of system activity logs can help identify configuration errors, troubleshoot service disruptions, and analyze compromises or attacks that have occurred, have begun, or are about to begin. Audit logs are necessary to provide a trail of evidence in case the system or network is compromised.","remediation":"1. Open a terminal session and edit the /etc/security/audit_control file 2. Find the line beginning with \"flags\" 3. Add the following flags: lo, ad, fd, fm, -all.  4. Save the file.","compliance":{"cis":"3.2"},"rules":["f:/etc/security/audit_control -> NIN r:^flags && r:lo;","f:/etc/security/audit_control -> NIN r:^flags && r:ad;","f:/etc/security/audit_control -> NIN r:^flags && r:fd;","f:/etc/security/audit_control -> NIN r:^flags && r:fm;","f:/etc/security/audit_control -> NIN r:^flags && r:-all;"],"file":"/etc/security/audit_control","result":"failed"}}
sca.type: check
sca.scan_id: 1023940218
sca.policy: CIS Apple macOS 10.12 Benchmark
sca.check.id: 13519
sca.check.title: Configure Security Auditing Flags (Scored)
sca.check.description: Auditing is the capture and maintenance of information about security-related events.
sca.check.rationale: Maintaining an audit trail of system activity logs can help identify configuration errors, troubleshoot service disruptions, and analyze compromises or attacks that have occurred, have begun, or are about to begin. Audit logs are necessary to provide a trail of evidence in case the system or network is compromised.
sca.check.remediation: 1. Open a terminal session and edit the /etc/security/audit_control file 2. Find the line beginning with "flags" 3. Add the following flags: lo, ad, fd, fm, -all.  4. Save the file.
sca.check.compliance.cis: 3.2
sca.check.file: ["/etc/security/audit_control"]
sca.check.result: failed

** Alert 1557493221.544863: - sca,gdpr_IV_35.7.d
2019 May 10 15:00:21 (macos10.12) any->sca
Rule: 19009 (level 3) -> 'CIS Apple macOS 10.12 Benchmark: Disable Bonjour advertising service (Scored)'
{"type":"check","id":1023940218,"policy":"CIS Apple macOS 10.12 Benchmark","policy_id":"cis_apple_macos_10_12","check":{"id":13520,"title":"Disable Bonjour advertising service (Scored)","description":"Bonjour is an auto-discovery mechanism for TCP/IP devices which enumerate devices and services within a local subnet. DNS on macOS is integrated with Bonjour and should not be turned off, but the Bonjour advertising service can be disabled.","rationale":"Bonjour can simplify device discovery from an internal rogue or compromised host. An attacker could use Bonjour's multicast DNS feature to discover a vulnerable or poorly- configured service or additional information to aid a targeted attack. Implementing this control disables the continuous broadcasting of \"I'm here!\" messages. Typical end-user endpoints should not have to advertise services to other computers.","remediation":"Run the following command in Terminal: defaults write /Library/Preferences/com.apple.mDNSResponder.plist NoMulticastAdvertisements","compliance":{"cis":"4.1"},"rules":["c:defaults read /Library/Preferences/com.apple.mDNSResponder.plist NoMulticastAdvertisements -> r:^\\s*0$;"],"command":"defaults read /Library/Preferences/com.apple.mDNSResponder.plist NoMulticastAdvertisements","status":"Not applicable","reason":"Internal error running command 'defaults read /Library/Preferences/com.apple.mDNSResponder.plist NoMulticastAdvertisements'"}}
sca.type: check
sca.scan_id: 1023940218
sca.policy: CIS Apple macOS 10.12 Benchmark
sca.check.id: 13520
sca.check.title: Disable Bonjour advertising service (Scored)
sca.check.description: Bonjour is an auto-discovery mechanism for TCP/IP devices which enumerate devices and services within a local subnet. DNS on macOS is integrated with Bonjour and should not be turned off, but the Bonjour advertising service can be disabled.
sca.check.rationale: Bonjour can simplify device discovery from an internal rogue or compromised host. An attacker could use Bonjour's multicast DNS feature to discover a vulnerable or poorly- configured service or additional information to aid a targeted attack. Implementing this control disables the continuous broadcasting of "I'm here!" messages. Typical end-user endpoints should not have to advertise services to other computers.
sca.check.remediation: Run the following command in Terminal: defaults write /Library/Preferences/com.apple.mDNSResponder.plist NoMulticastAdvertisements
sca.check.compliance.cis: 4.1
sca.check.command: ["defaults read /Library/Preferences/com.apple.mDNSResponder.plist NoMulticastAdvertisements"]
sca.check.status: Not applicable
sca.check.reason: Internal error running command 'defaults read /Library/Preferences/com.apple.mDNSResponder.plist NoMulticastAdvertisements'

** Alert 1557493221.547835: - sca,gdpr_IV_35.7.d
2019 May 10 15:00:21 (macos10.12) any->sca
Rule: 19008 (level 3) -> 'CIS Apple macOS 10.12 Benchmark: Ensure http server is not running (Scored)'
{"type":"check","id":1023940218,"policy":"CIS Apple macOS 10.12 Benchmark","policy_id":"cis_apple_macos_10_12","check":{"id":13521,"title":"Ensure http server is not running (Scored)","description":"macOS used to have a graphical front-end to the embedded Apache web server in the Operating System. Personal web sharing could be enabled to allow someone on another computer to download files or information from the user's computer. Personal web sharing from a user endpoint has long been considered questionable and Apple has removed that capability from the GUI. Apache however is still part of the Operating System and can be easily turned on to share files and provide remote connectivity to an end user computer.  Web sharing should only be done through hardened web servers and appropriate cloud services.","rationale":"Web serving should not be done from a user desktop. Dedicated webservers or appropriate cloud storage should be used. Open ports make it easier to exploit the computer.","remediation":"Stop the Web Server sudo apachectl stop    Ensure that the web server will not auto-start at boot sudo defaults write /System/Library/LaunchDaemons/org.apache.httpd Disabled - bool true","compliance":{"cis":"4.4"},"rules":["p:httpd;","p:/usr/sbin/httpd;","p:/usr/sbin/httpd -D FOREGROUND;"],"process":"httpd,/usr/sbin/httpd,/usr/sbin/httpd -D FOREGROUND","result":"passed"}}
sca.type: check
sca.scan_id: 1023940218
sca.policy: CIS Apple macOS 10.12 Benchmark
sca.check.id: 13521
sca.check.title: Ensure http server is not running (Scored)
sca.check.description: macOS used to have a graphical front-end to the embedded Apache web server in the Operating System. Personal web sharing could be enabled to allow someone on another computer to download files or information from the user's computer. Personal web sharing from a user endpoint has long been considered questionable and Apple has removed that capability from the GUI. Apache however is still part of the Operating System and can be easily turned on to share files and provide remote connectivity to an end user computer.  Web sharing should only be done through hardened web servers and appropriate cloud services.
sca.check.rationale: Web serving should not be done from a user desktop. Dedicated webservers or appropriate cloud storage should be used. Open ports make it easier to exploit the computer.
sca.check.remediation: Stop the Web Server sudo apachectl stop    Ensure that the web server will not auto-start at boot sudo defaults write /System/Library/LaunchDaemons/org.apache.httpd Disabled - bool true
sca.check.compliance.cis: 4.4
sca.check.process: ["httpd", "/usr/sbin/httpd", "/usr/sbin/httpd -D FOREGROUND"]
sca.check.result: passed

** Alert 1557493221.550752: - sca,gdpr_IV_35.7.d
2019 May 10 15:00:21 (macos10.12) any->sca
Rule: 19008 (level 3) -> 'CIS Apple macOS 10.12 Benchmark: Ensure FTP server is not running (Scored)'
{"type":"check","id":1023940218,"policy":"CIS Apple macOS 10.12 Benchmark","policy_id":"cis_apple_macos_10_12","check":{"id":13522,"title":"Ensure FTP server is not running (Scored)","description":"macOS used to have a graphical front-end to the embedded FTP server in the Operating System. FTP sharing could be enabled to allow someone on another computer to download files or information from the user's computer. Running an FTP server from a user endpoint has long been considered questionable and Apple has removed that capability from the GUI. The FTP server however is still part of the Operating System and can be easily turned on to share files and provide remote connectivity to an end user computer. FTP servers meet a specialized need to distribute files without strong authentication and should only be done through hardened servers. Cloud services or other distribution methods should be considered","rationale":"FTP servers should not be run on an end user desktop. Dedicated servers or appropriate cloud storage should be used. Open ports make it easier to exploit the computer.","remediation":"Stop the ftp Server sudo -s launchctl unload -w /System/Library/LaunchDaemons/ftp.plist","compliance":{"cis":"4.5"},"rules":["c:launchctl list -> r:ftp;"],"command":"launchctl list","result":"passed"}}
sca.type: check
sca.scan_id: 1023940218
sca.policy: CIS Apple macOS 10.12 Benchmark
sca.check.id: 13522
sca.check.title: Ensure FTP server is not running (Scored)
sca.check.description: macOS used to have a graphical front-end to the embedded FTP server in the Operating System. FTP sharing could be enabled to allow someone on another computer to download files or information from the user's computer. Running an FTP server from a user endpoint has long been considered questionable and Apple has removed that capability from the GUI. The FTP server however is still part of the Operating System and can be easily turned on to share files and provide remote connectivity to an end user computer. FTP servers meet a specialized need to distribute files without strong authentication and should only be done through hardened servers. Cloud services or other distribution methods should be considered
sca.check.rationale: FTP servers should not be run on an end user desktop. Dedicated servers or appropriate cloud storage should be used. Open ports make it easier to exploit the computer.
sca.check.remediation: Stop the ftp Server sudo -s launchctl unload -w /System/Library/LaunchDaemons/ftp.plist
sca.check.compliance.cis: 4.5
sca.check.command: ["launchctl list"]
sca.check.result: passed

** Alert 1557493221.553552: - sca,gdpr_IV_35.7.d
2019 May 10 15:00:21 (macos10.12) any->sca
Rule: 19008 (level 3) -> 'CIS Apple macOS 10.12 Benchmark: Ensure nfs server is not running (Scored)'
{"type":"check","id":1023940218,"policy":"CIS Apple macOS 10.12 Benchmark","policy_id":"cis_apple_macos_10_12","check":{"id":13523,"title":"Ensure nfs server is not running (Scored)","description":"macOS can act as an NFS fileserver. NFS sharing could be enabled to allow someone on another computer to mount shares and gain access to information from the user's computer. File sharing from a user endpoint has long been considered questionable and Apple has removed that capability from the GUI. NFSD is still part of the Operating System and can be easily turned on to export shares and provide remote connectivity to an end user computer.","rationale":"File serving should not be done from a user desktop, dedicated servers should be used.  Open ports make it easier to exploit the computer.","remediation":"Stop the NFS Server sudo nfsd disable    Remove the exported Directory listing rm /etc/export","compliance":{"cis":"4.6"},"rules":["p:nfsd;","f:/etc/exports;"],"file":"/etc/exports","process":"nfsd","result":"passed"}}
sca.type: check
sca.scan_id: 1023940218
sca.policy: CIS Apple macOS 10.12 Benchmark
sca.check.id: 13523
sca.check.title: Ensure nfs server is not running (Scored)
sca.check.description: macOS can act as an NFS fileserver. NFS sharing could be enabled to allow someone on another computer to mount shares and gain access to information from the user's computer. File sharing from a user endpoint has long been considered questionable and Apple has removed that capability from the GUI. NFSD is still part of the Operating System and can be easily turned on to export shares and provide remote connectivity to an end user computer.
sca.check.rationale: File serving should not be done from a user desktop, dedicated servers should be used.  Open ports make it easier to exploit the computer.
sca.check.remediation: Stop the NFS Server sudo nfsd disable    Remove the exported Directory listing rm /etc/export
sca.check.compliance.cis: 4.6
sca.check.file: ["/etc/exports"]
sca.check.process: ["nfsd"]
sca.check.result: passed

** Alert 1557493221.555800: - sca,gdpr_IV_35.7.d
2019 May 10 15:00:21 (macos10.12) any->sca
Rule: 19008 (level 3) -> 'CIS Apple macOS 10.12 Benchmark: Do not enable the "root" account (Scored)'
{"type":"check","id":1023940218,"policy":"CIS Apple macOS 10.12 Benchmark","policy_id":"cis_apple_macos_10_12","check":{"id":13524,"title":"Do not enable the \"root\" account (Scored)","description":"The root account is a superuser account that has access privileges to perform any actions and read/write to any file on the computer. With some Linux distros the system administrator may commonly uses the root account to perform administrative functions.","rationale":"Enabling and using the root account puts the system at risk since any successful exploit or mistake while the root account is in use could have unlimited access privileges within the system. Using the sudo command allows users to perform functions as a root user while limiting and password protecting the access privileges. By default the root account is not enabled on a macOS computer. An administrator can escalate privileges using the sudo command (use -s or -i to get a root shell).","remediation":"Open System Preferences, Uses & Groups. Click the lock icon to unlock it. In the Network Account Server section, click Join or Edit. Click Open Directory Utility. Click the lock icon to unlock it. Select the Edit menu > Disable Root User.","compliance":{"cis":"5.8"},"rules":["c:dscl . -read /Users/root AuthenticationAuthority -> !r:^No such key: AuthenticationAuthority;"],"command":"dscl . -read /Users/root AuthenticationAuthority","result":"passed"}}
sca.type: check
sca.scan_id: 1023940218
sca.policy: CIS Apple macOS 10.12 Benchmark
sca.check.id: 13524
sca.check.title: Do not enable the "root" account (Scored)
sca.check.description: The root account is a superuser account that has access privileges to perform any actions and read/write to any file on the computer. With some Linux distros the system administrator may commonly uses the root account to perform administrative functions.
sca.check.rationale: Enabling and using the root account puts the system at risk since any successful exploit or mistake while the root account is in use could have unlimited access privileges within the system. Using the sudo command allows users to perform functions as a root user while limiting and password protecting the access privileges. By default the root account is not enabled on a macOS computer. An administrator can escalate privileges using the sudo command (use -s or -i to get a root shell).
sca.check.remediation: Open System Preferences, Uses & Groups. Click the lock icon to unlock it. In the Network Account Server section, click Join or Edit. Click Open Directory Utility. Click the lock icon to unlock it. Select the Edit menu > Disable Root User.
sca.check.compliance.cis: 5.8
sca.check.command: ["dscl . -read /Users/root AuthenticationAuthority"]
sca.check.result: passed

** Alert 1557493221.558765: - sca,gdpr_IV_35.7.d
2019 May 10 15:00:21 (macos10.12) any->sca
Rule: 19008 (level 3) -> 'CIS Apple macOS 10.12 Benchmark: Disable automatic login (Scored)'
{"type":"check","id":1023940218,"policy":"CIS Apple macOS 10.12 Benchmark","policy_id":"cis_apple_macos_10_12","check":{"id":13525,"title":"Disable automatic login (Scored)","description":"The automatic login feature saves a user's system access credentials and bypasses the login screen, instead the system automatically loads to the user's desktop screen.","rationale":"Disabling automatic login decreases the likelihood of an unauthorized person gaining access to a system.","remediation":"Run the following command in Terminal: sudo defaults delete /Library/Preferences/com.apple.loginwindow autoLoginUser","compliance":{"cis":"5.9"},"rules":["c:defaults read /Library/Preferences/com.apple.loginwindow -> r:autoLoginUser;"],"command":"defaults read /Library/Preferences/com.apple.loginwindow","result":"passed"}}
sca.type: check
sca.scan_id: 1023940218
sca.policy: CIS Apple macOS 10.12 Benchmark
sca.check.id: 13525
sca.check.title: Disable automatic login (Scored)
sca.check.description: The automatic login feature saves a user's system access credentials and bypasses the login screen, instead the system automatically loads to the user's desktop screen.
sca.check.rationale: Disabling automatic login decreases the likelihood of an unauthorized person gaining access to a system.
sca.check.remediation: Run the following command in Terminal: sudo defaults delete /Library/Preferences/com.apple.loginwindow autoLoginUser
sca.check.compliance.cis: 5.9
sca.check.command: ["defaults read /Library/Preferences/com.apple.loginwindow"]
sca.check.result: passed

** Alert 1557493221.560516: - sca,gdpr_IV_35.7.d
2019 May 10 15:00:21 (macos10.12) any->sca
Rule: 19008 (level 3) -> 'CIS Apple macOS 10.12 Benchmark: System Integrity Protection status (Scored)'
{"type":"check","id":1023940218,"policy":"CIS Apple macOS 10.12 Benchmark","policy_id":"cis_apple_macos_10_12","check":{"id":13526,"title":"System Integrity Protection status (Scored)","description":"System Integrity Protection is a security feature introduced in OS X 10.11 El Capitan.  System Integrity Protection restricts access to System domain locations and restricts runtime attachment to system processes. Any attempt to attempt to inspect or attach to a system process will fail. Kernel Extensions are now restricted to /Library/Extensions and are required to be signed with a Developer ID.","rationale":"Running without System Integrity Protection on a production system runs the risk of the modification of system binaries or code injection of system processes that would otherwise be protected by SIP.","remediation":"Perform the following while booted in macOS Recovery Partition.  1. Select Terminal from the Utilities menu    2. Run the following command in Terminal: /usr/bin/csrutil enable    3. The output should be: Successfully enabled System Integrity Protection. Please restart the machine for the changes to take effect.    4. Reboot.","compliance":{"cis":"5.20"},"rules":["c:/usr/bin/csrutil status -> !r:^\\s*System Integrity Protection status: enabled;"],"command":"/usr/bin/csrutil status","result":"passed"}}
sca.type: check
sca.scan_id: 1023940218
sca.policy: CIS Apple macOS 10.12 Benchmark
sca.check.id: 13526
sca.check.title: System Integrity Protection status (Scored)
sca.check.description: System Integrity Protection is a security feature introduced in OS X 10.11 El Capitan.  System Integrity Protection restricts access to System domain locations and restricts runtime attachment to system processes. Any attempt to attempt to inspect or attach to a system process will fail. Kernel Extensions are now restricted to /Library/Extensions and are required to be signed with a Developer ID.
sca.check.rationale: Running without System Integrity Protection on a production system runs the risk of the modification of system binaries or code injection of system processes that would otherwise be protected by SIP.
sca.check.remediation: Perform the following while booted in macOS Recovery Partition.  1. Select Terminal from the Utilities menu    2. Run the following command in Terminal: /usr/bin/csrutil enable    3. The output should be: Successfully enabled System Integrity Protection. Please restart the machine for the changes to take effect.    4. Reboot.
sca.check.compliance.cis: 5.20
sca.check.command: ["/usr/bin/csrutil status"]
sca.check.result: passed

** Alert 1557493221.563313: - sca,gdpr_IV_35.7.d
2019 May 10 15:00:21 (macos10.12) any->sca
Rule: 19008 (level 3) -> 'CIS Apple macOS 10.12 Benchmark: Disable guest account login (Scored)'
{"type":"check","id":1023940218,"policy":"CIS Apple macOS 10.12 Benchmark","policy_id":"cis_apple_macos_10_12","check":{"id":13527,"title":"Disable guest account login (Scored)","description":"The guest account allows users access to the system without having to create an account or password. Guest users are unable to make setting changes, cannot remotely login to the system and all created files, caches, and passwords are deleted upon logging out.","rationale":"Disabling the guest account mitigates the risk of an untrusted user doing basic reconnaissance and possibly using privilege escalation attacks to take control of the system.","remediation":"Run the following command in Terminal: sudo defaults write /Library/Preferences/com.apple.loginwindow GuestEnabled - bool NO","compliance":{"cis":"6.1.3"},"rules":["c:defaults read /Library/Preferences/com.apple.loginwindow.plist GuestEnabled -> !r:^\\s*0$;"],"command":"defaults read /Library/Preferences/com.apple.loginwindow.plist GuestEnabled","result":"passed"}}
sca.type: check
sca.scan_id: 1023940218
sca.policy: CIS Apple macOS 10.12 Benchmark
sca.check.id: 13527
sca.check.title: Disable guest account login (Scored)
sca.check.description: The guest account allows users access to the system without having to create an account or password. Guest users are unable to make setting changes, cannot remotely login to the system and all created files, caches, and passwords are deleted upon logging out.
sca.check.rationale: Disabling the guest account mitigates the risk of an untrusted user doing basic reconnaissance and possibly using privilege escalation attacks to take control of the system.
sca.check.remediation: Run the following command in Terminal: sudo defaults write /Library/Preferences/com.apple.loginwindow GuestEnabled - bool NO
sca.check.compliance.cis: 6.1.3
sca.check.command: ["defaults read /Library/Preferences/com.apple.loginwindow.plist GuestEnabled"]
sca.check.result: passed

** Alert 1557493221.565468: - sca,gdpr_IV_35.7.d
2019 May 10 15:00:21 (macos10.12) any->sca
Rule: 19008 (level 3) -> 'CIS Apple macOS 10.12 Benchmark: Remove Guest home folder (Scored)'
{"type":"check","id":1023940218,"policy":"CIS Apple macOS 10.12 Benchmark","policy_id":"cis_apple_macos_10_12","check":{"id":13528,"title":"Remove Guest home folder (Scored)","description":"The guest account login should have been disabled, so there is no need for the legacy Guest home folder to remain in the file system. When normal user accounts are removed you have the option to archive it, leave it in place or delete. In the case of the guest folder the folder remains in place without a GUI option to remove it. If at some point in the future a Guest account is needed it will be re-created. The presence of the Guest home folder can cause automated audits to fail when looking for compliant settings within all User folders as well. Rather than ignoring the folders continued existence it is best removed.","rationale":"The Guest home folders are unneeded after the Guest account is disabled and could be used inappropriately.","remediation":"1. Run the following command in Terminal: rm -R /Users/Guest  2. Make sure there is no output","compliance":{"cis":"6.1.5"},"rules":["d:/Users/Guest;"],"result":"passed"}}
sca.type: check
sca.scan_id: 1023940218
sca.policy: CIS Apple macOS 10.12 Benchmark
sca.check.id: 13528
sca.check.title: Remove Guest home folder (Scored)
sca.check.description: The guest account login should have been disabled, so there is no need for the legacy Guest home folder to remain in the file system. When normal user accounts are removed you have the option to archive it, leave it in place or delete. In the case of the guest folder the folder remains in place without a GUI option to remove it. If at some point in the future a Guest account is needed it will be re-created. The presence of the Guest home folder can cause automated audits to fail when looking for compliant settings within all User folders as well. Rather than ignoring the folders continued existence it is best removed.
sca.check.rationale: The Guest home folders are unneeded after the Guest account is disabled and could be used inappropriately.
sca.check.remediation: 1. Run the following command in Terminal: rm -R /Users/Guest  2. Make sure there is no output
sca.check.compliance.cis: 6.1.5
sca.check.result: passed

** Alert 1557493221.567886: - sca,gdpr_IV_35.7.d
2019 May 10 15:00:21 (macos10.12) any->sca
Rule: 19009 (level 3) -> 'CIS Apple macOS 10.12 Benchmark: Turn on filename extensions (Scored)'
{"type":"check","id":1023940218,"policy":"CIS Apple macOS 10.12 Benchmark","policy_id":"cis_apple_macos_10_12","check":{"id":13529,"title":"Turn on filename extensions (Scored)","description":"A filename extension is a suffix added to a base filename that indicates the base filename's file format.","rationale":"Visible filename extensions allows the user to identify the file type and the application it is associated with which leads to quick identification of misrepresented malicious files.","remediation":"Perform the following to implement the prescribed state: 1. Select Finder 2. Select Preferences 3. Check Show all filename extensions Alternatively, use the following command: defaults write NSGlobalDomain AppleShowAllExtensions -bool true","compliance":{"cis":"6.2"},"rules":["c:defaults read NSGlobalDomain AppleShowAllExtensions -> r:^\\s*0$;"],"command":"defaults read NSGlobalDomain AppleShowAllExtensions","status":"Not applicable","reason":"Internal error running command 'defaults read NSGlobalDomain AppleShowAllExtensions'"}}
sca.type: check
sca.scan_id: 1023940218
sca.policy: CIS Apple macOS 10.12 Benchmark
sca.check.id: 13529
sca.check.title: Turn on filename extensions (Scored)
sca.check.description: A filename extension is a suffix added to a base filename that indicates the base filename's file format.
sca.check.rationale: Visible filename extensions allows the user to identify the file type and the application it is associated with which leads to quick identification of misrepresented malicious files.
sca.check.remediation: Perform the following to implement the prescribed state: 1. Select Finder 2. Select Preferences 3. Check Show all filename extensions Alternatively, use the following command: defaults write NSGlobalDomain AppleShowAllExtensions -bool true
sca.check.compliance.cis: 6.2
sca.check.command: ["defaults read NSGlobalDomain AppleShowAllExtensions"]
sca.check.status: Not applicable
sca.check.reason: Internal error running command 'defaults read NSGlobalDomain AppleShowAllExtensions'

** Alert 1557493221.570119: - sca,gdpr_IV_35.7.d
2019 May 10 15:00:21 (macos10.12) any->sca
Rule: 19009 (level 3) -> 'CIS Apple macOS 10.12 Benchmark: Disable the automatic run of safe files in Safari (Scored)'
{"type":"check","id":1023940218,"policy":"CIS Apple macOS 10.12 Benchmark","policy_id":"cis_apple_macos_10_12","check":{"id":13530,"title":"Disable the automatic run of safe files in Safari (Scored)","description":"Safari will automatically run or execute what it considers safe files. This can include installers and other files that execute on the operating system. Safari bases file safety by using a list of filetypes maintained by Apple. The list of files include text, image, video and archive formats that would be run in the context of the OS rather than the browser.","rationale":"Hackers have taken advantage of this setting via drive-by attacks. These attacks occur when a user visits a legitimate website that has been corrupted. The user unknowingly downloads a malicious file either by closing an infected pop-up or hovering over a malicious banner. An attacker can create a malicious file that will fall within Safari's safe file list that will download and execute without user input.","remediation":"Perform the following to implement the prescribed state: 1. Open Safari 2. Select Safari from the menu bar 3. Select Preferences 4. Select General 5. Uncheck Open \"safe\" files after downloading Alternatively run the following command in Terminal: defaults write com.apple.Safari AutoOpenSafeDownloads -boolean no","compliance":{"cis":"6.3"},"rules":["c:defaults read com.apple.Safari AutoOpenSafeDownloads -> r:^1$;"],"command":"defaults read com.apple.Safari AutoOpenSafeDownloads","status":"Not applicable","reason":"Internal error running command 'defaults read com.apple.Safari AutoOpenSafeDownloads'"}}
sca.type: check
sca.scan_id: 1023940218
sca.policy: CIS Apple macOS 10.12 Benchmark
sca.check.id: 13530
sca.check.title: Disable the automatic run of safe files in Safari (Scored)
sca.check.description: Safari will automatically run or execute what it considers safe files. This can include installers and other files that execute on the operating system. Safari bases file safety by using a list of filetypes maintained by Apple. The list of files include text, image, video and archive formats that would be run in the context of the OS rather than the browser.
sca.check.rationale: Hackers have taken advantage of this setting via drive-by attacks. These attacks occur when a user visits a legitimate website that has been corrupted. The user unknowingly downloads a malicious file either by closing an infected pop-up or hovering over a malicious banner. An attacker can create a malicious file that will fall within Safari's safe file list that will download and execute without user input.
sca.check.remediation: Perform the following to implement the prescribed state: 1. Open Safari 2. Select Safari from the menu bar 3. Select Preferences 4. Select General 5. Uncheck Open "safe" files after downloading Alternatively run the following command in Terminal: defaults write com.apple.Safari AutoOpenSafeDownloads -boolean no
sca.check.compliance.cis: 6.3
sca.check.command: ["defaults read com.apple.Safari AutoOpenSafeDownloads"]
sca.check.status: Not applicable
sca.check.reason: Internal error running command 'defaults read com.apple.Safari AutoOpenSafeDownloads'

** Alert 1557493228.573533: - sca,gdpr_IV_35.7.d
2019 May 10 15:00:28 (macos10.12) any->sca
Rule: 19003 (level 5) -> 'SCA summary: CIS Apple macOS 10.12 Benchmark: Score less than 80% (60)'
{"type":"summary","scan_id":1023940218,"name":"CIS Apple macOS 10.12 Benchmark","policy_id":"cis_apple_macos_10_12","file":"cis_apple_macOS_10.12.yml","description":"This document, CIS Apple macOS 10.12 Benchmark, provides prescriptive guidance for establishing a secure configuration posture for Apple macOS 10.12. This guide was tested against Apple macOS 10.12. To obtain the latest version of this guide, please visit https://benchmarks.cisecurity.org. If you have questions, comments, or have identified ways to improve this guide, please write us at feedback@cisecurity.org.","references":"https://www.cisecurity.org/cis-benchmarks/","passed":15,"failed":10,"invalid":6,"total_checks":31,"score":60.000003814697266,"start_time":1557493186,"end_time":1557493215,"hash":"72b565887f03abbcbe9bbea84778841680f7347f82fbcdb9d88e0f29998d0a64","hash_file":"464f7699dbdf00479f8930751356bf22c7168fc1b193ca7ea8235dbed2963b58","force_alert":"1"}
sca.type: summary
sca.scan_id: 1023940218
sca.policy: CIS Apple macOS 10.12 Benchmark
sca.description: This document, CIS Apple macOS 10.12 Benchmark, provides prescriptive guidance for establishing a secure configuration posture for Apple macOS 10.12. This guide was tested against Apple macOS 10.12. To obtain the latest version of this guide, please visit https://benchmarks.cisecurity.org. If you have questions, comments, or have identified ways to improve this guide, please write us at feedback@cisecurity.org.
sca.policy_id: cis_apple_macos_10_12
sca.passed: 15
sca.failed: 10
sca.invalid: 6
sca.total_checks: 31
sca.score: 60
sca.file: cis_apple_macOS_10.12.yml
sca.type: summary
sca.scan_id: 1023940218
sca.policy: CIS Apple macOS 10.12 Benchmark
sca.description: This document, CIS Apple macOS 10.12 Benchmark, provides prescriptive guidance for establishing a secure configuration posture for Apple macOS 10.12. This guide was tested against Apple macOS 10.12. To obtain the latest version of this guide, please visit https://benchmarks.cisecurity.org. If you have questions, comments, or have identified ways to improve this guide, please write us at feedback@cisecurity.org.
sca.policy_id: cis_apple_macos_10_12
sca.passed: 15
sca.failed: 10
sca.invalid: 6
sca.total_checks: 31
sca.score: 60
sca.file: cis_apple_macOS_10.12.yml
```

SQL DB:

```
select id,result,reason,status from sca_check;
13500|failed||
13501||Internal error running command 'defaults read /Library/Preferences/com.apple.SoftwareUpdate AutomaticCheckEnabled'|Not applicable
13502|failed||
13503|failed||
13504|failed||
13505|failed||
13506|passed||
13507|passed||
13508|passed||
13509|failed||
13510|passed||
13511|passed||
13512|failed||
13513|passed||
13514|failed||
13515|failed||
13516||Internal error running command 'defaults read -app Terminal SecureKeyboardEntry'|Not applicable
13517||Internal error running command 'java -version'|Not applicable
13518|passed||
13519|failed||
13520||Internal error running command 'defaults read /Library/Preferences/com.apple.mDNSResponder.plist NoMulticastAdvertisements'|Not applicable
13521|passed||
13522|passed||
13523|passed||
13524|passed||
13525|passed||
13526|passed||
13527|passed||
13528|passed||
13529||Internal error running command 'defaults read NSGlobalDomain AppleShowAllExtensions'|Not applicable
13530||Internal error running command 'defaults read com.apple.Safari AutoOpenSafeDownloads'|Not applicable
```

## Test 10.11

```
** Alert 1557496144.607839: - sca,gdpr_IV_35.7.d
2019 May 10 15:49:04 (macos1011) any->sca
Rule: 19007 (level 7) -> 'CIS Apple OSX 10.11 Benchmark: Enable app update installs (Scored)'
{"type":"check","id":1813888922,"policy":"CIS Apple OSX 10.11 Benchmark","policy_id":"cis_apple_macos_10_11","check":{"id":3002,"title":"Enable app update installs (Scored)","description":"Ensure that application updates are installed after they are available from Apple. These updates do not require reboots or admin privileges for end users.","rationale":"Patches need to be applied in a timely manner to reduce the risk of vulnerabilities being exploited","remediation":"Open a terminal session and enter the following command to enable the auto update feature: sudo defaults write /Library/Preferences/com.apple.commerce AutoUpdate -bool TRUE    The remediation requires a log out and log in to show in the GUI. Please note that.","compliance":{"cis":"1.3"},"rules":["c:defaults read /Library/Preferences/com.apple.commerce AutoUpdate -> r:^\\s*0$;"],"command":"defaults read /Library/Preferences/com.apple.commerce AutoUpdate","result":"failed"}}
sca.type: check
sca.scan_id: 1813888922
sca.policy: CIS Apple OSX 10.11 Benchmark
sca.check.id: 3002
sca.check.title: Enable app update installs (Scored)
sca.check.description: Ensure that application updates are installed after they are available from Apple. These updates do not require reboots or admin privileges for end users.
sca.check.rationale: Patches need to be applied in a timely manner to reduce the risk of vulnerabilities being exploited
sca.check.remediation: Open a terminal session and enter the following command to enable the auto update feature: sudo defaults write /Library/Preferences/com.apple.commerce AutoUpdate -bool TRUE    The remediation requires a log out and log in to show in the GUI. Please note that.
sca.check.compliance.cis: 1.3
sca.check.command: ["defaults read /Library/Preferences/com.apple.commerce AutoUpdate"]
sca.check.result: failed

** Alert 1557496144.609856: - sca,gdpr_IV_35.7.d
2019 May 10 15:49:04 (macos1011) any->sca
Rule: 19007 (level 7) -> 'CIS Apple OSX 10.11 Benchmark: Verify all Apple provided software is current (Scored)'
{"type":"check","id":1813888922,"policy":"CIS Apple OSX 10.11 Benchmark","policy_id":"cis_apple_macos_10_11","check":{"id":3000,"title":"Verify all Apple provided software is current (Scored)","description":"Software vendors release security patches and software updates for their products when security vulnerabilities are discovered. There is no simple way to complete this action without a network connection to an Apple software repository. Please ensure appropriate access for this control. This check is only for what Apple provides through software update.","rationale":"It is important that these updates be applied in a timely manner to prevent unauthorized persons from exploiting the identified vulnerabilities.","remediation":"1. In Terminal, run the following: softwareupdate -l  2. In Terminal, run the following for any packages that show up in step 1: sudo softwareupdate -i packagename","compliance":{"cis":"1.1"},"rules":["c:softwareupdate -l -> !r:^\\s*No new software available;"],"command":"softwareupdate -l","result":"failed"}}
sca.type: check
sca.scan_id: 1813888922
sca.policy: CIS Apple OSX 10.11 Benchmark
sca.check.id: 3000
sca.check.title: Verify all Apple provided software is current (Scored)
sca.check.description: Software vendors release security patches and software updates for their products when security vulnerabilities are discovered. There is no simple way to complete this action without a network connection to an Apple software repository. Please ensure appropriate access for this control. This check is only for what Apple provides through software update.
sca.check.rationale: It is important that these updates be applied in a timely manner to prevent unauthorized persons from exploiting the identified vulnerabilities.
sca.check.remediation: 1. In Terminal, run the following: softwareupdate -l  2. In Terminal, run the following for any packages that show up in step 1: sudo softwareupdate -i packagename
sca.check.compliance.cis: 1.1
sca.check.command: ["softwareupdate -l"]
sca.check.result: failed

** Alert 1557496144.612113: - sca,gdpr_IV_35.7.d
2019 May 10 15:49:04 (macos1011) any->sca
Rule: 19009 (level 3) -> 'CIS Apple OSX 10.11 Benchmark: Enable Auto Update (Scored)'
{"type":"check","id":1813888922,"policy":"CIS Apple OSX 10.11 Benchmark","policy_id":"cis_apple_macos_10_11","check":{"id":3001,"title":"Enable Auto Update (Scored)","description":"Auto Update verifies that your system has the newest security patches and software updates. If \"Automatically check for updates\" is not selected background updates for new malware definition files from Apple for XProtect and Gatekeeper will not occur.","rationale":"It is important that a system has the newest updates applied so as to prevent unauthorized persons from exploiting identified vulnerabilities.","remediation":"Open a terminal session and enter the following command to enable the auto update feature: sudo defaults write /Library/Preferences/com.apple.SoftwareUpdate AutomaticCheckEnabled -int 1","compliance":{"cis":"1.2"},"rules":["c:defaults read /Library/Preferences/com.apple.SoftwareUpdate AutomaticCheckEnabled -> r:^\\s*0$;"],"references":"https://macops.ca/os-x-admins-your-clients-are-not-getting-background-security-updates/,https://derflounder.wordpress.com/2014/12/17/forcing-xprotect-blacklist-updates-on-mavericks-and-yosemite/","command":"defaults read /Library/Preferences/com.apple.SoftwareUpdate AutomaticCheckEnabled","status":"Not applicable","reason":"Internal error running command 'defaults read /Library/Preferences/com.apple.SoftwareUpdate AutomaticCheckEnabled'"}}
sca.type: check
sca.scan_id: 1813888922
sca.policy: CIS Apple OSX 10.11 Benchmark
sca.check.id: 3001
sca.check.title: Enable Auto Update (Scored)
sca.check.description: Auto Update verifies that your system has the newest security patches and software updates. If "Automatically check for updates" is not selected background updates for new malware definition files from Apple for XProtect and Gatekeeper will not occur.
sca.check.rationale: It is important that a system has the newest updates applied so as to prevent unauthorized persons from exploiting identified vulnerabilities.
sca.check.remediation: Open a terminal session and enter the following command to enable the auto update feature: sudo defaults write /Library/Preferences/com.apple.SoftwareUpdate AutomaticCheckEnabled -int 1
sca.check.compliance.cis: 1.2
sca.check.references: https://macops.ca/os-x-admins-your-clients-are-not-getting-background-security-updates/,https://derflounder.wordpress.com/2014/12/17/forcing-xprotect-blacklist-updates-on-mavericks-and-yosemite/
sca.check.command: ["defaults read /Library/Preferences/com.apple.SoftwareUpdate AutomaticCheckEnabled"]
sca.check.status: Not applicable
sca.check.reason: Internal error running command 'defaults read /Library/Preferences/com.apple.SoftwareUpdate AutomaticCheckEnabled'

** Alert 1557496144.614993: - sca,gdpr_IV_35.7.d
2019 May 10 15:49:04 (macos1011) any->sca
Rule: 19007 (level 7) -> 'CIS Apple OSX 10.11 Benchmark: Enable OS X update installs (Scored)'
{"type":"check","id":1813888922,"policy":"CIS Apple OSX 10.11 Benchmark","policy_id":"cis_apple_macos_10_11","check":{"id":3004,"title":"Enable OS X update installs (Scored)","description":"Ensure that OS X updates are installed after they are available from Apple. This setting enables OS X updates to be automatically installed. Some environments will want to approve and test updates before they are delivered. It is best practice to test first where updates can and have caused disruptions to operations. Automatic updates should be turned off where changes are tightly controlled and there are mature testing and approval processes. Automatic updates should not be turned off so the admin can call the users first to let them know it's ok to install. A dependable repeatable process involving a patch agent or remote management tool should be in place before auto-updates are turned off.","rationale":"Patches need to be applied in a timely manner to reduce the risk of vulnerabilities being exploited","remediation":"Open a terminal session and enter the following command to enable install system data files and security updates: sudo defaults write /Library/Preferences/com.apple.commerce AutoUpdateRestartRequired -bool TRUE","compliance":{"cis":"1.5"},"rules":["c:defaults read /Library/Preferences/com.apple.commerce AutoUpdateRestartRequired -> r:^\\s*0$;"],"command":"defaults read /Library/Preferences/com.apple.commerce AutoUpdateRestartRequired","result":"failed"}}
sca.type: check
sca.scan_id: 1813888922
sca.policy: CIS Apple OSX 10.11 Benchmark
sca.check.id: 3004
sca.check.title: Enable OS X update installs (Scored)
sca.check.description: Ensure that OS X updates are installed after they are available from Apple. This setting enables OS X updates to be automatically installed. Some environments will want to approve and test updates before they are delivered. It is best practice to test first where updates can and have caused disruptions to operations. Automatic updates should be turned off where changes are tightly controlled and there are mature testing and approval processes. Automatic updates should not be turned off so the admin can call the users first to let them know it's ok to install. A dependable repeatable process involving a patch agent or remote management tool should be in place before auto-updates are turned off.
sca.check.rationale: Patches need to be applied in a timely manner to reduce the risk of vulnerabilities being exploited
sca.check.remediation: Open a terminal session and enter the following command to enable install system data files and security updates: sudo defaults write /Library/Preferences/com.apple.commerce AutoUpdateRestartRequired -bool TRUE
sca.check.compliance.cis: 1.5
sca.check.command: ["defaults read /Library/Preferences/com.apple.commerce AutoUpdateRestartRequired"]
sca.check.result: failed

** Alert 1557496144.618056: - sca,gdpr_IV_35.7.d
2019 May 10 15:49:04 (macos1011) any->sca
Rule: 19008 (level 3) -> 'CIS Apple OSX 10.11 Benchmark: Enable system data files and security update installs (Scored)'
{"type":"check","id":1813888922,"policy":"CIS Apple OSX 10.11 Benchmark","policy_id":"cis_apple_macos_10_11","check":{"id":3003,"title":"Enable system data files and security update installs (Scored)","description":"Ensure that system and security updates are installed after they are available from Apple.  This setting enables definition updates for XProtect and Gatekeeper, with this setting in place new malware and adware that Apple has added to the list of malware or untrusted software will not execute. These updates do not require reboots or end user admin rights.","rationale":"Patches need to be applied in a timely manner to reduce the risk of vulnerabilities being exploited","remediation":"Open a terminal session and enter the following command to enable install system data files and security updates: sudo defaults write /Library/Preferences/com.apple.SoftwareUpdate ConfigDataInstall -bool true && sudo defaults write /Library/Preferences/com.apple.SoftwareUpdate CriticalUpdateInstall -bool true","compliance":{"cis":"1.4"},"rules":["c:defaults read /Library/Preferences/com.apple.SoftwareUpdate -> IN r:^\\s*ConfigDataInstall\\s*= && !r:\\s*1;","c:defaults read /Library/Preferences/com.apple.SoftwareUpdate -> IN r:^\\s*CriticalUpdateInstall\\s*= && !r:\\s*1;"],"references":"https://www.thesafemac.com/tag/xprotect/,https://support.apple.com/en-us/HT202491","command":"defaults read /Library/Preferences/com.apple.SoftwareUpdate","result":"passed"}}
sca.type: check
sca.scan_id: 1813888922
sca.policy: CIS Apple OSX 10.11 Benchmark
sca.check.id: 3003
sca.check.title: Enable system data files and security update installs (Scored)
sca.check.description: Ensure that system and security updates are installed after they are available from Apple.  This setting enables definition updates for XProtect and Gatekeeper, with this setting in place new malware and adware that Apple has added to the list of malware or untrusted software will not execute. These updates do not require reboots or end user admin rights.
sca.check.rationale: Patches need to be applied in a timely manner to reduce the risk of vulnerabilities being exploited
sca.check.remediation: Open a terminal session and enter the following command to enable install system data files and security updates: sudo defaults write /Library/Preferences/com.apple.SoftwareUpdate ConfigDataInstall -bool true && sudo defaults write /Library/Preferences/com.apple.SoftwareUpdate CriticalUpdateInstall -bool true
sca.check.compliance.cis: 1.4
sca.check.references: https://www.thesafemac.com/tag/xprotect/,https://support.apple.com/en-us/HT202491
sca.check.command: ["defaults read /Library/Preferences/com.apple.SoftwareUpdate"]
sca.check.result: passed

** Alert 1557496144.621000: - sca,gdpr_IV_35.7.d
2019 May 10 15:49:04 (macos1011) any->sca
Rule: 19007 (level 7) -> 'CIS Apple OSX 10.11 Benchmark: Restrict NTP server to loopback interface (Scored)'
{"type":"check","id":1813888922,"policy":"CIS Apple OSX 10.11 Benchmark","policy_id":"cis_apple_macos_10_11","check":{"id":3007,"title":"Restrict NTP server to loopback interface (Scored)","description":"The Apple System Preference setting to \"Set date and time automatically\" enables both an NTP client that can synchronize the time from known time server(s) and an open listening NTP server that can be used by any other computer that can connect to port 123 on the time syncing computer. This open listening service can allow for both exploits of future NTP vulnerabilities and allow for open ports that can be used for fingerprinting to target exploits. Access to this port should be restricted.  Editing the /etc/ntp-restrict.conf file by adding a control on the loopback interface limits external access.","rationale":"Mobile workstations on untrusted networks should not have open listening services available to other nodes on the network.","remediation":"1. Run the following command in Terminal:  sudo vim /etc/ntp-restrict.conf  2. Add the following lines to the file: restrict lo interface ignore wildcard interface listen lo","compliance":{"cis":"2.2.3"},"rules":["f:/etc/ntp-restrict.conf -> !r:restrict lo;"],"file":"/etc/ntp-restrict.conf","result":"failed"}}
sca.type: check
sca.scan_id: 1813888922
sca.policy: CIS Apple OSX 10.11 Benchmark
sca.check.id: 3007
sca.check.title: Restrict NTP server to loopback interface (Scored)
sca.check.description: The Apple System Preference setting to "Set date and time automatically" enables both an NTP client that can synchronize the time from known time server(s) and an open listening NTP server that can be used by any other computer that can connect to port 123 on the time syncing computer. This open listening service can allow for both exploits of future NTP vulnerabilities and allow for open ports that can be used for fingerprinting to target exploits. Access to this port should be restricted.  Editing the /etc/ntp-restrict.conf file by adding a control on the loopback interface limits external access.
sca.check.rationale: Mobile workstations on untrusted networks should not have open listening services available to other nodes on the network.
sca.check.remediation: 1. Run the following command in Terminal:  sudo vim /etc/ntp-restrict.conf  2. Add the following lines to the file: restrict lo interface ignore wildcard interface listen lo
sca.check.compliance.cis: 2.2.3
sca.check.file: ["/etc/ntp-restrict.conf"]
sca.check.result: failed

** Alert 1557496144.623719: - sca,gdpr_IV_35.7.d
2019 May 10 15:49:04 (macos1011) any->sca
Rule: 19008 (level 3) -> 'CIS Apple OSX 10.11 Benchmark: Disable Remote Apple Events (Scored)'
{"type":"check","id":1813888922,"policy":"CIS Apple OSX 10.11 Benchmark","policy_id":"cis_apple_macos_10_11","check":{"id":3008,"title":"Disable Remote Apple Events (Scored)","description":"Apple Events is a technology that allows one program to communicate with other programs. Remote Apple Events allows a program on one computer to communicate with a program on a different computer.","rationale":"Disabling Remote Apple Events mitigates the risk of an unauthorized program gaining access to the system.","remediation":"Run the following command in Terminal: sudo systemsetup -setremoteappleevents off","compliance":{"cis":"2.4.1"},"rules":["c:systemsetup -getremoteappleevents -> !r:^Remote Apple Events:\\s*Off;"],"command":"systemsetup -getremoteappleevents","result":"passed"}}
sca.type: check
sca.scan_id: 1813888922
sca.policy: CIS Apple OSX 10.11 Benchmark
sca.check.id: 3008
sca.check.title: Disable Remote Apple Events (Scored)
sca.check.description: Apple Events is a technology that allows one program to communicate with other programs. Remote Apple Events allows a program on one computer to communicate with a program on a different computer.
sca.check.rationale: Disabling Remote Apple Events mitigates the risk of an unauthorized program gaining access to the system.
sca.check.remediation: Run the following command in Terminal: sudo systemsetup -setremoteappleevents off
sca.check.compliance.cis: 2.4.1
sca.check.command: ["systemsetup -getremoteappleevents"]
sca.check.result: passed

** Alert 1557496144.625412: - sca,gdpr_IV_35.7.d
2019 May 10 15:49:04 (macos1011) any->sca
Rule: 19007 (level 7) -> 'CIS Apple OSX 10.11 Benchmark: Turn off Bluetooth "Discoverable" mode when not pairing devices (Scored)'
{"type":"check","id":1813888922,"policy":"CIS Apple OSX 10.11 Benchmark","policy_id":"cis_apple_macos_10_11","check":{"id":3005,"title":"Turn off Bluetooth \"Discoverable\" mode when not pairing devices (Scored)","description":"When Bluetooth is set to discoverable mode, the Mac sends a signal indicating that it's available to pair with another Bluetooth device. When a device is \"discoverable\" it broadcasts information about itself and its location. Starting with OS X 10.9 Discoverable mode is enabled while the Bluetooth System Preference is open and turned off once closed.  Systems that have the Bluetooth System Preference open at the time of audit will show as Discoverable.","rationale":"When in the discoverable state an unauthorized user could gain access to the system by pairing it with a remote device.","remediation":"Starting with OS X (10.9) Bluetooth is only set to Discoverable when the Bluetooth System Preference is selected. To ensure that the computer is not Discoverable do not leave that preference open.","compliance":{"cis":"2.1.2"},"rules":["c:/usr/sbin/system_profiler SPBluetoothDataType -> !r:^\\s*[Dd]iscoverable:\\s*Off;"],"command":"/usr/sbin/system_profiler SPBluetoothDataType","result":"failed"}}
sca.type: check
sca.scan_id: 1813888922
sca.policy: CIS Apple OSX 10.11 Benchmark
sca.check.id: 3005
sca.check.title: Turn off Bluetooth "Discoverable" mode when not pairing devices (Scored)
sca.check.description: When Bluetooth is set to discoverable mode, the Mac sends a signal indicating that it's available to pair with another Bluetooth device. When a device is "discoverable" it broadcasts information about itself and its location. Starting with OS X 10.9 Discoverable mode is enabled while the Bluetooth System Preference is open and turned off once closed.  Systems that have the Bluetooth System Preference open at the time of audit will show as Discoverable.
sca.check.rationale: When in the discoverable state an unauthorized user could gain access to the system by pairing it with a remote device.
sca.check.remediation: Starting with OS X (10.9) Bluetooth is only set to Discoverable when the Bluetooth System Preference is selected. To ensure that the computer is not Discoverable do not leave that preference open.
sca.check.compliance.cis: 2.1.2
sca.check.command: ["/usr/sbin/system_profiler SPBluetoothDataType"]
sca.check.result: failed

** Alert 1557496144.628031: - sca,gdpr_IV_35.7.d
2019 May 10 15:49:04 (macos1011) any->sca
Rule: 19008 (level 3) -> 'CIS Apple OSX 10.11 Benchmark: Enable "Set time and date automatically" (Not Scored)'
{"type":"check","id":1813888922,"policy":"CIS Apple OSX 10.11 Benchmark","policy_id":"cis_apple_macos_10_11","check":{"id":3006,"title":"Enable \"Set time and date automatically\" (Not Scored)","description":"Correct date and time settings are required for authentication protocols, file creation, modification dates and log entries. Apple's automatic time update solution will enable an NTP server that is not controlled by the Application Firewall. Turning on \"Set time and date automatically\" allows other computers to connect to set their time and allows for exploit attempts against ntpd. It also allows for more accurate network detection and OS fingerprinting.","rationale":"Kerberos may not operate correctly if the time on the Mac is off by more than 5 minutes.  This in turn can affect Apple's single sign-on feature, Active Directory logons, and other features.","remediation":"Run the following commands: sudo systemsetup -setnetworktimeserver <timeserver>    sudo systemsetup -setusingnetworktime on","compliance":{"cis":"2.2.1"},"rules":["c:systemsetup -getusingnetworktime -> !r:^\\s*Network Time:\\s*On;"],"command":"systemsetup -getusingnetworktime","result":"passed"}}
sca.type: check
sca.scan_id: 1813888922
sca.policy: CIS Apple OSX 10.11 Benchmark
sca.check.id: 3006
sca.check.title: Enable "Set time and date automatically" (Not Scored)
sca.check.description: Correct date and time settings are required for authentication protocols, file creation, modification dates and log entries. Apple's automatic time update solution will enable an NTP server that is not controlled by the Application Firewall. Turning on "Set time and date automatically" allows other computers to connect to set their time and allows for exploit attempts against ntpd. It also allows for more accurate network detection and OS fingerprinting.
sca.check.rationale: Kerberos may not operate correctly if the time on the Mac is off by more than 5 minutes.  This in turn can affect Apple's single sign-on feature, Active Directory logons, and other features.
sca.check.remediation: Run the following commands: sudo systemsetup -setnetworktimeserver <timeserver>    sudo systemsetup -setusingnetworktime on
sca.check.compliance.cis: 2.2.1
sca.check.command: ["systemsetup -getusingnetworktime"]
sca.check.result: passed

** Alert 1557496144.630550: - sca,gdpr_IV_35.7.d
2019 May 10 15:49:04 (macos1011) any->sca
Rule: 19008 (level 3) -> 'CIS Apple OSX 10.11 Benchmark: Disable Printer Sharing (Scored)'
{"type":"check","id":1813888922,"policy":"CIS Apple OSX 10.11 Benchmark","policy_id":"cis_apple_macos_10_11","check":{"id":3009,"title":"Disable Printer Sharing (Scored)","description":"By enabling Printer sharing the computer is set up as a print server to accept print jobs from other computers. Dedicated print servers or direct IP printing should be used instead.","rationale":"Disabling Printer Sharing mitigates the risk of attackers attempting to exploit the print server to gain access to the system.","remediation":"Perform the following to implement the prescribed state: 1. Open System Preferences 2. Select Sharing 3. Uncheck Printer Sharing","compliance":{"cis":"2.4.4"},"rules":["c:system_profiler SPPrintersDataType -> r:Shared:\\s*Yes;"],"command":"system_profiler SPPrintersDataType","result":"passed"}}
sca.type: check
sca.scan_id: 1813888922
sca.policy: CIS Apple OSX 10.11 Benchmark
sca.check.id: 3009
sca.check.title: Disable Printer Sharing (Scored)
sca.check.description: By enabling Printer sharing the computer is set up as a print server to accept print jobs from other computers. Dedicated print servers or direct IP printing should be used instead.
sca.check.rationale: Disabling Printer Sharing mitigates the risk of attackers attempting to exploit the print server to gain access to the system.
sca.check.remediation: Perform the following to implement the prescribed state: 1. Open System Preferences 2. Select Sharing 3. Uncheck Printer Sharing
sca.check.compliance.cis: 2.4.4
sca.check.command: ["system_profiler SPPrintersDataType"]
sca.check.result: passed

** Alert 1557496144.632325: - sca,gdpr_IV_35.7.d
2019 May 10 15:49:04 (macos1011) any->sca
Rule: 19007 (level 7) -> 'CIS Apple OSX 10.11 Benchmark: Disable Remote Login (Scored)'
{"type":"check","id":1813888922,"policy":"CIS Apple OSX 10.11 Benchmark","policy_id":"cis_apple_macos_10_11","check":{"id":3010,"title":"Disable Remote Login (Scored)","description":"Remote Login allows an interactive terminal connection to a computer.","rationale":"Disabling Remote Login mitigates the risk of an unauthorized person gaining access to the system via Secure Shell (SSH). While SSH is an industry standard to connect to posix servers, the scope of the benchmark is for Apple OSX clients, not servers.","remediation":"Run the following command in Terminal: sudo systemsetup -setremotelogin off","compliance":{"cis":"2.4.5"},"rules":["c:systemsetup -getremotelogin -> r:^Remote Login:\\s*On;"],"command":"systemsetup -getremotelogin","result":"failed"}}
sca.type: check
sca.scan_id: 1813888922
sca.policy: CIS Apple OSX 10.11 Benchmark
sca.check.id: 3010
sca.check.title: Disable Remote Login (Scored)
sca.check.description: Remote Login allows an interactive terminal connection to a computer.
sca.check.rationale: Disabling Remote Login mitigates the risk of an unauthorized person gaining access to the system via Secure Shell (SSH). While SSH is an industry standard to connect to posix servers, the scope of the benchmark is for Apple OSX clients, not servers.
sca.check.remediation: Run the following command in Terminal: sudo systemsetup -setremotelogin off
sca.check.compliance.cis: 2.4.5
sca.check.command: ["systemsetup -getremotelogin"]
sca.check.result: failed

** Alert 1557496144.633992: - sca,gdpr_IV_35.7.d
2019 May 10 15:49:04 (macos1011) any->sca
Rule: 19008 (level 3) -> 'CIS Apple OSX 10.11 Benchmark: Disable File Sharing (Scored)'
{"type":"check","id":1813888922,"policy":"CIS Apple OSX 10.11 Benchmark","policy_id":"cis_apple_macos_10_11","check":{"id":3011,"title":"Disable File Sharing (Scored)","description":"Apple's File Sharing uses a combination of SMB (Windows sharing) and AFP (Mac sharing)","rationale":"By disabling file sharing, the remote attack surface and risk of unauthorized access to files stored on the system is reduced.","remediation":"Run the following command in Terminal to turn off AFP from the command line: sudo launchctl unload -w /System/Library/LaunchDaemons/com.apple.AppleFileServer.plist  - Run the following command in Terminal to turn off SMB sharing from the CLI:  sudo launchctl unload -w /System/Library/LaunchDaemons/com.apple.smbd.plist","compliance":{"cis":"2.4.8"},"rules":["c:launchctl list -> r:AppleFileServer;"],"command":"launchctl list","result":"passed"}}
sca.type: check
sca.scan_id: 1813888922
sca.policy: CIS Apple OSX 10.11 Benchmark
sca.check.id: 3011
sca.check.title: Disable File Sharing (Scored)
sca.check.description: Apple's File Sharing uses a combination of SMB (Windows sharing) and AFP (Mac sharing)
sca.check.rationale: By disabling file sharing, the remote attack surface and risk of unauthorized access to files stored on the system is reduced.
sca.check.remediation: Run the following command in Terminal to turn off AFP from the command line: sudo launchctl unload -w /System/Library/LaunchDaemons/com.apple.AppleFileServer.plist  - Run the following command in Terminal to turn off SMB sharing from the CLI:  sudo launchctl unload -w /System/Library/LaunchDaemons/com.apple.smbd.plist
sca.check.compliance.cis: 2.4.8
sca.check.command: ["launchctl list"]
sca.check.result: passed

** Alert 1557496144.635891: - sca,gdpr_IV_35.7.d
2019 May 10 15:49:04 (macos1011) any->sca
Rule: 19008 (level 3) -> 'CIS Apple OSX 10.11 Benchmark: Disable "Wake for network access" (Scored)'
{"type":"check","id":1813888922,"policy":"CIS Apple OSX 10.11 Benchmark","policy_id":"cis_apple_macos_10_11","check":{"id":3012,"title":"Disable \"Wake for network access\" (Scored)","description":"This feature allows other users to be able to access your computer’s shared resources, such as shared printers or iTunes playlists, even when your computer is in sleep mode","rationale":"Disabling this feature mitigates the risk of an attacker remotely waking the system and gaining access.","remediation":"Run the following command in Terminal:  sudo pmset -a womp 0   Note: The -c flag means \"wall power.\" Different settings must be used for other power sources.","compliance":{"cis":"2.5.1"},"rules":["c:pmset -g -> r:^\\s*womp\\s+1$;","c:pmset -b -g -> r:^\\s*womp\\s+1$;"],"command":"pmset -g,pmset -b -g","result":"passed"}}
sca.type: check
sca.scan_id: 1813888922
sca.policy: CIS Apple OSX 10.11 Benchmark
sca.check.id: 3012
sca.check.title: Disable "Wake for network access" (Scored)
sca.check.description: This feature allows other users to be able to access your computer’s shared resources, such as shared printers or iTunes playlists, even when your computer is in sleep mode
sca.check.rationale: Disabling this feature mitigates the risk of an attacker remotely waking the system and gaining access.
sca.check.remediation: Run the following command in Terminal:  sudo pmset -a womp 0   Note: The -c flag means "wall power." Different settings must be used for other power sources.
sca.check.compliance.cis: 2.5.1
sca.check.command: ["pmset -g", "pmset -b -g"]
sca.check.result: passed

** Alert 1557496144.637686: - sca,gdpr_IV_35.7.d
2019 May 10 15:49:04 (macos1011) any->sca
Rule: 19007 (level 7) -> 'CIS Apple OSX 10.11 Benchmark: Enable FileVault (Scored)'
{"type":"check","id":1813888922,"policy":"CIS Apple OSX 10.11 Benchmark","policy_id":"cis_apple_macos_10_11","check":{"id":3013,"title":"Enable FileVault (Scored)","description":"FileVault secures a system's data by automatically encrypting its boot volume and requiring a password or recovery key to access it.","rationale":"Encrypting sensitive data minimizes the likelihood of unauthorized users gaining access to it.","remediation":"Perform the following to implement the prescribed state: 1. Open System Preferences 2. Select Security & Privacy 3. Select FileVault 4. Select Turn on FileVault","compliance":{"cis":"2.6.1"},"rules":["c:diskutil cs list -> r:[Ee]ncryption [Ss]tatus: -> !r:[Uu]nlocked;","c:diskutil cs list -> !r:[Ee]ncryption [Tt]ype:;"],"command":"diskutil cs list","result":"failed"}}
sca.type: check
sca.scan_id: 1813888922
sca.policy: CIS Apple OSX 10.11 Benchmark
sca.check.id: 3013
sca.check.title: Enable FileVault (Scored)
sca.check.description: FileVault secures a system's data by automatically encrypting its boot volume and requiring a password or recovery key to access it.
sca.check.rationale: Encrypting sensitive data minimizes the likelihood of unauthorized users gaining access to it.
sca.check.remediation: Perform the following to implement the prescribed state: 1. Open System Preferences 2. Select Security & Privacy 3. Select FileVault 4. Select Turn on FileVault
sca.check.compliance.cis: 2.6.1
sca.check.command: ["diskutil cs list"]
sca.check.result: failed

** Alert 1557496144.639367: - sca,gdpr_IV_35.7.d
2019 May 10 15:49:04 (macos1011) any->sca
Rule: 19008 (level 3) -> 'CIS Apple OSX 10.11 Benchmark: Enable Gatekeeper (Scored)'
{"type":"check","id":1813888922,"policy":"CIS Apple OSX 10.11 Benchmark","policy_id":"cis_apple_macos_10_11","check":{"id":3014,"title":"Enable Gatekeeper (Scored)","description":"Gatekeeper is Apple's application white-listing control that restricts downloaded applications from launching. It functions as a control to limit applications from unverified sources from running without authorization.","rationale":"Disallowing unsigned software will reduce the risk of unauthorized or malicious applications from running on the system.","remediation":"Run the following command in Terminal: sudo spctl --master-enable","compliance":{"cis":"2.6.2"},"rules":["c:spctl --status -> !r:^assessments enabled;"],"command":"spctl --status","result":"passed"}}
sca.type: check
sca.scan_id: 1813888922
sca.policy: CIS Apple OSX 10.11 Benchmark
sca.check.id: 3014
sca.check.title: Enable Gatekeeper (Scored)
sca.check.description: Gatekeeper is Apple's application white-listing control that restricts downloaded applications from launching. It functions as a control to limit applications from unverified sources from running without authorization.
sca.check.rationale: Disallowing unsigned software will reduce the risk of unauthorized or malicious applications from running on the system.
sca.check.remediation: Run the following command in Terminal: sudo spctl --master-enable
sca.check.compliance.cis: 2.6.2
sca.check.command: ["spctl --status"]
sca.check.result: passed

** Alert 1557496144.641007: - sca,gdpr_IV_35.7.d
2019 May 10 15:49:04 (macos1011) any->sca
Rule: 19007 (level 7) -> 'CIS Apple OSX 10.11 Benchmark: Enable Firewall (Scored)'
{"type":"check","id":1813888922,"policy":"CIS Apple OSX 10.11 Benchmark","policy_id":"cis_apple_macos_10_11","check":{"id":3015,"title":"Enable Firewall (Scored)","description":"A firewall is a piece of software that blocks unwanted incoming connections to a system.  Apple has posted general documentation about the application firewall.","rationale":"A firewall minimizes the threat of unauthorized users from gaining access to your system while connected to a network or the Internet.","remediation":"Run the following command in Terminal: defaults write /Library/Preferences/com.apple.alf globalstate - int <value>    Where <value> is:   1 = on for specific services   2 = on for essential services","compliance":{"cis":"2.6.3"},"rules":["c:defaults read /Library/Preferences/com.apple.alf globalstate -> !r:^\\s*1$;","c:defaults read /Library/Preferences/com.apple.alf globalstate -> !r:^\\s*2$;"],"references":"https://support.apple.com/en-us/HT201642","command":"defaults read /Library/Preferences/com.apple.alf globalstate","result":"failed"}}
sca.type: check
sca.scan_id: 1813888922
sca.policy: CIS Apple OSX 10.11 Benchmark
sca.check.id: 3015
sca.check.title: Enable Firewall (Scored)
sca.check.description: A firewall is a piece of software that blocks unwanted incoming connections to a system.  Apple has posted general documentation about the application firewall.
sca.check.rationale: A firewall minimizes the threat of unauthorized users from gaining access to your system while connected to a network or the Internet.
sca.check.remediation: Run the following command in Terminal: defaults write /Library/Preferences/com.apple.alf globalstate - int <value>    Where <value> is:   1 = on for specific services   2 = on for essential services
sca.check.compliance.cis: 2.6.3
sca.check.references: https://support.apple.com/en-us/HT201642
sca.check.command: ["defaults read /Library/Preferences/com.apple.alf globalstate"]
sca.check.result: failed

** Alert 1557496144.643143: - sca,gdpr_IV_35.7.d
2019 May 10 15:49:04 (macos1011) any->sca
Rule: 19007 (level 7) -> 'CIS Apple OSX 10.11 Benchmark: Enable Firewall Stealth Mode (Scored)'
{"type":"check","id":1813888922,"policy":"CIS Apple OSX 10.11 Benchmark","policy_id":"cis_apple_macos_10_11","check":{"id":3016,"title":"Enable Firewall Stealth Mode (Scored)","description":"While in Stealth mode the computer will not respond to unsolicited probes, dropping that traffic.","rationale":"Stealth mode on the firewall minimizes the threat of system discovery tools while connected to a network or the Internet.","remediation":"Run the following command in Terminal: sudo /usr/libexec/ApplicationFirewall/socketfilterfw --setstealthmode on","compliance":{"cis":"2.6.4"},"rules":["c:/usr/libexec/ApplicationFirewall/socketfilterfw --getstealthmode -> !r:^\\s*Stealth mode enabled;"],"references":"https://support.apple.com/en-us/HT201642","command":"/usr/libexec/ApplicationFirewall/socketfilterfw --getstealthmode","result":"failed"}}
sca.type: check
sca.scan_id: 1813888922
sca.policy: CIS Apple OSX 10.11 Benchmark
sca.check.id: 3016
sca.check.title: Enable Firewall Stealth Mode (Scored)
sca.check.description: While in Stealth mode the computer will not respond to unsolicited probes, dropping that traffic.
sca.check.rationale: Stealth mode on the firewall minimizes the threat of system discovery tools while connected to a network or the Internet.
sca.check.remediation: Run the following command in Terminal: sudo /usr/libexec/ApplicationFirewall/socketfilterfw --setstealthmode on
sca.check.compliance.cis: 2.6.4
sca.check.references: https://support.apple.com/en-us/HT201642
sca.check.command: ["/usr/libexec/ApplicationFirewall/socketfilterfw --getstealthmode"]
sca.check.result: failed

** Alert 1557496144.644942: - sca,gdpr_IV_35.7.d
2019 May 10 15:49:04 (macos1011) any->sca
Rule: 19009 (level 3) -> 'CIS Apple OSX 10.11 Benchmark: Enable Secure Keyboard Entry in terminal.app (Scored)'
{"type":"check","id":1813888922,"policy":"CIS Apple OSX 10.11 Benchmark","policy_id":"cis_apple_macos_10_11","check":{"id":3017,"title":"Enable Secure Keyboard Entry in terminal.app (Scored)","description":"Secure Keyboard Entry prevents other applications on the system and/or network from detecting and recording what is typed into Terminal.","rationale":"Enabling Secure Keyboard Entry minimizes the risk of a key logger from detecting what is entered in Terminal.","remediation":"Perform the following to implement the prescribed state: 1. Open Terminal 2. Select Terminal 3. Select Secure Keyboard Entry","compliance":{"cis":"2.10"},"rules":["c:defaults read -app Terminal SecureKeyboardEntry -> r:^\\s*0$;"],"command":"defaults read -app Terminal SecureKeyboardEntry","status":"Not applicable","reason":"Internal error running command 'defaults read -app Terminal SecureKeyboardEntry'"}}
sca.type: check
sca.scan_id: 1813888922
sca.policy: CIS Apple OSX 10.11 Benchmark
sca.check.id: 3017
sca.check.title: Enable Secure Keyboard Entry in terminal.app (Scored)
sca.check.description: Secure Keyboard Entry prevents other applications on the system and/or network from detecting and recording what is typed into Terminal.
sca.check.rationale: Enabling Secure Keyboard Entry minimizes the risk of a key logger from detecting what is entered in Terminal.
sca.check.remediation: Perform the following to implement the prescribed state: 1. Open Terminal 2. Select Terminal 3. Select Secure Keyboard Entry
sca.check.compliance.cis: 2.10
sca.check.command: ["defaults read -app Terminal SecureKeyboardEntry"]
sca.check.status: Not applicable
sca.check.reason: Internal error running command 'defaults read -app Terminal SecureKeyboardEntry'

** Alert 1557496144.646885: - sca,gdpr_IV_35.7.d
2019 May 10 15:49:04 (macos1011) any->sca
Rule: 19009 (level 3) -> 'CIS Apple OSX 10.11 Benchmark: Java 6 is not the default Java runtime (Scored)'
{"type":"check","id":1813888922,"policy":"CIS Apple OSX 10.11 Benchmark","policy_id":"cis_apple_macos_10_11","check":{"id":3018,"title":"Java 6 is not the default Java runtime (Scored)","description":"Apple had made Java part of the core Operating System for OS X. Apple is no longer providing Java updates for OS X and updated JREs and JDK are made available by Oracle.  The latest version of Java 6 made available by Apple has many unpatched vulnerabilities and should not be the default runtime for Java applets that request one from the Operating System","rationale":"Java is one of the most exploited environments and is no longer maintained by Apple, old versions may still be installed and should be removed from the computer or not be in the default path.","remediation":"Java 6 can be removed completely or, if necessary Java applications will only work with Java 6, a custom path can be used.","compliance":{"cis":"2.11"},"rules":["c:java -version -> r:version.*1.6.0;","c:java -version -> r:Runtime Environment.*build.*1.6.0;"],"command":"java -version","status":"Not applicable","reason":"Internal error running command 'java -version'"}}
sca.type: check
sca.scan_id: 1813888922
sca.policy: CIS Apple OSX 10.11 Benchmark
sca.check.id: 3018
sca.check.title: Java 6 is not the default Java runtime (Scored)
sca.check.description: Apple had made Java part of the core Operating System for OS X. Apple is no longer providing Java updates for OS X and updated JREs and JDK are made available by Oracle.  The latest version of Java 6 made available by Apple has many unpatched vulnerabilities and should not be the default runtime for Java applets that request one from the Operating System
sca.check.rationale: Java is one of the most exploited environments and is no longer maintained by Apple, old versions may still be installed and should be removed from the computer or not be in the default path.
sca.check.remediation: Java 6 can be removed completely or, if necessary Java applications will only work with Java 6, a custom path can be used.
sca.check.compliance.cis: 2.11
sca.check.command: ["java -version"]
sca.check.status: Not applicable
sca.check.reason: Internal error running command 'java -version'

** Alert 1557496144.649305: - sca,gdpr_IV_35.7.d
2019 May 10 15:49:04 (macos1011) any->sca
Rule: 19008 (level 3) -> 'CIS Apple OSX 10.11 Benchmark: Enable security auditing (Scored)'
{"type":"check","id":1813888922,"policy":"CIS Apple OSX 10.11 Benchmark","policy_id":"cis_apple_macos_10_11","check":{"id":3019,"title":"Enable security auditing (Scored)","description":"OSX's audit facility, auditd, receives notifications from the kernel when certain system calls, such as open, fork, and exit, are made. These notifications are captured and written to an audit log.","rationale":"Logs generated by auditd may be useful when investigating a security incident as they may help reveal the vulnerable application and the actions taken by a malicious actor.","remediation":"Run the following command in Terminal: sudo launchctl load -w /System/Library/LaunchDaemons/com.apple.auditd.plist","compliance":{"cis":"3.2"},"rules":["c:launchctl list -> !r:com.apple.auditd;"],"command":"launchctl list","result":"passed"}}
sca.type: check
sca.scan_id: 1813888922
sca.policy: CIS Apple OSX 10.11 Benchmark
sca.check.id: 3019
sca.check.title: Enable security auditing (Scored)
sca.check.description: OSX's audit facility, auditd, receives notifications from the kernel when certain system calls, such as open, fork, and exit, are made. These notifications are captured and written to an audit log.
sca.check.rationale: Logs generated by auditd may be useful when investigating a security incident as they may help reveal the vulnerable application and the actions taken by a malicious actor.
sca.check.remediation: Run the following command in Terminal: sudo launchctl load -w /System/Library/LaunchDaemons/com.apple.auditd.plist
sca.check.compliance.cis: 3.2
sca.check.command: ["launchctl list"]
sca.check.result: passed

** Alert 1557496144.651118: - sca,gdpr_IV_35.7.d
2019 May 10 15:49:04 (macos1011) any->sca
Rule: 19007 (level 7) -> 'CIS Apple OSX 10.11 Benchmark: Configure Security Auditing Flags (Scored)'
{"type":"check","id":1813888922,"policy":"CIS Apple OSX 10.11 Benchmark","policy_id":"cis_apple_macos_10_11","check":{"id":3020,"title":"Configure Security Auditing Flags (Scored)","description":"Auditing is the capture and maintenance of information about security-related events.","rationale":"Maintaining an audit trail of system activity logs can help identify configuration errors, troubleshoot service disruptions, and analyze compromises or attacks that have occurred, have begun, or are about to begin. Audit logs are necessary to provide a trail of evidence in case the system or network is compromised.","remediation":"1. Open a terminal session and edit the /etc/security/audit_control file 2. Find the line beginning with \"flags\" 3. Add the following flags: lo, ad, fd, fm, -all.  4. Save the file.","compliance":{"cis":"3.3"},"rules":["f:/etc/security/audit_control -> NIN r:^flags && r:lo;","f:/etc/security/audit_control -> NIN r:^flags && r:ad;","f:/etc/security/audit_control -> NIN r:^flags && r:fd;","f:/etc/security/audit_control -> NIN r:^flags && r:fm;","f:/etc/security/audit_control -> NIN r:^flags && r:-all;"],"file":"/etc/security/audit_control","result":"failed"}}
sca.type: check
sca.scan_id: 1813888922
sca.policy: CIS Apple OSX 10.11 Benchmark
sca.check.id: 3020
sca.check.title: Configure Security Auditing Flags (Scored)
sca.check.description: Auditing is the capture and maintenance of information about security-related events.
sca.check.rationale: Maintaining an audit trail of system activity logs can help identify configuration errors, troubleshoot service disruptions, and analyze compromises or attacks that have occurred, have begun, or are about to begin. Audit logs are necessary to provide a trail of evidence in case the system or network is compromised.
sca.check.remediation: 1. Open a terminal session and edit the /etc/security/audit_control file 2. Find the line beginning with "flags" 3. Add the following flags: lo, ad, fd, fm, -all.  4. Save the file.
sca.check.compliance.cis: 3.3
sca.check.file: ["/etc/security/audit_control"]
sca.check.result: failed

** Alert 1557496144.653422: - sca,gdpr_IV_35.7.d
2019 May 10 15:49:04 (macos1011) any->sca
Rule: 19009 (level 3) -> 'CIS Apple OSX 10.11 Benchmark: Disable Bonjour advertising service (Scored)'
{"type":"check","id":1813888922,"policy":"CIS Apple OSX 10.11 Benchmark","policy_id":"cis_apple_macos_10_11","check":{"id":3021,"title":"Disable Bonjour advertising service (Scored)","description":"Bonjour is an auto-discovery mechanism for TCP/IP devices which enumerate devices and services within a local subnet. DNS on Mac OS X  is integrated with Bonjour and should not be turned off, but the Bonjour advertising service can be disabled.","rationale":"Bonjour can simplify device discovery from an internal rogue or compromised host. An attacker could use Bonjour's multicast DNS feature to discover a vulnerable or poorly- configured service or additional information to aid a targeted attack. Implementing this control disables the continuous broadcasting of \"I'm here!\" messages. Typical end-user endpoints should not have to advertise services to other computers. This setting does not stop the computer from sending out service discovery messages when looking for services on an internal subnet, if the computer is looking for a printer or server and using service discovery. To block all Bonjour traffic except to approved devices the pf or other firewall would be needed.","remediation":"Run the following command in Terminal: defaults write /Library/Preferences/com.apple.mDNSResponder.plist NoMulticastAdvertisements","compliance":{"cis":"4.1"},"rules":["c:defaults read /Library/Preferences/com.apple.mDNSResponder.plist NoMulticastAdvertisements -> r:^\\s*0$;"],"command":"defaults read /Library/Preferences/com.apple.mDNSResponder.plist NoMulticastAdvertisements","status":"Not applicable","reason":"Internal error running command 'defaults read /Library/Preferences/com.apple.mDNSResponder.plist NoMulticastAdvertisements'"}}
sca.type: check
sca.scan_id: 1813888922
sca.policy: CIS Apple OSX 10.11 Benchmark
sca.check.id: 3021
sca.check.title: Disable Bonjour advertising service (Scored)
sca.check.description: Bonjour is an auto-discovery mechanism for TCP/IP devices which enumerate devices and services within a local subnet. DNS on Mac OS X  is integrated with Bonjour and should not be turned off, but the Bonjour advertising service can be disabled.
sca.check.rationale: Bonjour can simplify device discovery from an internal rogue or compromised host. An attacker could use Bonjour's multicast DNS feature to discover a vulnerable or poorly- configured service or additional information to aid a targeted attack. Implementing this control disables the continuous broadcasting of "I'm here!" messages. Typical end-user endpoints should not have to advertise services to other computers. This setting does not stop the computer from sending out service discovery messages when looking for services on an internal subnet, if the computer is looking for a printer or server and using service discovery. To block all Bonjour traffic except to approved devices the pf or other firewall would be needed.
sca.check.remediation: Run the following command in Terminal: defaults write /Library/Preferences/com.apple.mDNSResponder.plist NoMulticastAdvertisements
sca.check.compliance.cis: 4.1
sca.check.command: ["defaults read /Library/Preferences/com.apple.mDNSResponder.plist NoMulticastAdvertisements"]
sca.check.status: Not applicable
sca.check.reason: Internal error running command 'defaults read /Library/Preferences/com.apple.mDNSResponder.plist NoMulticastAdvertisements'

** Alert 1557496144.657015: - sca,gdpr_IV_35.7.d
2019 May 10 15:49:04 (macos1011) any->sca
Rule: 19008 (level 3) -> 'CIS Apple OSX 10.11 Benchmark: Ensure http server is not running (Scored)'
{"type":"check","id":1813888922,"policy":"CIS Apple OSX 10.11 Benchmark","policy_id":"cis_apple_macos_10_11","check":{"id":3022,"title":"Ensure http server is not running (Scored)","description":"Mac OS X used to have a graphical front-end to the embedded Apache web server in the Operating System. Personal web sharing could be enabled to allow someone on another computer to download files or information from the user's computer. Personal web sharing from a user endpoint has long been considered questionable and Apple has removed that capability from the GUI. Apache however is still part of the Operating System and can be easily turned on to share files and provide remote connectivity to an end user computer.  Web sharing should only be done through hardened web servers and appropriate cloud services.","rationale":"Web serving should not be done from a user desktop. Dedicated webservers or appropriate cloud storage should be used. Open ports make it easier to exploit the computer.","remediation":"Ensure that the Web Server is not running and is not set to start at boot    Stop the Web Server: sudo apachectl stop    Ensure that the web server will not auto-start at boot: sudo defaults write /System/Library/LaunchDaemons/org.apache.httpd Disabled -bool true","compliance":{"cis":"4.4"},"rules":["p:httpd;","p:/usr/sbin/httpd;","p:/usr/sbin/httpd -D FOREGROUND;"],"process":"httpd,/usr/sbin/httpd,/usr/sbin/httpd -D FOREGROUND","result":"passed"}}
sca.type: check
sca.scan_id: 1813888922
sca.policy: CIS Apple OSX 10.11 Benchmark
sca.check.id: 3022
sca.check.title: Ensure http server is not running (Scored)
sca.check.description: Mac OS X used to have a graphical front-end to the embedded Apache web server in the Operating System. Personal web sharing could be enabled to allow someone on another computer to download files or information from the user's computer. Personal web sharing from a user endpoint has long been considered questionable and Apple has removed that capability from the GUI. Apache however is still part of the Operating System and can be easily turned on to share files and provide remote connectivity to an end user computer.  Web sharing should only be done through hardened web servers and appropriate cloud services.
sca.check.rationale: Web serving should not be done from a user desktop. Dedicated webservers or appropriate cloud storage should be used. Open ports make it easier to exploit the computer.
sca.check.remediation: Ensure that the Web Server is not running and is not set to start at boot    Stop the Web Server: sudo apachectl stop    Ensure that the web server will not auto-start at boot: sudo defaults write /System/Library/LaunchDaemons/org.apache.httpd Disabled -bool true
sca.check.compliance.cis: 4.4
sca.check.process: ["httpd", "/usr/sbin/httpd", "/usr/sbin/httpd -D FOREGROUND"]
sca.check.result: passed

** Alert 1557496144.660085: - sca,gdpr_IV_35.7.d
2019 May 10 15:49:04 (macos1011) any->sca
Rule: 19008 (level 3) -> 'CIS Apple OSX 10.11 Benchmark: Ensure ftp server is not running (Scored)'
{"type":"check","id":1813888922,"policy":"CIS Apple OSX 10.11 Benchmark","policy_id":"cis_apple_macos_10_11","check":{"id":3023,"title":"Ensure ftp server is not running (Scored)","description":"Mac OS X used to have a graphical front-end to the embedded ftp server in the Operating System. Ftp sharing could be enabled to allow someone on another computer to download files or information from the user's computer. Running an Ftp server from a user endpoint has long been considered questionable and Apple has removed that capability from the GUI. The Ftp server however is still part of the Operating System and can be easily turned on to share files and provide remote connectivity to an end user computer. Ftp servers meet a specialized need to distribute files without strong authentication and should only be done through hardened servers. Cloud services or other distribution methods should be considered","rationale":"Ftp servers should not be run on an end user desktop. Dedicated servers or appropriate cloud storage should be used. Open ports make it easier to exploit the computer.","remediation":"Ensure that the FTP Server is not running and is not set to start at boot. Stop the ftp Server: sudo -s launchctl unload -w /System/Library/LaunchDaemons/ftp.plist","compliance":{"cis":"4.5"},"rules":["c:launchctl list -> r:ftp;"],"command":"launchctl list","result":"passed"}}
sca.type: check
sca.scan_id: 1813888922
sca.policy: CIS Apple OSX 10.11 Benchmark
sca.check.id: 3023
sca.check.title: Ensure ftp server is not running (Scored)
sca.check.description: Mac OS X used to have a graphical front-end to the embedded ftp server in the Operating System. Ftp sharing could be enabled to allow someone on another computer to download files or information from the user's computer. Running an Ftp server from a user endpoint has long been considered questionable and Apple has removed that capability from the GUI. The Ftp server however is still part of the Operating System and can be easily turned on to share files and provide remote connectivity to an end user computer. Ftp servers meet a specialized need to distribute files without strong authentication and should only be done through hardened servers. Cloud services or other distribution methods should be considered
sca.check.rationale: Ftp servers should not be run on an end user desktop. Dedicated servers or appropriate cloud storage should be used. Open ports make it easier to exploit the computer.
sca.check.remediation: Ensure that the FTP Server is not running and is not set to start at boot. Stop the ftp Server: sudo -s launchctl unload -w /System/Library/LaunchDaemons/ftp.plist
sca.check.compliance.cis: 4.5
sca.check.command: ["launchctl list"]
sca.check.result: passed

** Alert 1557496144.663034: - sca,gdpr_IV_35.7.d
2019 May 10 15:49:04 (macos1011) any->sca
Rule: 19008 (level 3) -> 'CIS Apple OSX 10.11 Benchmark: Ensure nfs server is not running (Scored)'
{"type":"check","id":1813888922,"policy":"CIS Apple OSX 10.11 Benchmark","policy_id":"cis_apple_macos_10_11","check":{"id":3024,"title":"Ensure nfs server is not running (Scored)","description":"Mac OS X can act as an NFS fileserver. NFS sharing could be enabled to allow someone on another computer to mount shares and gain access to information from the user's computer. File sharing from a user endpoint has long been considered questionable and Apple has removed that capability from the GUI. NFSD is still part of the Operating System and can be easily turned on to export shares and provide remote connectivity to an end user computer.","rationale":"File serving should not be done from a user desktop, dedicated servers should be used.  Open ports make it easier to exploit the computer.","remediation":"Stop the NFS Server: sudo nfsd disable    Remove the exported Directory listing: rm /etc/export","compliance":{"cis":"4.6"},"rules":["p:nfsd;","f:/etc/exports;"],"file":"/etc/exports","process":"nfsd","result":"passed"}}
sca.type: check
sca.scan_id: 1813888922
sca.policy: CIS Apple OSX 10.11 Benchmark
sca.check.id: 3024
sca.check.title: Ensure nfs server is not running (Scored)
sca.check.description: Mac OS X can act as an NFS fileserver. NFS sharing could be enabled to allow someone on another computer to mount shares and gain access to information from the user's computer. File sharing from a user endpoint has long been considered questionable and Apple has removed that capability from the GUI. NFSD is still part of the Operating System and can be easily turned on to export shares and provide remote connectivity to an end user computer.
sca.check.rationale: File serving should not be done from a user desktop, dedicated servers should be used.  Open ports make it easier to exploit the computer.
sca.check.remediation: Stop the NFS Server: sudo nfsd disable    Remove the exported Directory listing: rm /etc/export
sca.check.compliance.cis: 4.6
sca.check.file: ["/etc/exports"]
sca.check.process: ["nfsd"]
sca.check.result: passed

** Alert 1557496144.665283: - sca,gdpr_IV_35.7.d
2019 May 10 15:49:04 (macos1011) any->sca
Rule: 19008 (level 3) -> 'CIS Apple OSX 10.11 Benchmark: Do not enable the "root" account (Scored)'
{"type":"check","id":1813888922,"policy":"CIS Apple OSX 10.11 Benchmark","policy_id":"cis_apple_macos_10_11","check":{"id":3025,"title":"Do not enable the \"root\" account (Scored)","description":"The root account is a superuser account that has access privileges to perform any actions and read/write to any file on the computer. In the UNIX/Linux world, the system administrator commonly uses the root account to perform administrative functions.","rationale":"Enabling and using the root account puts the system at risk since any successful exploit or mistake while the root account is in use could have unlimited access privileges within the system. Using the sudo command allows users to perform functions as a root user while limiting and password protecting the access privileges.  By default the root account is not enabled on a Mac OS X client computer. It is enabled on Mac OS X Server. An administrator can escalate privileges using the sudo command (use -s or -i to get a root shell).","remediation":"Open System Preferences, Uses & Groups.  Click the lock icon to unlock it.  In the Network Account Server section, click Join or Edit.  Click Open Directory Utility.  Click the lock icon to unlock it.  Select the Edit menu > Disable Root User.","compliance":{"cis":"5.7"},"rules":["c:dscl . -read /Users/root AuthenticationAuthority -> !r:^No such key: AuthenticationAuthority;"],"command":"dscl . -read /Users/root AuthenticationAuthority","result":"passed"}}
sca.type: check
sca.scan_id: 1813888922
sca.policy: CIS Apple OSX 10.11 Benchmark
sca.check.id: 3025
sca.check.title: Do not enable the "root" account (Scored)
sca.check.description: The root account is a superuser account that has access privileges to perform any actions and read/write to any file on the computer. In the UNIX/Linux world, the system administrator commonly uses the root account to perform administrative functions.
sca.check.rationale: Enabling and using the root account puts the system at risk since any successful exploit or mistake while the root account is in use could have unlimited access privileges within the system. Using the sudo command allows users to perform functions as a root user while limiting and password protecting the access privileges.  By default the root account is not enabled on a Mac OS X client computer. It is enabled on Mac OS X Server. An administrator can escalate privileges using the sudo command (use -s or -i to get a root shell).
sca.check.remediation: Open System Preferences, Uses & Groups.  Click the lock icon to unlock it.  In the Network Account Server section, click Join or Edit.  Click Open Directory Utility.  Click the lock icon to unlock it.  Select the Edit menu > Disable Root User.
sca.check.compliance.cis: 5.7
sca.check.command: ["dscl . -read /Users/root AuthenticationAuthority"]
sca.check.result: passed

** Alert 1557496144.668333: - sca,gdpr_IV_35.7.d
2019 May 10 15:49:04 (macos1011) any->sca
Rule: 19008 (level 3) -> 'CIS Apple OSX 10.11 Benchmark: Disable automatic login (Scored)'
{"type":"check","id":1813888922,"policy":"CIS Apple OSX 10.11 Benchmark","policy_id":"cis_apple_macos_10_11","check":{"id":3026,"title":"Disable automatic login (Scored)","description":"The automatic login feature saves a user's system access credentials and bypasses the login screen, instead the system automatically loads to the user's desktop screen.","rationale":"Disabling automatic login decreases the likelihood of an unauthorized person gaining access to a system.","remediation":"Run the following command in Terminal: sudo defaults delete /Library/Preferences/com.apple.loginwindow autoLoginUser","compliance":{"cis":"5.8"},"rules":["c:defaults read /Library/Preferences/com.apple.loginwindow -> r:autoLoginUser;"],"command":"defaults read /Library/Preferences/com.apple.loginwindow","result":"passed"}}
sca.type: check
sca.scan_id: 1813888922
sca.policy: CIS Apple OSX 10.11 Benchmark
sca.check.id: 3026
sca.check.title: Disable automatic login (Scored)
sca.check.description: The automatic login feature saves a user's system access credentials and bypasses the login screen, instead the system automatically loads to the user's desktop screen.
sca.check.rationale: Disabling automatic login decreases the likelihood of an unauthorized person gaining access to a system.
sca.check.remediation: Run the following command in Terminal: sudo defaults delete /Library/Preferences/com.apple.loginwindow autoLoginUser
sca.check.compliance.cis: 5.8
sca.check.command: ["defaults read /Library/Preferences/com.apple.loginwindow"]
sca.check.result: passed

** Alert 1557496144.670075: - sca,gdpr_IV_35.7.d
2019 May 10 15:49:04 (macos1011) any->sca
Rule: 19009 (level 3) -> 'CIS Apple OSX 10.11 Benchmark: Require a password to wake the computer from sleep or screen saver (Scored)'
{"type":"check","id":1813888922,"policy":"CIS Apple OSX 10.11 Benchmark","policy_id":"cis_apple_macos_10_11","check":{"id":3027,"title":"Require a password to wake the computer from sleep or screen saver (Scored)","description":"Sleep and screensaver modes are low power modes that reduces electrical consumption while the system is not in use.","rationale":"Prompting for a password when waking from sleep or screensaver mode mitigates the threat of an unauthorized person gaining access to a system in the user's absence.","remediation":"1. Run the following command in Terminal: The current user will need to log off and on for changes to take effect.  defaults write com.apple.screensaver askForPassword -int 1  2.  The current user will need to log off and on for changes to take effect.","compliance":{"cis":"5.9"},"rules":["c:defaults read com.apple.screensaver askForPassword -> r:^\\s*0$;"],"command":"defaults read com.apple.screensaver askForPassword","status":"Not applicable","reason":"Internal error running command 'defaults read com.apple.screensaver askForPassword'"}}
sca.type: check
sca.scan_id: 1813888922
sca.policy: CIS Apple OSX 10.11 Benchmark
sca.check.id: 3027
sca.check.title: Require a password to wake the computer from sleep or screen saver (Scored)
sca.check.description: Sleep and screensaver modes are low power modes that reduces electrical consumption while the system is not in use.
sca.check.rationale: Prompting for a password when waking from sleep or screensaver mode mitigates the threat of an unauthorized person gaining access to a system in the user's absence.
sca.check.remediation: 1. Run the following command in Terminal: The current user will need to log off and on for changes to take effect.  defaults write com.apple.screensaver askForPassword -int 1  2.  The current user will need to log off and on for changes to take effect.
sca.check.compliance.cis: 5.9
sca.check.command: ["defaults read com.apple.screensaver askForPassword"]
sca.check.status: Not applicable
sca.check.reason: Internal error running command 'defaults read com.apple.screensaver askForPassword'

** Alert 1557496144.672421: - sca,gdpr_IV_35.7.d
2019 May 10 15:49:04 (macos1011) any->sca
Rule: 19007 (level 7) -> 'CIS Apple OSX 10.11 Benchmark: Disable ability to login to another user's active and locked session (Scored)'
{"type":"check","id":1813888922,"policy":"CIS Apple OSX 10.11 Benchmark","policy_id":"cis_apple_macos_10_11","check":{"id":3028,"title":"Disable ability to login to another user's active and locked session (Scored)","description":"OSX has a privilege that can be granted to any user that will allow that user to unlock active user's sessions.","rationale":"Disabling the admins and/or user's ability to log into another user's active and locked session prevents unauthorized persons from viewing potentially sensitive and/or personal information.","remediation":"1. Run the following command in Terminal:  sudo vi /etc/pam.d/screensaver 2. Locate   \"account    required     pam_group.so no_warn group=admin,wheel fail_safe\" 3. Remove \"admin,\" 4. Save","compliance":{"cis":"5.11"},"rules":["f:/etc/pam.d/screensaver -> r:group=admin,wheel fail_safe;"],"file":"/etc/pam.d/screensaver","result":"failed"}}
sca.type: check
sca.scan_id: 1813888922
sca.policy: CIS Apple OSX 10.11 Benchmark
sca.check.id: 3028
sca.check.title: Disable ability to login to another user's active and locked session (Scored)
sca.check.description: OSX has a privilege that can be granted to any user that will allow that user to unlock active user's sessions.
sca.check.rationale: Disabling the admins and/or user's ability to log into another user's active and locked session prevents unauthorized persons from viewing potentially sensitive and/or personal information.
sca.check.remediation: 1. Run the following command in Terminal:  sudo vi /etc/pam.d/screensaver 2. Locate   "account    required     pam_group.so no_warn group=admin,wheel fail_safe" 3. Remove "admin," 4. Save
sca.check.compliance.cis: 5.11
sca.check.file: ["/etc/pam.d/screensaver"]
sca.check.result: failed

** Alert 1557496144.674408: - sca,gdpr_IV_35.7.d
2019 May 10 15:49:04 (macos1011) any->sca
Rule: 19008 (level 3) -> 'CIS Apple OSX 10.11 Benchmark: System Integrity Protection status (Scored)'
{"type":"check","id":1813888922,"policy":"CIS Apple OSX 10.11 Benchmark","policy_id":"cis_apple_macos_10_11","check":{"id":3029,"title":"System Integrity Protection status (Scored)","description":"System Integrity Protection is a new security feature introduced in OS X 10.11 El Capitan.  System Integrity Protection restricts access to System domain locations and restricts runtime attachment to system processes. Any attempt to attempt to inspect or attach to a system process will fail. Kernel Extensions are now restricted to /Library/Extensions and are required to be signed with a Developer ID.","rationale":"Running without System Integrity Protection on a production system runs the risk of the modification of system binaries or code injection of system processes that would otherwise be protected by SIP.","remediation":"Perform the following while booted in OS X Recovery Partition.  1. Select Terminal from the Utilities menu    2. Run the following command in Terminal: /usr/bin/csrutil enable    3. The output should be: Successfully enabled System Integrity Protection. Please restart the machine for the changes to take effect.    4. Reboot.","compliance":{"cis":"5.18"},"rules":["c:/usr/bin/csrutil status -> !r:^\\s*System Integrity Protection status: enabled;"],"command":"/usr/bin/csrutil status","result":"passed"}}
sca.type: check
sca.scan_id: 1813888922
sca.policy: CIS Apple OSX 10.11 Benchmark
sca.check.id: 3029
sca.check.title: System Integrity Protection status (Scored)
sca.check.description: System Integrity Protection is a new security feature introduced in OS X 10.11 El Capitan.  System Integrity Protection restricts access to System domain locations and restricts runtime attachment to system processes. Any attempt to attempt to inspect or attach to a system process will fail. Kernel Extensions are now restricted to /Library/Extensions and are required to be signed with a Developer ID.
sca.check.rationale: Running without System Integrity Protection on a production system runs the risk of the modification of system binaries or code injection of system processes that would otherwise be protected by SIP.
sca.check.remediation: Perform the following while booted in OS X Recovery Partition.  1. Select Terminal from the Utilities menu    2. Run the following command in Terminal: /usr/bin/csrutil enable    3. The output should be: Successfully enabled System Integrity Protection. Please restart the machine for the changes to take effect.    4. Reboot.
sca.check.compliance.cis: 5.18
sca.check.command: ["/usr/bin/csrutil status"]
sca.check.result: passed

** Alert 1557496144.677202: - sca,gdpr_IV_35.7.d
2019 May 10 15:49:04 (macos1011) any->sca
Rule: 19008 (level 3) -> 'CIS Apple OSX 10.11 Benchmark: Disable guest account login (Scored)'
{"type":"check","id":1813888922,"policy":"CIS Apple OSX 10.11 Benchmark","policy_id":"cis_apple_macos_10_11","check":{"id":3030,"title":"Disable guest account login (Scored)","description":"The guest account allows users access to the system without having to create an account or password. Guest users are unable to make setting changes, cannot remotely login to the system and all created files, caches, and passwords are deleted upon logging out.","rationale":"Disabling the guest account mitigates the risk of an untrusted user doing basic reconnaissance and possibly using privilege escalation attacks to take control of the system.","remediation":"Run the following command in Terminal: sudo defaults write /Library/Preferences/com.apple.loginwindow GuestEnabled - bool NO","compliance":{"cis":"6.1.3"},"rules":["c:defaults read /Library/Preferences/com.apple.loginwindow.plist GuestEnabled -> !r:^\\s*0$;"],"command":"defaults read /Library/Preferences/com.apple.loginwindow.plist GuestEnabled","result":"passed"}}
sca.type: check
sca.scan_id: 1813888922
sca.policy: CIS Apple OSX 10.11 Benchmark
sca.check.id: 3030
sca.check.title: Disable guest account login (Scored)
sca.check.description: The guest account allows users access to the system without having to create an account or password. Guest users are unable to make setting changes, cannot remotely login to the system and all created files, caches, and passwords are deleted upon logging out.
sca.check.rationale: Disabling the guest account mitigates the risk of an untrusted user doing basic reconnaissance and possibly using privilege escalation attacks to take control of the system.
sca.check.remediation: Run the following command in Terminal: sudo defaults write /Library/Preferences/com.apple.loginwindow GuestEnabled - bool NO
sca.check.compliance.cis: 6.1.3
sca.check.command: ["defaults read /Library/Preferences/com.apple.loginwindow.plist GuestEnabled"]
sca.check.result: passed

** Alert 1557496144.679348: - sca,gdpr_IV_35.7.d
2019 May 10 15:49:04 (macos1011) any->sca
Rule: 19008 (level 3) -> 'CIS Apple OSX 10.11 Benchmark: Remove Guest home folder (Scored)'
{"type":"check","id":1813888922,"policy":"CIS Apple OSX 10.11 Benchmark","policy_id":"cis_apple_macos_10_11","check":{"id":3031,"title":"Remove Guest home folder (Scored)","description":"The guest account login should have been disabled, so there is no need for the legacy Guest home folder to remain in the file system. When normal user accounts are removed you have the option to archive it, leave it in place or delete. In the case of the guest folder the folder remains in place without a GUI option to remove it. If at some point in the future a Guest account is needed it will be re-created. The presence of the Guest home folder can cause automated audits to fail when looking for compliant settings within all User folders as well. Rather than ignoring the folders continued existence it is best removed.","rationale":"The Guest home folders are unneeded after the Guest account is disabled and could be used inappropriately.","remediation":"1. Run the following command in Terminal: rm -R /Users/Guest  2. Make sure there is no output","compliance":{"cis":"6.1.5"},"rules":["d:/Users/Guest;"],"result":"passed"}}
sca.type: check
sca.scan_id: 1813888922
sca.policy: CIS Apple OSX 10.11 Benchmark
sca.check.id: 3031
sca.check.title: Remove Guest home folder (Scored)
sca.check.description: The guest account login should have been disabled, so there is no need for the legacy Guest home folder to remain in the file system. When normal user accounts are removed you have the option to archive it, leave it in place or delete. In the case of the guest folder the folder remains in place without a GUI option to remove it. If at some point in the future a Guest account is needed it will be re-created. The presence of the Guest home folder can cause automated audits to fail when looking for compliant settings within all User folders as well. Rather than ignoring the folders continued existence it is best removed.
sca.check.rationale: The Guest home folders are unneeded after the Guest account is disabled and could be used inappropriately.
sca.check.remediation: 1. Run the following command in Terminal: rm -R /Users/Guest  2. Make sure there is no output
sca.check.compliance.cis: 6.1.5
sca.check.result: passed

** Alert 1557496144.681757: - sca,gdpr_IV_35.7.d
2019 May 10 15:49:04 (macos1011) any->sca
Rule: 19009 (level 3) -> 'CIS Apple OSX 10.11 Benchmark: Turn on filename extensions (Scored)'
{"type":"check","id":1813888922,"policy":"CIS Apple OSX 10.11 Benchmark","policy_id":"cis_apple_macos_10_11","check":{"id":3032,"title":"Turn on filename extensions (Scored)","description":"A filename extension is a suffix added to a base filename that indicates the base filename's file format.","rationale":"Visible filename extensions allows the user to identify the file type and the application it is associated with which leads to quick identification of misrepresented malicious files.","remediation":"Perform the following to implement the prescribed state: 1. Select Finder 2. Select Preferences 3. Check Show all filename extensions    Alternatively, use the following command: defaults write NSGlobalDomain AppleShowAllExtensions -bool true","compliance":{"cis":"6.2"},"rules":["c:defaults read NSGlobalDomain AppleShowAllExtensions -> r:^\\s*0$;"],"command":"defaults read NSGlobalDomain AppleShowAllExtensions","status":"Not applicable","reason":"Internal error running command 'defaults read NSGlobalDomain AppleShowAllExtensions'"}}
sca.type: check
sca.scan_id: 1813888922
sca.policy: CIS Apple OSX 10.11 Benchmark
sca.check.id: 3032
sca.check.title: Turn on filename extensions (Scored)
sca.check.description: A filename extension is a suffix added to a base filename that indicates the base filename's file format.
sca.check.rationale: Visible filename extensions allows the user to identify the file type and the application it is associated with which leads to quick identification of misrepresented malicious files.
sca.check.remediation: Perform the following to implement the prescribed state: 1. Select Finder 2. Select Preferences 3. Check Show all filename extensions    Alternatively, use the following command: defaults write NSGlobalDomain AppleShowAllExtensions -bool true
sca.check.compliance.cis: 6.2
sca.check.command: ["defaults read NSGlobalDomain AppleShowAllExtensions"]
sca.check.status: Not applicable
sca.check.reason: Internal error running command 'defaults read NSGlobalDomain AppleShowAllExtensions'

** Alert 1557496144.683987: - sca,gdpr_IV_35.7.d
2019 May 10 15:49:04 (macos1011) any->sca
Rule: 19009 (level 3) -> 'CIS Apple OSX 10.11 Benchmark: Disable the automatic run of safe files in Safari (Scored)'
{"type":"check","id":1813888922,"policy":"CIS Apple OSX 10.11 Benchmark","policy_id":"cis_apple_macos_10_11","check":{"id":3033,"title":"Disable the automatic run of safe files in Safari (Scored)","description":"Safari will automatically run or execute what it considers safe files. This can include installers and other files that execute on the operating system. Safari bases file safety by using a list of filetypes maintained by Apple. The list of files include text, image, video and archive formats that would be run in the context of the OS rather than the browser.","rationale":"Hackers have taken advantage of this setting via drive-by attacks. These attacks occur when a user visits a legitimate website that has been corrupted. The user unknowingly downloads a malicious file either by closing an infected pop-up or hovering over a malicious banner. An attacker can create a malicious file that will fall within Safari's safe file list that will download and execute without user input.","remediation":"Perform the following to implement the prescribed state: 1. Open Safari 2. Select Safari from the menu bar 3. Select Preferences 4. Select General 5. Uncheck Open \"safe\" files after downloading    Alternatively run the following command in Terminal: defaults write com.apple.Safari AutoOpenSafeDownloads -boolean no","compliance":{"cis":"6.3"},"rules":["c:defaults read com.apple.Safari AutoOpenSafeDownloads -> r:^1$;"],"command":"defaults read com.apple.Safari AutoOpenSafeDownloads","status":"Not applicable","reason":"Internal error running command 'defaults read com.apple.Safari AutoOpenSafeDownloads'"}}
sca.type: check
sca.scan_id: 1813888922
sca.policy: CIS Apple OSX 10.11 Benchmark
sca.check.id: 3033
sca.check.title: Disable the automatic run of safe files in Safari (Scored)
sca.check.description: Safari will automatically run or execute what it considers safe files. This can include installers and other files that execute on the operating system. Safari bases file safety by using a list of filetypes maintained by Apple. The list of files include text, image, video and archive formats that would be run in the context of the OS rather than the browser.
sca.check.rationale: Hackers have taken advantage of this setting via drive-by attacks. These attacks occur when a user visits a legitimate website that has been corrupted. The user unknowingly downloads a malicious file either by closing an infected pop-up or hovering over a malicious banner. An attacker can create a malicious file that will fall within Safari's safe file list that will download and execute without user input.
sca.check.remediation: Perform the following to implement the prescribed state: 1. Open Safari 2. Select Safari from the menu bar 3. Select Preferences 4. Select General 5. Uncheck Open "safe" files after downloading    Alternatively run the following command in Terminal: defaults write com.apple.Safari AutoOpenSafeDownloads -boolean no
sca.check.compliance.cis: 6.3
sca.check.command: ["defaults read com.apple.Safari AutoOpenSafeDownloads"]
sca.check.status: Not applicable
sca.check.reason: Internal error running command 'defaults read com.apple.Safari AutoOpenSafeDownloads'

** Alert 1557496151.687398: - sca,gdpr_IV_35.7.d
2019 May 10 15:49:11 (macos1011) any->sca
Rule: 19003 (level 5) -> 'SCA summary: CIS Apple OSX 10.11 Benchmark: Score less than 80% (59)'
{"type":"summary","scan_id":1813888922,"name":"CIS Apple OSX 10.11 Benchmark","policy_id":"cis_apple_macos_10_11","file":"cis_apple_macOS_10.11.yml","description":"This document, CIS Apple OSX 10.11 Benchmark, provides prescriptive guidance for establishing a secure configuration posture for Apple OSX 10.11. This guide was tested against Apple OSX 10.11. To obtain the latest version of this guide, please visit https://benchmarks.cisecurity.org. If you have questions, comments, or have identified ways to improve this guide, please write us at feedback@cisecurity.org.","references":"https://www.cisecurity.org/cis-benchmarks/","passed":16,"failed":11,"invalid":7,"total_checks":34,"score":59.259258270263672,"start_time":1557496131,"end_time":1557496139,"hash":"41f33423e0750c9e93673a8f3c61f72ae19e468b59858c5173ae89b9432af122","hash_file":"c875a71dc8efeeac00a064a1e29dd9643ea2a7ba0b41e54c7bf58c1c3556a9e3","force_alert":"1"}
sca.type: summary
sca.scan_id: 1813888922
sca.policy: CIS Apple OSX 10.11 Benchmark
sca.description: This document, CIS Apple OSX 10.11 Benchmark, provides prescriptive guidance for establishing a secure configuration posture for Apple OSX 10.11. This guide was tested against Apple OSX 10.11. To obtain the latest version of this guide, please visit https://benchmarks.cisecurity.org. If you have questions, comments, or have identified ways to improve this guide, please write us at feedback@cisecurity.org.
sca.policy_id: cis_apple_macos_10_11
sca.passed: 16
sca.failed: 11
sca.invalid: 7
sca.total_checks: 34
sca.score: 59
sca.file: cis_apple_macOS_10.11.yml
sca.type: summary
sca.scan_id: 1813888922
sca.policy: CIS Apple OSX 10.11 Benchmark
sca.description: This document, CIS Apple OSX 10.11 Benchmark, provides prescriptive guidance for establishing a secure configuration posture for Apple OSX 10.11. This guide was tested against Apple OSX 10.11. To obtain the latest version of this guide, please visit https://benchmarks.cisecurity.org. If you have questions, comments, or have identified ways to improve this guide, please write us at feedback@cisecurity.org.
sca.policy_id: cis_apple_macos_10_11
sca.passed: 16
sca.failed: 11
sca.invalid: 7
sca.total_checks: 34
sca.score: 59
sca.file: cis_apple_macOS_10.11.yml
```

SQL DB:

```
select id,result,reason,status from sca_check;
3000|failed||
3001||Internal error running command 'defaults read /Library/Preferences/com.apple.SoftwareUpdate AutomaticCheckEnabled'|Not applicable
3002|failed||
3003|passed||
3004|failed||
3005|failed||
3006|passed||
3007|failed||
3008|passed||
3009|passed||
3010|failed||
3011|passed||
3012|passed||
3013|failed||
3014|passed||
3015|failed||
3016|failed||
3017||Internal error running command 'defaults read -app Terminal SecureKeyboardEntry'|Not applicable
3018||Internal error running command 'java -version'|Not applicable
3019|passed||
3020|failed||
3021||Internal error running command 'defaults read /Library/Preferences/com.apple.mDNSResponder.plist NoMulticastAdvertisements'|Not applicable
3022|passed||
3023|passed||
3024|passed||
3025|passed||
3026|passed||
3027||Internal error running command 'defaults read com.apple.screensaver askForPassword'|Not applicable
3028|failed||
3029|passed||
3030|passed||
3031|passed||
3032||Internal error running command 'defaults read NSGlobalDomain AppleShowAllExtensions'|Not applicable
3033||Internal error running command 'defaults read com.apple.Safari AutoOpenSafeDownloads'|Not applicable
```