### PR TITLE
Fixed Windows registry Windows NT

### DIFF
--- a/sca/windows/cis_win10_enterprise_L1_rcl.yml
+++ b/sca/windows/cis_win10_enterprise_L1_rcl.yml
@@ -83,8 +83,8 @@ checks:
     - cis_csc: "5.1"
    condition: any
    rules:
-     - 'r:HKEY_LOCAL_MACHINE\Software\Microsoft\WindowsNT\CurrentVersion\Winlogon -> AllocateDASD -> 1;'
-     - 'r:HKEY_LOCAL_MACHINE\Software\Microsoft\WindowsNT\CurrentVersion\Winlogon -> AllocateDASD -> 2;'
+     - 'r:HKEY_LOCAL_MACHINE\Software\Microsoft\Windows NT\CurrentVersion\Winlogon -> AllocateDASD -> 1;'
+     - 'r:HKEY_LOCAL_MACHINE\Software\Microsoft\Windows NT\CurrentVersion\Winlogon -> AllocateDASD -> 2;'
  - id: 12005
    title: "Ensure 'Domain member: Digitally encrypt or sign secure channel data (always)' is set to 'Enabled'"
    description: "This policy setting determines whether all secure channel traffic that is initiated by the domain member must be signed or encrypted. The recommended state for this setting is: Enabled."
@@ -200,23 +200,23 @@ checks:
     - cis_csc: "16"
    condition: any
    rules:
-     - 'r:HKEY_LOCAL_MACHINE\Software\Microsoft\WindowsNT\CurrentVersion\Winlogon -> PasswordExpiryWarning -> 0;'
-     - 'r:HKEY_LOCAL_MACHINE\Software\Microsoft\WindowsNT\CurrentVersion\Winlogon -> PasswordExpiryWarning -> 1;'
-     - 'r:HKEY_LOCAL_MACHINE\Software\Microsoft\WindowsNT\CurrentVersion\Winlogon -> PasswordExpiryWarning -> 2;'
-     - 'r:HKEY_LOCAL_MACHINE\Software\Microsoft\WindowsNT\CurrentVersion\Winlogon -> PasswordExpiryWarning -> 3;'
-     - 'r:HKEY_LOCAL_MACHINE\Software\Microsoft\WindowsNT\CurrentVersion\Winlogon -> PasswordExpiryWarning -> 4;'
-     - 'r:HKEY_LOCAL_MACHINE\Software\Microsoft\WindowsNT\CurrentVersion\Winlogon -> PasswordExpiryWarning -> 0F;'
-     - 'r:HKEY_LOCAL_MACHINE\Software\Microsoft\WindowsNT\CurrentVersion\Winlogon -> PasswordExpiryWarning -> r:1\w;'
-     - 'r:HKEY_LOCAL_MACHINE\Software\Microsoft\WindowsNT\CurrentVersion\Winlogon -> PasswordExpiryWarning -> r:2\w;'
-     - 'r:HKEY_LOCAL_MACHINE\Software\Microsoft\WindowsNT\CurrentVersion\Winlogon -> PasswordExpiryWarning -> r:3\w;'
-     - 'r:HKEY_LOCAL_MACHINE\Software\Microsoft\WindowsNT\CurrentVersion\Winlogon -> PasswordExpiryWarning -> r:4\w;'
-     - 'r:HKEY_LOCAL_MACHINE\Software\Microsoft\WindowsNT\CurrentVersion\Winlogon -> PasswordExpiryWarning -> r:5\w;'
-     - 'r:HKEY_LOCAL_MACHINE\Software\Microsoft\WindowsNT\CurrentVersion\Winlogon -> PasswordExpiryWarning -> r:6\w;'
-     - 'r:HKEY_LOCAL_MACHINE\Software\Microsoft\WindowsNT\CurrentVersion\Winlogon -> PasswordExpiryWarning -> r:7\w;'
-     - 'r:HKEY_LOCAL_MACHINE\Software\Microsoft\WindowsNT\CurrentVersion\Winlogon -> PasswordExpiryWarning -> r:8\w;'
-     - 'r:HKEY_LOCAL_MACHINE\Software\Microsoft\WindowsNT\CurrentVersion\Winlogon -> PasswordExpiryWarning -> r:9\w;'
-     - 'r:HKEY_LOCAL_MACHINE\Software\Microsoft\WindowsNT\CurrentVersion\Winlogon -> PasswordExpiryWarning -> r:\D\w;'
-     - 'r:HKEY_LOCAL_MACHINE\Software\Microsoft\WindowsNT\CurrentVersion\Winlogon -> PasswordExpiryWarning -> r:\w\w\w+;'
+     - 'r:HKEY_LOCAL_MACHINE\Software\Microsoft\Windows NT\CurrentVersion\Winlogon -> PasswordExpiryWarning -> 0;'
+     - 'r:HKEY_LOCAL_MACHINE\Software\Microsoft\Windows NT\CurrentVersion\Winlogon -> PasswordExpiryWarning -> 1;'
+     - 'r:HKEY_LOCAL_MACHINE\Software\Microsoft\Windows NT\CurrentVersion\Winlogon -> PasswordExpiryWarning -> 2;'
+     - 'r:HKEY_LOCAL_MACHINE\Software\Microsoft\Windows NT\CurrentVersion\Winlogon -> PasswordExpiryWarning -> 3;'
+     - 'r:HKEY_LOCAL_MACHINE\Software\Microsoft\Windows NT\CurrentVersion\Winlogon -> PasswordExpiryWarning -> 4;'
+     - 'r:HKEY_LOCAL_MACHINE\Software\Microsoft\Windows NT\CurrentVersion\Winlogon -> PasswordExpiryWarning -> 0F;'
+     - 'r:HKEY_LOCAL_MACHINE\Software\Microsoft\Windows NT\CurrentVersion\Winlogon -> PasswordExpiryWarning -> r:1\w;'
+     - 'r:HKEY_LOCAL_MACHINE\Software\Microsoft\Windows NT\CurrentVersion\Winlogon -> PasswordExpiryWarning -> r:2\w;'
+     - 'r:HKEY_LOCAL_MACHINE\Software\Microsoft\Windows NT\CurrentVersion\Winlogon -> PasswordExpiryWarning -> r:3\w;'
+     - 'r:HKEY_LOCAL_MACHINE\Software\Microsoft\Windows NT\CurrentVersion\Winlogon -> PasswordExpiryWarning -> r:4\w;'
+     - 'r:HKEY_LOCAL_MACHINE\Software\Microsoft\Windows NT\CurrentVersion\Winlogon -> PasswordExpiryWarning -> r:5\w;'
+     - 'r:HKEY_LOCAL_MACHINE\Software\Microsoft\Windows NT\CurrentVersion\Winlogon -> PasswordExpiryWarning -> r:6\w;'
+     - 'r:HKEY_LOCAL_MACHINE\Software\Microsoft\Windows NT\CurrentVersion\Winlogon -> PasswordExpiryWarning -> r:7\w;'
+     - 'r:HKEY_LOCAL_MACHINE\Software\Microsoft\Windows NT\CurrentVersion\Winlogon -> PasswordExpiryWarning -> r:8\w;'
+     - 'r:HKEY_LOCAL_MACHINE\Software\Microsoft\Windows NT\CurrentVersion\Winlogon -> PasswordExpiryWarning -> r:9\w;'
+     - 'r:HKEY_LOCAL_MACHINE\Software\Microsoft\Windows NT\CurrentVersion\Winlogon -> PasswordExpiryWarning -> r:\D\w;'
+     - 'r:HKEY_LOCAL_MACHINE\Software\Microsoft\Windows NT\CurrentVersion\Winlogon -> PasswordExpiryWarning -> r:\w\w\w+;'
  - id: 12014
    title: "Ensure 'Interactive logon: Smart card removal behavior' is set to 'Lock Workstation' or higher"
    description: "This policy setting determines what happens when the smart card for a logged-on user is removed from the smart card reader. The recommended state for this setting is: Lock Workstation. Configuring this setting to Force Logoff or Disconnect if a Remote Desktop Services session also conforms to the benchmark."
@@ -227,8 +227,8 @@ checks:
     - cis_csc: "16.5"
    condition: any
    rules:
-     - 'r:HKEY_LOCAL_MACHINE\Software\Microsoft\WindowsNT\CurrentVersion\Winlogon -> ScRemoveOption -> 0;'
-     - 'r:HKEY_LOCAL_MACHINE\Software\Microsoft\WindowsNT\CurrentVersion\Winlogon -> !ScRemoveOption;'
+     - 'r:HKEY_LOCAL_MACHINE\Software\Microsoft\Windows NT\CurrentVersion\Winlogon -> ScRemoveOption -> 0;'
+     - 'r:HKEY_LOCAL_MACHINE\Software\Microsoft\Windows NT\CurrentVersion\Winlogon -> !ScRemoveOption;'
  - id: 12015
    title: "Ensure 'Microsoft network client: Digitally sign communications (always)' is set to 'Enabled'"
    description: "This policy setting determines whether packet signing is required by the SMB client component. Note: When Windows Vista-based computers have this policy setting enabled and they connect to file or print shares on remote servers, it is important that the setting is synchronized with its companion setting, Microsoft network server: Digitally sign communications (always), on those servers. For more information about these settings, see the \"Microsoft network client and server: Digitally sign communications (four related settings)\" section in Chapter 5 of the Threats and Countermeasures guide. The recommended state for this setting is: Enabled."

--- a/sca/windows/cis_win2012r2_domainL1_rcl.yml
+++ b/sca/windows/cis_win2012r2_domainL1_rcl.yml
@@ -115,8 +115,8 @@ checks:
     - cis_csc: "5.1"
    condition: any
    rules:
-     - 'r:HKEY_LOCAL_MACHINE\Software\Microsoft\WindowsNT\CurrentVersion\Winlogon -> AllocateDASD -> 1;'
-     - 'r:HKEY_LOCAL_MACHINE\Software\Microsoft\WindowsNT\CurrentVersion\Winlogon -> AllocateDASD -> 2;'
+     - 'r:HKEY_LOCAL_MACHINE\Software\Microsoft\Windows NT\CurrentVersion\Winlogon -> AllocateDASD -> 1;'
+     - 'r:HKEY_LOCAL_MACHINE\Software\Microsoft\Windows NT\CurrentVersion\Winlogon -> AllocateDASD -> 2;'
  - id: 8006
    title: "Ensure 'Devices: Prevent users from installing printer drivers' is set to 'Enabled'"
    description: "For a computer to print to a shared printer, the driver for that shared printer must be installed on the local computer. This security setting determines who is allowed to install a printer driver as part of connecting to a shared printer.  The recommended state for this setting is: Enabled.  Note: This setting does not affect the ability to add a local printer. This setting does not affect Administrators."
@@ -280,23 +280,23 @@ checks:
     - cis_csc: "16"
    condition: any
    rules:
-     - 'r:HKEY_LOCAL_MACHINE\Software\Microsoft\WindowsNT\CurrentVersion\Winlogon -> PasswordExpiryWarning -> 0;'
-     - 'r:HKEY_LOCAL_MACHINE\Software\Microsoft\WindowsNT\CurrentVersion\Winlogon -> PasswordExpiryWarning -> 1;'
-     - 'r:HKEY_LOCAL_MACHINE\Software\Microsoft\WindowsNT\CurrentVersion\Winlogon -> PasswordExpiryWarning -> 2;'
-     - 'r:HKEY_LOCAL_MACHINE\Software\Microsoft\WindowsNT\CurrentVersion\Winlogon -> PasswordExpiryWarning -> 3;'
-     - 'r:HKEY_LOCAL_MACHINE\Software\Microsoft\WindowsNT\CurrentVersion\Winlogon -> PasswordExpiryWarning -> 4;'
-     - 'r:HKEY_LOCAL_MACHINE\Software\Microsoft\WindowsNT\CurrentVersion\Winlogon -> PasswordExpiryWarning -> 0F;'
-     - 'r:HKEY_LOCAL_MACHINE\Software\Microsoft\WindowsNT\CurrentVersion\Winlogon -> PasswordExpiryWarning -> r:1\w;'
-     - 'r:HKEY_LOCAL_MACHINE\Software\Microsoft\WindowsNT\CurrentVersion\Winlogon -> PasswordExpiryWarning -> r:2\w;'
-     - 'r:HKEY_LOCAL_MACHINE\Software\Microsoft\WindowsNT\CurrentVersion\Winlogon -> PasswordExpiryWarning -> r:3\w;'
-     - 'r:HKEY_LOCAL_MACHINE\Software\Microsoft\WindowsNT\CurrentVersion\Winlogon -> PasswordExpiryWarning -> r:4\w;'
-     - 'r:HKEY_LOCAL_MACHINE\Software\Microsoft\WindowsNT\CurrentVersion\Winlogon -> PasswordExpiryWarning -> r:5\w;'
-     - 'r:HKEY_LOCAL_MACHINE\Software\Microsoft\WindowsNT\CurrentVersion\Winlogon -> PasswordExpiryWarning -> r:6\w;'
-     - 'r:HKEY_LOCAL_MACHINE\Software\Microsoft\WindowsNT\CurrentVersion\Winlogon -> PasswordExpiryWarning -> r:7\w;'
-     - 'r:HKEY_LOCAL_MACHINE\Software\Microsoft\WindowsNT\CurrentVersion\Winlogon -> PasswordExpiryWarning -> r:8\w;'
-     - 'r:HKEY_LOCAL_MACHINE\Software\Microsoft\WindowsNT\CurrentVersion\Winlogon -> PasswordExpiryWarning -> r:9\w;'
-     - 'r:HKEY_LOCAL_MACHINE\Software\Microsoft\WindowsNT\CurrentVersion\Winlogon -> PasswordExpiryWarning -> r:\D\w;'
-     - 'r:HKEY_LOCAL_MACHINE\Software\Microsoft\WindowsNT\CurrentVersion\Winlogon -> PasswordExpiryWarning -> r:\w\w\w+;'
+     - 'r:HKEY_LOCAL_MACHINE\Software\Microsoft\Windows NT\CurrentVersion\Winlogon -> PasswordExpiryWarning -> 0;'
+     - 'r:HKEY_LOCAL_MACHINE\Software\Microsoft\Windows NT\CurrentVersion\Winlogon -> PasswordExpiryWarning -> 1;'
+     - 'r:HKEY_LOCAL_MACHINE\Software\Microsoft\Windows NT\CurrentVersion\Winlogon -> PasswordExpiryWarning -> 2;'
+     - 'r:HKEY_LOCAL_MACHINE\Software\Microsoft\Windows NT\CurrentVersion\Winlogon -> PasswordExpiryWarning -> 3;'
+     - 'r:HKEY_LOCAL_MACHINE\Software\Microsoft\Windows NT\CurrentVersion\Winlogon -> PasswordExpiryWarning -> 4;'
+     - 'r:HKEY_LOCAL_MACHINE\Software\Microsoft\Windows NT\CurrentVersion\Winlogon -> PasswordExpiryWarning -> 0F;'
+     - 'r:HKEY_LOCAL_MACHINE\Software\Microsoft\Windows NT\CurrentVersion\Winlogon -> PasswordExpiryWarning -> r:1\w;'
+     - 'r:HKEY_LOCAL_MACHINE\Software\Microsoft\Windows NT\CurrentVersion\Winlogon -> PasswordExpiryWarning -> r:2\w;'
+     - 'r:HKEY_LOCAL_MACHINE\Software\Microsoft\Windows NT\CurrentVersion\Winlogon -> PasswordExpiryWarning -> r:3\w;'
+     - 'r:HKEY_LOCAL_MACHINE\Software\Microsoft\Windows NT\CurrentVersion\Winlogon -> PasswordExpiryWarning -> r:4\w;'
+     - 'r:HKEY_LOCAL_MACHINE\Software\Microsoft\Windows NT\CurrentVersion\Winlogon -> PasswordExpiryWarning -> r:5\w;'
+     - 'r:HKEY_LOCAL_MACHINE\Software\Microsoft\Windows NT\CurrentVersion\Winlogon -> PasswordExpiryWarning -> r:6\w;'
+     - 'r:HKEY_LOCAL_MACHINE\Software\Microsoft\Windows NT\CurrentVersion\Winlogon -> PasswordExpiryWarning -> r:7\w;'
+     - 'r:HKEY_LOCAL_MACHINE\Software\Microsoft\Windows NT\CurrentVersion\Winlogon -> PasswordExpiryWarning -> r:8\w;'
+     - 'r:HKEY_LOCAL_MACHINE\Software\Microsoft\Windows NT\CurrentVersion\Winlogon -> PasswordExpiryWarning -> r:9\w;'
+     - 'r:HKEY_LOCAL_MACHINE\Software\Microsoft\Windows NT\CurrentVersion\Winlogon -> PasswordExpiryWarning -> r:\D\w;'
+     - 'r:HKEY_LOCAL_MACHINE\Software\Microsoft\Windows NT\CurrentVersion\Winlogon -> PasswordExpiryWarning -> r:\w\w\w+;'
  - id: 8019
    title: "Ensure 'Interactive logon: Smart card removal behavior' is set to 'Lock Workstation' or higher"
    description: "This policy setting determines what happens when the smart card for a logged-on user is removed from the smart card reader.  The recommended state for this setting is: Lock Workstation. Configuring this setting to Force Logoff or Disconnect if a Remote Desktop Services session also conforms to the benchmark."
@@ -307,8 +307,8 @@ checks:
     - cis_csc: "16.5"
    condition: any
    rules:
-     - 'r:HKEY_LOCAL_MACHINE\Software\Microsoft\WindowsNT\CurrentVersion\Winlogon -> ScRemoveOption -> 0;'
-     - 'r:HKEY_LOCAL_MACHINE\Software\Microsoft\WindowsNT\CurrentVersion\Winlogon -> !ScRemoveOption;'
+     - 'r:HKEY_LOCAL_MACHINE\Software\Microsoft\Windows NT\CurrentVersion\Winlogon -> ScRemoveOption -> 0;'
+     - 'r:HKEY_LOCAL_MACHINE\Software\Microsoft\Windows NT\CurrentVersion\Winlogon -> !ScRemoveOption;'
  - id: 8020
    title: "Ensure 'Microsoft network client: Digitally sign communications (always)' is set to 'Enabled'"
    description: "This policy setting determines whether packet signing is required by the SMB client component.  Note: When Windows Vista-based computers have this policy setting enabled and they connect to file or print shares on remote servers, it is important that the setting is synchronized with its companion setting, Microsoft network server: Digitally sign communications (always), on those servers. For more information about these settings, see the 'Microsoft network client and server: Digitally sign communications (four related settings)' section in Chapter 5 of the Threats and Countermeasures guide.  The recommended state for this setting is: Enabled."

--- a/sca/windows/cis_win2012r2_memberL1_rcl.yml
+++ b/sca/windows/cis_win2012r2_memberL1_rcl.yml
@@ -115,8 +115,8 @@ checks:
     - cis_csc: "5.1"
    condition: any
    rules:
-     - 'r:HKEY_LOCAL_MACHINE\Software\Microsoft\WindowsNT\CurrentVersion\Winlogon -> AllocateDASD -> 1;'
-     - 'r:HKEY_LOCAL_MACHINE\Software\Microsoft\WindowsNT\CurrentVersion\Winlogon -> AllocateDASD -> 2;'
+     - 'r:HKEY_LOCAL_MACHINE\Software\Microsoft\Windows NT\CurrentVersion\Winlogon -> AllocateDASD -> 1;'
+     - 'r:HKEY_LOCAL_MACHINE\Software\Microsoft\Windows NT\CurrentVersion\Winlogon -> AllocateDASD -> 2;'
  - id: 9006
    title: "Ensure 'Devices: Prevent users from installing printer drivers' is set to 'Enabled'"
    description: "For a computer to print to a shared printer, the driver for that shared printer must be installed on the local computer. This security setting determines who is allowed to install a printer driver as part of connecting to a shared printer.  The recommended state for this setting is: Enabled.  Note: This setting does not affect the ability to add a local printer. This setting does not affect Administrators."
@@ -245,23 +245,23 @@ checks:
     - cis_csc: "16"
    condition: any
    rules:
-     - 'r:HKEY_LOCAL_MACHINE\Software\Microsoft\WindowsNT\CurrentVersion\Winlogon -> PasswordExpiryWarning -> 0;'
-     - 'r:HKEY_LOCAL_MACHINE\Software\Microsoft\WindowsNT\CurrentVersion\Winlogon -> PasswordExpiryWarning -> 1;'
-     - 'r:HKEY_LOCAL_MACHINE\Software\Microsoft\WindowsNT\CurrentVersion\Winlogon -> PasswordExpiryWarning -> 2;'
-     - 'r:HKEY_LOCAL_MACHINE\Software\Microsoft\WindowsNT\CurrentVersion\Winlogon -> PasswordExpiryWarning -> 3;'
-     - 'r:HKEY_LOCAL_MACHINE\Software\Microsoft\WindowsNT\CurrentVersion\Winlogon -> PasswordExpiryWarning -> 4;'
-     - 'r:HKEY_LOCAL_MACHINE\Software\Microsoft\WindowsNT\CurrentVersion\Winlogon -> PasswordExpiryWarning -> 0F;'
-     - 'r:HKEY_LOCAL_MACHINE\Software\Microsoft\WindowsNT\CurrentVersion\Winlogon -> PasswordExpiryWarning -> r:1\w;'
-     - 'r:HKEY_LOCAL_MACHINE\Software\Microsoft\WindowsNT\CurrentVersion\Winlogon -> PasswordExpiryWarning -> r:2\w;'
-     - 'r:HKEY_LOCAL_MACHINE\Software\Microsoft\WindowsNT\CurrentVersion\Winlogon -> PasswordExpiryWarning -> r:3\w;'
-     - 'r:HKEY_LOCAL_MACHINE\Software\Microsoft\WindowsNT\CurrentVersion\Winlogon -> PasswordExpiryWarning -> r:4\w;'
-     - 'r:HKEY_LOCAL_MACHINE\Software\Microsoft\WindowsNT\CurrentVersion\Winlogon -> PasswordExpiryWarning -> r:5\w;'
-     - 'r:HKEY_LOCAL_MACHINE\Software\Microsoft\WindowsNT\CurrentVersion\Winlogon -> PasswordExpiryWarning -> r:6\w;'
-     - 'r:HKEY_LOCAL_MACHINE\Software\Microsoft\WindowsNT\CurrentVersion\Winlogon -> PasswordExpiryWarning -> r:7\w;'
-     - 'r:HKEY_LOCAL_MACHINE\Software\Microsoft\WindowsNT\CurrentVersion\Winlogon -> PasswordExpiryWarning -> r:8\w;'
-     - 'r:HKEY_LOCAL_MACHINE\Software\Microsoft\WindowsNT\CurrentVersion\Winlogon -> PasswordExpiryWarning -> r:9\w;'
-     - 'r:HKEY_LOCAL_MACHINE\Software\Microsoft\WindowsNT\CurrentVersion\Winlogon -> PasswordExpiryWarning -> r:\D\w;'
-     - 'r:HKEY_LOCAL_MACHINE\Software\Microsoft\WindowsNT\CurrentVersion\Winlogon -> PasswordExpiryWarning -> r:\w\w\w+;'
+     - 'r:HKEY_LOCAL_MACHINE\Software\Microsoft\Windows NT\CurrentVersion\Winlogon -> PasswordExpiryWarning -> 0;'
+     - 'r:HKEY_LOCAL_MACHINE\Software\Microsoft\Windows NT\CurrentVersion\Winlogon -> PasswordExpiryWarning -> 1;'
+     - 'r:HKEY_LOCAL_MACHINE\Software\Microsoft\Windows NT\CurrentVersion\Winlogon -> PasswordExpiryWarning -> 2;'
+     - 'r:HKEY_LOCAL_MACHINE\Software\Microsoft\Windows NT\CurrentVersion\Winlogon -> PasswordExpiryWarning -> 3;'
+     - 'r:HKEY_LOCAL_MACHINE\Software\Microsoft\Windows NT\CurrentVersion\Winlogon -> PasswordExpiryWarning -> 4;'
+     - 'r:HKEY_LOCAL_MACHINE\Software\Microsoft\Windows NT\CurrentVersion\Winlogon -> PasswordExpiryWarning -> 0F;'
+     - 'r:HKEY_LOCAL_MACHINE\Software\Microsoft\Windows NT\CurrentVersion\Winlogon -> PasswordExpiryWarning -> r:1\w;'
+     - 'r:HKEY_LOCAL_MACHINE\Software\Microsoft\Windows NT\CurrentVersion\Winlogon -> PasswordExpiryWarning -> r:2\w;'
+     - 'r:HKEY_LOCAL_MACHINE\Software\Microsoft\Windows NT\CurrentVersion\Winlogon -> PasswordExpiryWarning -> r:3\w;'
+     - 'r:HKEY_LOCAL_MACHINE\Software\Microsoft\Windows NT\CurrentVersion\Winlogon -> PasswordExpiryWarning -> r:4\w;'
+     - 'r:HKEY_LOCAL_MACHINE\Software\Microsoft\Windows NT\CurrentVersion\Winlogon -> PasswordExpiryWarning -> r:5\w;'
+     - 'r:HKEY_LOCAL_MACHINE\Software\Microsoft\Windows NT\CurrentVersion\Winlogon -> PasswordExpiryWarning -> r:6\w;'
+     - 'r:HKEY_LOCAL_MACHINE\Software\Microsoft\Windows NT\CurrentVersion\Winlogon -> PasswordExpiryWarning -> r:7\w;'
+     - 'r:HKEY_LOCAL_MACHINE\Software\Microsoft\Windows NT\CurrentVersion\Winlogon -> PasswordExpiryWarning -> r:8\w;'
+     - 'r:HKEY_LOCAL_MACHINE\Software\Microsoft\Windows NT\CurrentVersion\Winlogon -> PasswordExpiryWarning -> r:9\w;'
+     - 'r:HKEY_LOCAL_MACHINE\Software\Microsoft\Windows NT\CurrentVersion\Winlogon -> PasswordExpiryWarning -> r:\D\w;'
+     - 'r:HKEY_LOCAL_MACHINE\Software\Microsoft\Windows NT\CurrentVersion\Winlogon -> PasswordExpiryWarning -> r:\w\w\w+;'
  - id: 9016
    title: "Ensure 'Interactive logon: Require Domain Controller Authentication to unlock workstation' is set to 'Enabled'"
    description: "Logon information is required to unlock a locked computer. For domain accounts, this security setting determines whether it is necessary to contact a Domain Controller to unlock a computer.  The recommended state for this setting is: Enabled."
@@ -284,8 +284,8 @@ checks:
     - cis_csc: "16.5"
    condition: any
    rules:
-     - 'r:HKEY_LOCAL_MACHINE\Software\Microsoft\WindowsNT\CurrentVersion\Winlogon -> ScRemoveOption -> 0;'
-     - 'r:HKEY_LOCAL_MACHINE\Software\Microsoft\WindowsNT\CurrentVersion\Winlogon -> !ScRemoveOption;'
+     - 'r:HKEY_LOCAL_MACHINE\Software\Microsoft\Windows NT\CurrentVersion\Winlogon -> ScRemoveOption -> 0;'
+     - 'r:HKEY_LOCAL_MACHINE\Software\Microsoft\Windows NT\CurrentVersion\Winlogon -> !ScRemoveOption;'
  - id: 9018
    title: "Ensure 'Microsoft network client: Digitally sign communications (always)' is set to 'Enabled'"
    description: "This policy setting determines whether packet signing is required by the SMB client component.  Note: When Windows Vista-based computers have this policy setting enabled and they connect to file or print shares on remote servers, it is important that the setting is synchronized with its companion setting, Microsoft network server: Digitally sign communications (always), on those servers. For more information about these settings, see the 'Microsoft network client and server: Digitally sign communications (four related settings)' section in Chapter 5 of the Threats and Countermeasures guide.  The recommended state for this setting is: Enabled."

--- a/sca/windows/win_audit_rcl.yml
+++ b/sca/windows/win_audit_rcl.yml
@@ -96,8 +96,8 @@ checks:
     - pci_dss: "10.6.1"
    condition: any
    rules:
-     - 'r:HKLM\SOFTWARE\Microsoft\WindowsNT\CurrentVersion\Winlogon -> DefaultPassword;'
-     - 'r:HKLM\SOFTWARE\Microsoft\WindowsNT\CurrentVersion\Winlogon -> AutoAdminLogon -> 1;'
+     - 'r:HKLM\Software\Microsoft\Windows NT\CurrentVersion\Winlogon -> DefaultPassword;'
+     - 'r:HKLM\Software\Microsoft\Windows NT\CurrentVersion\Winlogon -> AutoAdminLogon -> 1;'
  - id: 2508
    title: "Winpcap packet filter driver found"
    compliance:


### PR DESCRIPTION
### Wrong path for Windows NT registries

As explained at #391, the registry paths for Windows NT are wrong, resulting on many checks stated as `sca.check.status: Not applicable`.

This is now fixed by setting the correct path.


### Tests made

- [x] windows/cis_win10_enterprise_L1_rcl.yml

- Affected checks: 12127,12143,12145,12158,12159,12160,12192,12193,12194,12194,12196,12197,12198

Alerts generated:
```
** Alert 1557748260.3645984: - sca,gdpr_IV_35.7.d
2019 May 13 13:51:00 (windows10) any->sca
Rule: 19009 (level 3) -> 'CIS benchmark for Windows 10 Enterprise (Release 1709): Ensure 'Turn off multicast name resolution' is set to 'Enabled''
{"type":"check","id":311062296,"policy":"CIS benchmark for Windows 10 Enterprise (Release 1709)","policy_id":"cis_win10_enterprise_L1","check":{"id":12127,"title":"Ensure 'Turn off multicast name resolution' is set to 'Enabled'","description":"LLMNR is a secondary name resolution protocol. With LLMNR, queries are sent using multicast over a local network link on a single subnet from a client computer to another client computer on the same subnet that also has LLMNR enabled. LLMNR does not require a DNS server or DNS client configuration, and provides name resolution in scenarios in which conventional DNS name resolution is not possible. The recommended state for this setting is: Enabled.","rationale":"An attacker can listen on a network for these LLMNR (UDP/5355) or NBT-NS (UDP/137) broadcasts and respond to them, tricking the host into thinking that it knows the location of the requested system.","remediation":"To establish the recommended configuration via GP, set the following UI path to Enabled: Computer Configuration\\Policies\\Administrative Templates\\Network\\DNS Client\\Turn off multicast name resolution","compliance":{"cis":"18.5.4.2","cis_csc":"9"},"rules":["r:HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\Microsoft\\Windows NT\\DNSClient -> EnableMulticast -> !0;","r:HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\Microsoft\\Windows NT\\DNSClient -> !EnableMulticast;"],"registry":"HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\Microsoft\\Windows NT\\DNSClient","status":"Not applicable","reason":"Unable to read registry 'HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\Microsoft\\Windows NT\\DNSClient' (The system cannot find the file specified. )"}}
sca.type: check
sca.scan_id: 311062296
sca.policy: CIS benchmark for Windows 10 Enterprise (Release 1709)
sca.check.id: 12127
sca.check.title: Ensure 'Turn off multicast name resolution' is set to 'Enabled'
sca.check.description: LLMNR is a secondary name resolution protocol. With LLMNR, queries are sent using multicast over a local network link on a single subnet from a client computer to another client computer on the same subnet that also has LLMNR enabled. LLMNR does not require a DNS server or DNS client configuration, and provides name resolution in scenarios in which conventional DNS name resolution is not possible. The recommended state for this setting is: Enabled.
sca.check.rationale: An attacker can listen on a network for these LLMNR (UDP/5355) or NBT-NS (UDP/137) broadcasts and respond to them, tricking the host into thinking that it knows the location of the requested system.
sca.check.remediation: To establish the recommended configuration via GP, set the following UI path to Enabled: Computer Configuration\Policies\Administrative Templates\Network\DNS Client\Turn off multicast name resolution
sca.check.compliance.cis: 18.5.4.2
sca.check.compliance.cis_csc: 9
sca.check.registry: ["HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\Microsoft\\Windows NT\\DNSClient"]
sca.check.status: Not applicable
sca.check.reason: Unable to read registry 'HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\DNSClient' (The system cannot find the file specified. )


** Alert 1557748260.3702543: - sca,gdpr_IV_35.7.d
2019 May 13 13:51:00 (windows10) any->sca
Rule: 19009 (level 3) -> 'CIS benchmark for Windows 10 Enterprise (Release 1709): Ensure 'Turn off downloading of print drivers over HTTP' is set to 'Enabled''
{"type":"check","id":311062296,"policy":"CIS benchmark for Windows 10 Enterprise (Release 1709)","policy_id":"cis_win10_enterprise_L1","check":{"id":12143,"title":"Ensure 'Turn off downloading of print drivers over HTTP' is set to 'Enabled'","description":"This policy setting specifies whether to use the Store service for finding an application to open a file with an unhandled file type or protocol association. When a user opens a file type or protocol that is not associated with any applications on the computer, the user is given the choice to select a local application or use the Store service to find an application.","rationale":"The Store service is a retail outlet built into Windows, primarily for consumer use. In an enterprise managed environment the IT department should be managing the installation of all applications to reduce the risk of the installation of vulnerable software.","remediation":"To establish the recommended configuration via GP, set the following UI path to Enabled: Computer Configuration\\Policies\\Administrative Templates\\System\\Internet Communication Management\\Internet Communication settings\\Turn off access to the Store","compliance":{"cis":"18.8.22.1.2","cis_csc":"2"},"rules":["r:HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\Microsoft\\Windows NT\\Printers -> DisableWebPnPDownload -> !1;","r:HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\Microsoft\\Windows NT\\Printers -> !DisableWebPnPDownload;"],"registry":"HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\Microsoft\\Windows NT\\Printers","status":"Not applicable","reason":"Unable to read registry 'HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\Microsoft\\Windows NT\\Printers' (The system cannot find the file specified. )"}}
sca.type: check
sca.scan_id: 311062296
sca.policy: CIS benchmark for Windows 10 Enterprise (Release 1709)
sca.check.id: 12143
sca.check.title: Ensure 'Turn off downloading of print drivers over HTTP' is set to 'Enabled'
sca.check.description: This policy setting specifies whether to use the Store service for finding an application to open a file with an unhandled file type or protocol association. When a user opens a file type or protocol that is not associated with any applications on the computer, the user is given the choice to select a local application or use the Store service to find an application.
sca.check.rationale: The Store service is a retail outlet built into Windows, primarily for consumer use. In an enterprise managed environment the IT department should be managing the installation of all applications to reduce the risk of the installation of vulnerable software.
sca.check.remediation: To establish the recommended configuration via GP, set the following UI path to Enabled: Computer Configuration\Policies\Administrative Templates\System\Internet Communication Management\Internet Communication settings\Turn off access to the Store
sca.check.compliance.cis: 18.8.22.1.2
sca.check.compliance.cis_csc: 2
sca.check.registry: ["HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\Microsoft\\Windows NT\\Printers"]
sca.check.status: Not applicable
sca.check.reason: Unable to read registry 'HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Printers' (The system cannot find the file specified. )

** Alert 1557748260.3708994: - sca,gdpr_IV_35.7.d
2019 May 13 13:51:00 (windows10) any->sca
Rule: 19009 (level 3) -> 'CIS benchmark for Windows 10 Enterprise (Release 1709): Ensure 'Turn off printing over HTTP' is set to 'Enabled''
{"type":"check","id":311062296,"policy":"CIS benchmark for Windows 10 Enterprise (Release 1709)","policy_id":"cis_win10_enterprise_L1","check":{"id":12145,"title":"Ensure 'Turn off printing over HTTP' is set to 'Enabled'","description":"This policy setting allows you to disable the client computer's ability to print over HTTP, which allows the computer to print to printers on the intranet as well as the Internet.","rationale":"Information that is transmitted over HTTP through this capability is not protected and can be intercepted by malicious users. For this reason, it is not often used in enterprise managed environments.","remediation":"To establish the recommended configuration via GP, set the following UI path to Enabled: Computer Configuration\\Policies\\Administrative Templates\\System\\Internet Communication Management\\Internet Communication settings\\Turn off printing over HTTP","compliance":{"cis":"18.8.22.1.7","cis_csc":"13.1"},"rules":["r:HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\Microsoft\\Windows NT\\Printers -> DisableHTTPPrinting -> !1;","r:HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\Microsoft\\Windows NT\\Printers -> !DisableHTTPPrinting;"],"registry":"HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\Microsoft\\Windows NT\\Printers","status":"Not applicable","reason":"Unable to read registry 'HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\Microsoft\\Windows NT\\Printers' (The system cannot find the file specified. )"}}
sca.type: check
sca.scan_id: 311062296
sca.policy: CIS benchmark for Windows 10 Enterprise (Release 1709)
sca.check.id: 12145
sca.check.title: Ensure 'Turn off printing over HTTP' is set to 'Enabled'
sca.check.description: This policy setting allows you to disable the client computer's ability to print over HTTP, which allows the computer to print to printers on the intranet as well as the Internet.
sca.check.rationale: Information that is transmitted over HTTP through this capability is not protected and can be intercepted by malicious users. For this reason, it is not often used in enterprise managed environments.
sca.check.remediation: To establish the recommended configuration via GP, set the following UI path to Enabled: Computer Configuration\Policies\Administrative Templates\System\Internet Communication Management\Internet Communication settings\Turn off printing over HTTP
sca.check.compliance.cis: 18.8.22.1.7
sca.check.compliance.cis_csc: 13.1
sca.check.registry: ["HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\Microsoft\\Windows NT\\Printers"]
sca.check.status: Not applicable
sca.check.reason: Unable to read registry 'HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Printers' (The system cannot find the file specified. )

** Alert 1557748261.3746886: - sca,gdpr_IV_35.7.d
2019 May 13 13:51:01 (windows10) any->sca
Rule: 19009 (level 3) -> 'CIS benchmark for Windows 10 Enterprise (Release 1709): Ensure 'Configure Solicited Remote Assistance' is set to 'Disabled''
{"type":"check","id":311062296,"policy":"CIS benchmark for Windows 10 Enterprise (Release 1709)","policy_id":"cis_win10_enterprise_L1","check":{"id":12158,"title":"Ensure 'Configure Solicited Remote Assistance' is set to 'Disabled'","description":"This policy setting allows you to turn on or turn off Solicited (Ask for) Remote Assistance on this computer.","rationale":"There is slight risk that a rogue administrator will gain access to another user's desktop session, however, they cannot connect to a user's computer unannounced or control it without permission from the user. When an expert tries to connect, the user can still choose to deny the connection or give the expert view-only privileges. The user must explicitly click the Yes button to allow the expert to remotely control the workstation.","remediation":"To establish the recommended configuration via GP, set the following UI path to Disabled: Computer Configuration\\Policies\\Administrative Templates\\System\\Remote Assistance\\Configure Solicited Remote Assistance","compliance":{"cis":"18.8.35.2","cis_csc":"5.1"},"rules":["r:HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\Microsoft\\Windows NT\\Terminal Services -> fAllowToGetHelp -> !0;","r:HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\Microsoft\\Windows NT\\Terminal Services -> !fAllowToGetHelp;"],"registry":"HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\Microsoft\\Windows NT\\Terminal Services","status":"Not applicable","reason":"Key 'fAllowToGetHelp' not found for registry 'HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\Microsoft\\Windows NT\\Terminal Services'"}}
sca.type: check
sca.scan_id: 311062296
sca.policy: CIS benchmark for Windows 10 Enterprise (Release 1709)
sca.check.id: 12158
sca.check.title: Ensure 'Configure Solicited Remote Assistance' is set to 'Disabled'
sca.check.description: This policy setting allows you to turn on or turn off Solicited (Ask for) Remote Assistance on this computer.
sca.check.rationale: There is slight risk that a rogue administrator will gain access to another user's desktop session, however, they cannot connect to a user's computer unannounced or control it without permission from the user. When an expert tries to connect, the user can still choose to deny the connection or give the expert view-only privileges. The user must explicitly click the Yes button to allow the expert to remotely control the workstation.
sca.check.remediation: To establish the recommended configuration via GP, set the following UI path to Disabled: Computer Configuration\Policies\Administrative Templates\System\Remote Assistance\Configure Solicited Remote Assistance
sca.check.compliance.cis: 18.8.35.2
sca.check.compliance.cis_csc: 5.1
sca.check.registry: ["HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\Microsoft\\Windows NT\\Terminal Services"]
sca.check.status: Not applicable
sca.check.reason: Key 'fAllowToGetHelp' not found for registry 'HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Terminal Services'


** Alert 1557748261.3750090: - sca,gdpr_IV_35.7.d
2019 May 13 13:51:01 (windows10) any->sca
Rule: 19009 (level 3) -> 'CIS benchmark for Windows 10 Enterprise (Release 1709): Ensure 'Enable RPC Endpoint Mapper Client Authentication' is set to 'Enabled''
{"type":"check","id":311062296,"policy":"CIS benchmark for Windows 10 Enterprise (Release 1709)","policy_id":"cis_win10_enterprise_L1","check":{"id":12159,"title":"Ensure 'Enable RPC Endpoint Mapper Client Authentication' is set to 'Enabled'","description":"This policy setting controls whether RPC clients authenticate with the Endpoint Mapper Service when the call they are making contains authentication information. The Endpoint Mapper Service on computers running Windows NT4 (all service packs) cannot process authentication information supplied in this manner. This policy setting can cause a specific issue with 1-way forest trusts if it is applied to the trusting domain DCs (see Microsoft KB3073942), so we do not recommend applying it to Domain Controllers.","rationale":"Anonymous access to RPC services could result in accidental disclosure of information to unauthenticated users.","remediation":"To establish the recommended configuration via GP, set the following UI path to Enabled: Computer Configuration\\Policies\\Administrative Templates\\System\\Remote Procedure Call\\Enable RPC Endpoint Mapper Client Authentication","compliance":{"cis":"18.8.36.1","cis_csc":"9.1, 9.2"},"rules":["r:HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\Microsoft\\Windows NT\\Rpc -> EnableAuthEpResolution -> !1;","r:HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\Microsoft\\Windows NT\\Rpc -> !EnableAuthEpResolution;"],"registry":"HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\Microsoft\\Windows NT\\Rpc","status":"Not applicable","reason":"Unable to read registry 'HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\Microsoft\\Windows NT\\Rpc' (The system cannot find the file specified. )"}}
sca.type: check
sca.scan_id: 311062296
sca.policy: CIS benchmark for Windows 10 Enterprise (Release 1709)
sca.check.id: 12159
sca.check.title: Ensure 'Enable RPC Endpoint Mapper Client Authentication' is set to 'Enabled'
sca.check.description: This policy setting controls whether RPC clients authenticate with the Endpoint Mapper Service when the call they are making contains authentication information. The Endpoint Mapper Service on computers running Windows NT4 (all service packs) cannot process authentication information supplied in this manner. This policy setting can cause a specific issue with 1-way forest trusts if it is applied to the trusting domain DCs (see Microsoft KB3073942), so we do not recommend applying it to Domain Controllers.
sca.check.rationale: Anonymous access to RPC services could result in accidental disclosure of information to unauthenticated users.
sca.check.remediation: To establish the recommended configuration via GP, set the following UI path to Enabled: Computer Configuration\Policies\Administrative Templates\System\Remote Procedure Call\Enable RPC Endpoint Mapper Client Authentication
sca.check.compliance.cis: 18.8.36.1
sca.check.compliance.cis_csc: 9.1, 9.2
sca.check.registry: ["HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\Microsoft\\Windows NT\\Rpc"]
sca.check.status: Not applicable
sca.check.reason: Unable to read registry 'HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Rpc' (The system cannot find the file specified. )

** Alert 1557748261.3753496: - sca,gdpr_IV_35.7.d
2019 May 13 13:51:01 (windows10) any->sca
Rule: 19009 (level 3) -> 'CIS benchmark for Windows 10 Enterprise (Release 1709): Ensure 'Restrict Unauthenticated RPC clients' is set to 'Enabled: Authenticated''
{"type":"check","id":311062296,"policy":"CIS benchmark for Windows 10 Enterprise (Release 1709)","policy_id":"cis_win10_enterprise_L1","check":{"id":12160,"title":"Ensure 'Restrict Unauthenticated RPC clients' is set to 'Enabled: Authenticated'","description":"This policy setting controls how the RPC server runtime handles unauthenticated RPC clients connecting to RPC servers. This policy setting impacts all RPC applications. In a domain environment this policy setting should be used with caution as it can impact a wide range of functionality including group policy processing itself. Reverting a change to this policy setting can require manual intervention on each affected machine. This policy setting should never be applied to a Domain Controller. A client will be considered an authenticated client if it uses a named pipe to communicate with the server or if it uses RPC Security. RPC Interfaces that have specifically requested to be accessible by unauthenticated clients may be exempt from this restriction, depending on the selected value for this policy setting. -- None allows all RPC clients to connect to RPC Servers running on the machine on which the policy setting is applied. -- Authenticated allows only authenticated RPC Clients (per the definition above) to connect to RPC Servers running on the machine on which the policy setting is applied. Exemptions are granted to interfaces that have requested them. -- Authenticated without exceptions allows only authenticated RPC Clients (per the definition above) to connect to RPC Servers running on the machine on which the policy setting is applied. No exceptions are allowed. This value has the potential to cause serious problems and is not recommended.'","rationale":"Unauthenticated RPC communication can create a security vulnerability.","remediation":"To establish the recommended configuration via GP, set the following UI path to Enabled: Authenticated: Computer Configuration\\Policies\\Administrative Templates\\System\\Remote Procedure Call\\Restrict Unauthenticated RPC clients","compliance":{"cis":"18.8.36.2","cis_csc":"9.1, 9.2"},"rules":["r:HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\Microsoft\\Windows NT\\Rpc -> RestrictRemoteClients -> !1;"],"registry":"HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\Microsoft\\Windows NT\\Rpc","status":"Not applicable","reason":"Unable to read registry 'HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\Microsoft\\Windows NT\\Rpc' (The system cannot find the file specified. )"}}
sca.type: check
sca.scan_id: 311062296
sca.policy: CIS benchmark for Windows 10 Enterprise (Release 1709)
sca.check.id: 12160
sca.check.title: Ensure 'Restrict Unauthenticated RPC clients' is set to 'Enabled: Authenticated'
sca.check.description: This policy setting controls how the RPC server runtime handles unauthenticated RPC clients connecting to RPC servers. This policy setting impacts all RPC applications. In a domain environment this policy setting should be used with caution as it can impact a wide range of functionality including group policy processing itself. Reverting a change to this policy setting can require manual intervention on each affected machine. This policy setting should never be applied to a Domain Controller. A client will be considered an authenticated client if it uses a named pipe to communicate with the server or if it uses RPC Security. RPC Interfaces that have specifically requested to be accessible by unauthenticated clients may be exempt from this restriction, depending on the selected value for this policy setting. -- None allows all RPC clients to connect to RPC Servers running on the machine on which the policy setting is applied. -- Authenticated allows only authenticated RPC Clients (per the definition above) to connect to RPC Servers running on the machine on which the policy setting is applied. Exemptions are granted to interfaces that have requested them. -- Authenticated without exceptions allows only authenticated RPC Clients (per the definition above) to connect to RPC Servers running on the machine on which the policy setting is applied. No exceptions are allowed. This value has the potential to cause serious problems and is not recommended.'
sca.check.rationale: Unauthenticated RPC communication can create a security vulnerability.
sca.check.remediation: To establish the recommended configuration via GP, set the following UI path to Enabled: Authenticated: Computer Configuration\Policies\Administrative Templates\System\Remote Procedure Call\Restrict Unauthenticated RPC clients
sca.check.compliance.cis: 18.8.36.2
sca.check.compliance.cis_csc: 9.1, 9.2
sca.check.registry: ["HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\Microsoft\\Windows NT\\Rpc"]
sca.check.status: Not applicable
sca.check.reason: Unable to read registry 'HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Rpc' (The system cannot find the file specified. )


** Alert 1557748261.3857719: - sca,gdpr_IV_35.7.d
2019 May 13 13:51:01 (windows10) any->sca
Rule: 19009 (level 3) -> 'CIS benchmark for Windows 10 Enterprise (Release 1709): Ensure 'Do not allow passwords to be saved' is set to 'Enabled''
{"type":"check","id":311062296,"policy":"CIS benchmark for Windows 10 Enterprise (Release 1709)","policy_id":"cis_win10_enterprise_L1","check":{"id":12192,"title":"Ensure 'Do not allow passwords to be saved' is set to 'Enabled'","description":"This policy setting helps prevent Remote Desktop clients from saving passwords on a computer.","rationale":"An attacker with physical access to the computer may be able to break the protection guarding saved passwords. An attacker who compromises a user's account and connects to their computer could use saved passwords to gain access to additional hosts","remediation":"To establish the recommended configuration via GP, set the following UI path to Enabled: Computer Configuration\\Policies\\Administrative Templates\\Windows Components\\Remote Desktop Services\\Remote Desktop Connection Client\\Do not allow passwords to be saved","compliance":{"cis":"18.9.58.2.2","cis_csc":"16.4"},"rules":["r:HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\Microsoft\\Windows NT\\Terminal Services -> DisablePasswordSaving -> !1;","r:HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\Microsoft\\Windows NT\\Terminal Services -> !DisablePasswordSaving;"],"registry":"HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\Microsoft\\Windows NT\\Terminal Services","status":"Not applicable","reason":"Key 'DisablePasswordSaving' not found for registry 'HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\Microsoft\\Windows NT\\Terminal Services'"}}
sca.type: check
sca.scan_id: 311062296
sca.policy: CIS benchmark for Windows 10 Enterprise (Release 1709)
sca.check.id: 12192
sca.check.title: Ensure 'Do not allow passwords to be saved' is set to 'Enabled'
sca.check.description: This policy setting helps prevent Remote Desktop clients from saving passwords on a computer.
sca.check.rationale: An attacker with physical access to the computer may be able to break the protection guarding saved passwords. An attacker who compromises a user's account and connects to their computer could use saved passwords to gain access to additional hosts
sca.check.remediation: To establish the recommended configuration via GP, set the following UI path to Enabled: Computer Configuration\Policies\Administrative Templates\Windows Components\Remote Desktop Services\Remote Desktop Connection Client\Do not allow passwords to be saved
sca.check.compliance.cis: 18.9.58.2.2
sca.check.compliance.cis_csc: 16.4
sca.check.registry: ["HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\Microsoft\\Windows NT\\Terminal Services"]
sca.check.status: Not applicable
sca.check.reason: Key 'DisablePasswordSaving' not found for registry 'HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Terminal Services'


** Alert 1557748261.3860628: - sca,gdpr_IV_35.7.d
2019 May 13 13:51:01 (windows10) any->sca
Rule: 19009 (level 3) -> 'CIS benchmark for Windows 10 Enterprise (Release 1709): Ensure 'Do not allow drive redirection' is set to 'Enabled''
{"type":"check","id":311062296,"policy":"CIS benchmark for Windows 10 Enterprise (Release 1709)","policy_id":"cis_win10_enterprise_L1","check":{"id":12193,"title":"Ensure 'Do not allow drive redirection' is set to 'Enabled'","description":"This policy setting prevents users from sharing the local drives on their client computers to Remote Desktop Servers that they access. Mapped drives appear in the session folder tree in Windows Explorer in the following format: \\TSClient\\<driveletter>$ If local drives are shared they are left vulnerable to intruders who want to exploit the data that is stored on them.","rationale":"Data could be forwarded from the user's Remote Desktop Services session to the user's local computer without any direct user interaction. Malicious software already present on a compromised server would have direct and stealthy disk access to the user's local computer during the Remote Desktop session.","remediation":"To establish the recommended configuration via GP, set the following UI path to Enabled: Computer Configuration\\Policies\\Administrative Templates\\Windows Components\\Remote Desktop Services\\Remote Desktop Session Host\\Device and Resource Redirection\\Do not allow drive redirection","compliance":{"cis":"18.9.58.3.3.2","cis_csc":"13"},"rules":["r:HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\Microsoft\\Windows NT\\Terminal Services -> fDisableCdma -> !1;","r:HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\Microsoft\\Windows NT\\Terminal Services -> !fDisableCdm;"],"registry":"HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\Microsoft\\Windows NT\\Terminal Services","status":"Not applicable","reason":"Key 'fDisableCdma' not found for registry 'HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\Microsoft\\Windows NT\\Terminal Services'"}}
sca.type: check
sca.scan_id: 311062296
sca.policy: CIS benchmark for Windows 10 Enterprise (Release 1709)
sca.check.id: 12193
sca.check.title: Ensure 'Do not allow drive redirection' is set to 'Enabled'
sca.check.description: This policy setting prevents users from sharing the local drives on their client computers to Remote Desktop Servers that they access. Mapped drives appear in the session folder tree in Windows Explorer in the following format: \TSClient\<driveletter>$ If local drives are shared they are left vulnerable to intruders who want to exploit the data that is stored on them.
sca.check.rationale: Data could be forwarded from the user's Remote Desktop Services session to the user's local computer without any direct user interaction. Malicious software already present on a compromised server would have direct and stealthy disk access to the user's local computer during the Remote Desktop session.
sca.check.remediation: To establish the recommended configuration via GP, set the following UI path to Enabled: Computer Configuration\Policies\Administrative Templates\Windows Components\Remote Desktop Services\Remote Desktop Session Host\Device and Resource Redirection\Do not allow drive redirection
sca.check.compliance.cis: 18.9.58.3.3.2
sca.check.compliance.cis_csc: 13
sca.check.registry: ["HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\Microsoft\\Windows NT\\Terminal Services"]
sca.check.status: Not applicable
sca.check.reason: Key 'fDisableCdma' not found for registry 'HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Terminal Services'

** Alert 1557748261.3864203: - sca,gdpr_IV_35.7.d
2019 May 13 13:51:01 (windows10) any->sca
Rule: 19009 (level 3) -> 'CIS benchmark for Windows 10 Enterprise (Release 1709): Ensure 'Always prompt for password upon connection' is set to 'Enabled''
{"type":"check","id":311062296,"policy":"CIS benchmark for Windows 10 Enterprise (Release 1709)","policy_id":"cis_win10_enterprise_L1","check":{"id":12194,"title":"Ensure 'Always prompt for password upon connection' is set to 'Enabled'","description":"This policy setting specifies whether Remote Desktop Services always prompts the client computer for a password upon connection. You can use this policy setting to enforce a password prompt for users who log on to Remote Desktop Services, even if they already provided the password in the Remote Desktop Connection client.","rationale":"Users have the option to store both their username and password when they create a new Remote Desktop Connection shortcut. If the server that runs Remote Desktop Services allows users who have used this feature to log on to the server but not enter their password, then it is possible that an attacker who has gained physical access to the user's computer could connect to a Remote Desktop Server through the Remote Desktop Connection shortcut, even though they may not know the user's password.","remediation":"To establish the recommended configuration via GP, set the following UI path to Enabled: Computer Configuration\\Policies\\Administrative Templates\\Windows Components\\Remote Desktop Services\\Remote Desktop Session Host\\Security\\Always prompt for password upon connection","compliance":{"cis":"18.9.58.3.9.1","cis_csc":"16.14"},"rules":["r:HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\Microsoft\\Windows NT\\Terminal Services -> fPromptForPassword -> !1;","r:HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\Microsoft\\Windows NT\\Terminal Services -> !fPromptForPassword;"],"registry":"HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\Microsoft\\Windows NT\\Terminal Services","status":"Not applicable","reason":"Key 'fPromptForPassword' not found for registry 'HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\Microsoft\\Windows NT\\Terminal Services'"}}
sca.type: check
sca.scan_id: 311062296
sca.policy: CIS benchmark for Windows 10 Enterprise (Release 1709)
sca.check.id: 12194
sca.check.title: Ensure 'Always prompt for password upon connection' is set to 'Enabled'
sca.check.description: This policy setting specifies whether Remote Desktop Services always prompts the client computer for a password upon connection. You can use this policy setting to enforce a password prompt for users who log on to Remote Desktop Services, even if they already provided the password in the Remote Desktop Connection client.
sca.check.rationale: Users have the option to store both their username and password when they create a new Remote Desktop Connection shortcut. If the server that runs Remote Desktop Services allows users who have used this feature to log on to the server but not enter their password, then it is possible that an attacker who has gained physical access to the user's computer could connect to a Remote Desktop Server through the Remote Desktop Connection shortcut, even though they may not know the user's password.
sca.check.remediation: To establish the recommended configuration via GP, set the following UI path to Enabled: Computer Configuration\Policies\Administrative Templates\Windows Components\Remote Desktop Services\Remote Desktop Session Host\Security\Always prompt for password upon connection
sca.check.compliance.cis: 18.9.58.3.9.1
sca.check.compliance.cis_csc: 16.14
sca.check.registry: ["HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\Microsoft\\Windows NT\\Terminal Services"]
sca.check.status: Not applicable
sca.check.reason: Key 'fPromptForPassword' not found for registry 'HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Terminal Services'


** Alert 1557748261.3868109: - sca,gdpr_IV_35.7.d
2019 May 13 13:51:01 (windows10) any->sca
Rule: 19009 (level 3) -> 'CIS benchmark for Windows 10 Enterprise (Release 1709): Ensure 'Require secure RPC communication' is set to 'Enabled''
{"type":"check","id":311062296,"policy":"CIS benchmark for Windows 10 Enterprise (Release 1709)","policy_id":"cis_win10_enterprise_L1","check":{"id":12195,"title":"Ensure 'Require secure RPC communication' is set to 'Enabled'","description":"This policy setting allows you to specify whether Remote Desktop Services requires secure Remote Procedure Call (RPC) communication with all clients or allows unsecured communication. You can use this policy setting to strengthen the security of RPC communication with clients by allowing only authenticated and encrypted requests.","rationale":"Allowing unsecure RPC communication can exposes the server to man in the middle attacks and data disclosure attacks.","remediation":"To establish the recommended configuration via GP, set the following UI path to Enabled: Computer Configuration\\Policies\\Administrative Templates\\Windows Components\\Remote Desktop Services\\Remote Desktop Session Host\\Security\\Require secure RPC communication","compliance":{"cis":"18.9.58.3.9.2","cis_csc":"3.4"},"rules":["r:HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\Microsoft\\Windows NT\\Terminal Services -> fEncryptRPCTraffic -> !1;","r:HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\Microsoft\\Windows NT\\Terminal Services -> !fEncryptRPCTraffic;"],"registry":"HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\Microsoft\\Windows NT\\Terminal Services","status":"Not applicable","reason":"Key 'fEncryptRPCTraffic' not found for registry 'HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\Microsoft\\Windows NT\\Terminal Services'"}}
sca.type: check
sca.scan_id: 311062296
sca.policy: CIS benchmark for Windows 10 Enterprise (Release 1709)
sca.check.id: 12195
sca.check.title: Ensure 'Require secure RPC communication' is set to 'Enabled'
sca.check.description: This policy setting allows you to specify whether Remote Desktop Services requires secure Remote Procedure Call (RPC) communication with all clients or allows unsecured communication. You can use this policy setting to strengthen the security of RPC communication with clients by allowing only authenticated and encrypted requests.
sca.check.rationale: Allowing unsecure RPC communication can exposes the server to man in the middle attacks and data disclosure attacks.
sca.check.remediation: To establish the recommended configuration via GP, set the following UI path to Enabled: Computer Configuration\Policies\Administrative Templates\Windows Components\Remote Desktop Services\Remote Desktop Session Host\Security\Require secure RPC communication
sca.check.compliance.cis: 18.9.58.3.9.2
sca.check.compliance.cis_csc: 3.4
sca.check.registry: ["HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\Microsoft\\Windows NT\\Terminal Services"]
sca.check.status: Not applicable
sca.check.reason: Key 'fEncryptRPCTraffic' not found for registry 'HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Terminal Services'

** Alert 1557748261.3871221: - sca,gdpr_IV_35.7.d
2019 May 13 13:51:01 (windows10) any->sca
Rule: 19009 (level 3) -> 'CIS benchmark for Windows 10 Enterprise (Release 1709): Ensure 'Set client connection encryption level' is set to 'Enabled: High Level''
{"type":"check","id":311062296,"policy":"CIS benchmark for Windows 10 Enterprise (Release 1709)","policy_id":"cis_win10_enterprise_L1","check":{"id":12196,"title":"Ensure 'Set client connection encryption level' is set to 'Enabled: High Level'","description":"This policy setting specifies whether to require the use of a specific encryption level to secure communications between client computers and RD Session Host servers during Remote Desktop Protocol (RDP) connections. This policy only applies when you are using native RDP encryption. However, native RDP encryption (as opposed to SSL encryption) is not recommended. This policy does not apply to SSL encryption.","rationale":"If Remote Desktop client connections that use low level encryption are allowed, it is more likely that an attacker will be able to decrypt any captured Remote Desktop Services network traffic.","remediation":"To establish the recommended configuration via GP, set the following UI path to Enabled: High Level: Computer Configuration\\Policies\\Administrative Templates\\Windows Components\\Remote Desktop Services\\Remote Desktop Session Host\\Security\\Set client connection encryption level","compliance":{"cis":"18.9.58.3.9.3","cis_csc":"3.4"},"rules":["r:HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\Microsoft\\Windows NT\\Terminal Services -> MinEncryptionLevel -> !3;"],"registry":"HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\Microsoft\\Windows NT\\Terminal Services","status":"Not applicable","reason":"Key 'MinEncryptionLevel' not found for registry 'HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\Microsoft\\Windows NT\\Terminal Services'"}}
sca.type: check
sca.scan_id: 311062296
sca.policy: CIS benchmark for Windows 10 Enterprise (Release 1709)
sca.check.id: 12196
sca.check.title: Ensure 'Set client connection encryption level' is set to 'Enabled: High Level'
sca.check.description: This policy setting specifies whether to require the use of a specific encryption level to secure communications between client computers and RD Session Host servers during Remote Desktop Protocol (RDP) connections. This policy only applies when you are using native RDP encryption. However, native RDP encryption (as opposed to SSL encryption) is not recommended. This policy does not apply to SSL encryption.
sca.check.rationale: If Remote Desktop client connections that use low level encryption are allowed, it is more likely that an attacker will be able to decrypt any captured Remote Desktop Services network traffic.
sca.check.remediation: To establish the recommended configuration via GP, set the following UI path to Enabled: High Level: Computer Configuration\Policies\Administrative Templates\Windows Components\Remote Desktop Services\Remote Desktop Session Host\Security\Set client connection encryption level
sca.check.compliance.cis: 18.9.58.3.9.3
sca.check.compliance.cis_csc: 3.4
sca.check.registry: ["HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\Microsoft\\Windows NT\\Terminal Services"]
sca.check.status: Not applicable
sca.check.reason: Key 'MinEncryptionLevel' not found for registry 'HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Terminal Services'

** Alert 1557748262.3874624: - sca,gdpr_IV_35.7.d
2019 May 13 13:51:02 (windows10) any->sca
Rule: 19009 (level 3) -> 'CIS benchmark for Windows 10 Enterprise (Release 1709): Ensure 'Do not delete temp folders upon exit' is set to 'Disabled''
{"type":"check","id":311062296,"policy":"CIS benchmark for Windows 10 Enterprise (Release 1709)","policy_id":"cis_win10_enterprise_L1","check":{"id":12197,"title":"Ensure 'Do not delete temp folders upon exit' is set to 'Disabled'","description":"This policy setting specifies whether Remote Desktop Services retains a user's per-session temporary folders at logoff.","rationale":"Sensitive information could be contained inside the temporary folders and visible to other administrators that log into the system.","remediation":"To establish the recommended configuration via GP, set the following UI path to Disabled: Computer Configuration\\Policies\\Administrative Templates\\Windows Components\\Remote Desktop Services\\Remote Desktop Session Host\\Temporary Folders\\Do not delete temp folders upon exit","compliance":{"cis":"18.9.58.3.11.1","cis_csc":"14.4, 14.6"},"rules":["r:HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\Microsoft\\Windows NT\\Terminal Services -> DeleteTempDirsOnExit -> !1;"],"registry":"HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\Microsoft\\Windows NT\\Terminal Services","status":"Not applicable","reason":"Key 'DeleteTempDirsOnExit' not found for registry 'HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\Microsoft\\Windows NT\\Terminal Services'"}}
sca.type: check
sca.scan_id: 311062296
sca.policy: CIS benchmark for Windows 10 Enterprise (Release 1709)
sca.check.id: 12197
sca.check.title: Ensure 'Do not delete temp folders upon exit' is set to 'Disabled'
sca.check.description: This policy setting specifies whether Remote Desktop Services retains a user's per-session temporary folders at logoff.
sca.check.rationale: Sensitive information could be contained inside the temporary folders and visible to other administrators that log into the system.
sca.check.remediation: To establish the recommended configuration via GP, set the following UI path to Disabled: Computer Configuration\Policies\Administrative Templates\Windows Components\Remote Desktop Services\Remote Desktop Session Host\Temporary Folders\Do not delete temp folders upon exit
sca.check.compliance.cis: 18.9.58.3.11.1
sca.check.compliance.cis_csc: 14.4, 14.6
sca.check.registry: ["HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\Microsoft\\Windows NT\\Terminal Services"]
sca.check.status: Not applicable
sca.check.reason: Key 'DeleteTempDirsOnExit' not found for registry 'HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Terminal Services'

** Alert 1557748262.3877298: - sca,gdpr_IV_35.7.d
2019 May 13 13:51:02 (windows10) any->sca
Rule: 19009 (level 3) -> 'CIS benchmark for Windows 10 Enterprise (Release 1709): Ensure 'Do not use temporary folders per session' is set to 'Disabled''
{"type":"check","id":311062296,"policy":"CIS benchmark for Windows 10 Enterprise (Release 1709)","policy_id":"cis_win10_enterprise_L1","check":{"id":12198,"title":"Ensure 'Do not use temporary folders per session' is set to 'Disabled'","description":"By default, Remote Desktop Services creates a separate temporary folder on the RD Session Host server for each active session that a user maintains on the RD Session Host server. The temporary folder is created on the RD Session Host server in a Temp folder under the user's profile folder and is named with the sessionid. This temporary folder is used to store individual temporary files. To reclaim disk space, the temporary folder is deleted when the user logs off from a session.","rationale":"Disabling this setting keeps the cached data independent for each session, both reducing the chance of problems from shared cached data between sessions, and keeping possibly sensitive data separate to each user session.","remediation":"To establish the recommended configuration via GP, set the following UI path to Disabled: Computer Configuration\\Policies\\Administrative Templates\\Windows Components\\Remote Desktop Services\\Remote Desktop Session Host\\Temporary Folders\\Do not use temporary folders per session","compliance":{"cis":"18.9.58.3.11.2","cis_csc":"14.4, 14.6"},"rules":["r:HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\Microsoft\\Windows NT\\Terminal Services -> PerSessionTempDir -> !1;"],"registry":"HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\Microsoft\\Windows NT\\Terminal Services","status":"Not applicable","reason":"Key 'PerSessionTempDir' not found for registry 'HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\Microsoft\\Windows NT\\Terminal Services'"}}
sca.type: check
sca.scan_id: 311062296
sca.policy: CIS benchmark for Windows 10 Enterprise (Release 1709)
sca.check.id: 12198
sca.check.title: Ensure 'Do not use temporary folders per session' is set to 'Disabled'
sca.check.description: By default, Remote Desktop Services creates a separate temporary folder on the RD Session Host server for each active session that a user maintains on the RD Session Host server. The temporary folder is created on the RD Session Host server in a Temp folder under the user's profile folder and is named with the sessionid. This temporary folder is used to store individual temporary files. To reclaim disk space, the temporary folder is deleted when the user logs off from a session.
sca.check.rationale: Disabling this setting keeps the cached data independent for each session, both reducing the chance of problems from shared cached data between sessions, and keeping possibly sensitive data separate to each user session.
sca.check.remediation: To establish the recommended configuration via GP, set the following UI path to Disabled: Computer Configuration\Policies\Administrative Templates\Windows Components\Remote Desktop Services\Remote Desktop Session Host\Temporary Folders\Do not use temporary folders per session
sca.check.compliance.cis: 18.9.58.3.11.2
sca.check.compliance.cis_csc: 14.4, 14.6
sca.check.registry: ["HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\Microsoft\\Windows NT\\Terminal Services"]
sca.check.status: Not applicable
sca.check.reason: Key 'PerSessionTempDir' not found for registry 'HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Terminal Services'
```

SQL output:
```
select id,result,reason,status from sca_check where  id IN (12127,12143,12145,12158,12159,12160,12192,12193,12194,12194,12196,12197,12198);
12127||Unable to read registry 'HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\DNSClient' (The system cannot find the file specified. )|Not applicable
12143||Unable to read registry 'HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Printers' (The system cannot find the file specified. )|Not applicable
12145||Unable to read registry 'HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Printers' (The system cannot find the file specified. )|Not applicable
12158||Key 'fAllowToGetHelp' not found for registry 'HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Terminal Services'|Not applicable
12159||Unable to read registry 'HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Rpc' (The system cannot find the file specified. )|Not applicable
12160||Unable to read registry 'HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Rpc' (The system cannot find the file specified. )|Not applicable
12192||Key 'DisablePasswordSaving' not found for registry 'HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Terminal Services'|Not applicable
12193||Key 'fDisableCdma' not found for registry 'HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Terminal Services'|Not applicable
12194||Key 'fPromptForPassword' not found for registry 'HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Terminal Services'|Not applicable
12196||Key 'MinEncryptionLevel' not found for registry 'HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Terminal Services'|Not applicable
12197||Key 'DeleteTempDirsOnExit' not found for registry 'HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Terminal Services'|Not applicable
12198||Key 'PerSessionTempDir' not found for registry 'HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Terminal Services'|Not applicable
```


- [x] windows/cis_win2012r2_domainL1_rcl.yml

- Affected checks: 8005,8018,8019,8085,8091

Alerts generated:
```
** Alert 1557752705.4044786: - sca,gdpr_IV_35.7.d
2019 May 13 15:05:05 (win2012) any->sca
Rule: 19009 (level 3) -> 'CIS benchmark for Windows 2012 R2 Domain Controller L1: Ensure 'Devices: Allowed to format and eject removable media' is set to 'Administrators''
{"type":"check","id":1324549878,"policy":"CIS benchmark for Windows 2012 R2 Domain Controller L1","policy_id":"cis_win2012r2_domainL1","check":{"id":8005,"title":"Ensure 'Devices: Allowed to format and eject removable media' is set to 'Administrators'","description":"This policy setting determines who is allowed to format and eject removable NTFS media. You can use this policy setting to prevent unauthorized users from removing data on one computer to access it on another computer on which they have local administrator privileges. The recommended state for this setting is: Administrators.","rationale":"Users may be able to move data on removable disks to a different computer where they have administrative privileges. The user could then take ownership of any file, grant themselves full control, and view or modify any file. The fact that most removable storage devices will eject media by pressing a mechanical button diminishes the advantage of this policy setting.","remediation":"To establish the recommended configuration via GP, set the following UI path to Administrators: Computer Configuration\\Policies\\Windows Settings\\Security Settings\\Local Policies\\Security Options\\Devices: Allowed to format and eject removable media","compliance":{"cis":"2.3.4.1","cis_csc":"5.1"},"rules":["r:HKEY_LOCAL_MACHINE\\Software\\Microsoft\\Windows NT\\CurrentVersion\\Winlogon -> AllocateDASD -> 1;","r:HKEY_LOCAL_MACHINE\\Software\\Microsoft\\Windows NT\\CurrentVersion\\Winlogon -> AllocateDASD -> 2;"],"registry":"HKEY_LOCAL_MACHINE\\Software\\Microsoft\\Windows NT\\CurrentVersion\\Winlogon","status":"Not applicable","reason":"Key 'AllocateDASD' not found for registry 'HKEY_LOCAL_MACHINE\\Software\\Microsoft\\Windows NT\\CurrentVersion\\Winlogon'"}}
sca.type: check
sca.scan_id: 1324549878
sca.policy: CIS benchmark for Windows 2012 R2 Domain Controller L1
sca.check.id: 8005
sca.check.title: Ensure 'Devices: Allowed to format and eject removable media' is set to 'Administrators'
sca.check.description: This policy setting determines who is allowed to format and eject removable NTFS media. You can use this policy setting to prevent unauthorized users from removing data on one computer to access it on another computer on which they have local administrator privileges. The recommended state for this setting is: Administrators.
sca.check.rationale: Users may be able to move data on removable disks to a different computer where they have administrative privileges. The user could then take ownership of any file, grant themselves full control, and view or modify any file. The fact that most removable storage devices will eject media by pressing a mechanical button diminishes the advantage of this policy setting.
sca.check.remediation: To establish the recommended configuration via GP, set the following UI path to Administrators: Computer Configuration\Policies\Windows Settings\Security Settings\Local Policies\Security Options\Devices: Allowed to format and eject removable media
sca.check.compliance.cis: 2.3.4.1
sca.check.compliance.cis_csc: 5.1
sca.check.registry: ["HKEY_LOCAL_MACHINE\\Software\\Microsoft\\Windows NT\\CurrentVersion\\Winlogon"]
sca.check.status: Not applicable
sca.check.reason: Key 'AllocateDASD' not found for registry 'HKEY_LOCAL_MACHINE\Software\Microsoft\Windows NT\CurrentVersion\Winlogon'


** Alert 1557752705.4097266: - sca,gdpr_IV_35.7.d
2019 May 13 15:05:05 (win2012) any->sca
Rule: 19008 (level 3) -> 'CIS benchmark for Windows 2012 R2 Domain Controller L1: Ensure 'Interactive logon: Prompt user to change password before expiration' is set to 'between 5 and 14 days''
{"type":"check","id":1324549878,"policy":"CIS benchmark for Windows 2012 R2 Domain Controller L1","policy_id":"cis_win2012r2_domainL1","check":{"id":8018,"title":"Ensure 'Interactive logon: Prompt user to change password before expiration' is set to 'between 5 and 14 days'","description":"This policy setting determines how far in advance users are warned that their password will expire. It is recommended that you configure this policy setting to at least 5 days but no more than 14 days to sufficiently warn users when their passwords will expire.  The recommended state for this setting is: between 5 and 14 days.","rationale":"It is recommended that user passwords be configured to expire periodically. Users will need to be warned that their passwords are going to expire, or they may inadvertently be locked out of the computer when their passwords expire. This condition could lead to confusion for users who access the network locally, or make it impossible for users to access your organization's network through dial-up or virtual private network (VPN) connections.","remediation":"To establish the recommended configuration via GP, set the following UI path to a value between 5 and 14 days: Computer Configuration\\Policies\\Windows Settings\\Security Settings\\Local Policies\\Security Options\\Interactive logon: Prompt user to change password before expiration","compliance":{"cis":"2.3.7.7","cis_csc":"16"},"rules":["r:HKEY_LOCAL_MACHINE\\Software\\Microsoft\\Windows NT\\CurrentVersion\\Winlogon -> PasswordExpiryWarning -> 0;","r:HKEY_LOCAL_MACHINE\\Software\\Microsoft\\Windows NT\\CurrentVersion\\Winlogon -> PasswordExpiryWarning -> 1;","r:HKEY_LOCAL_MACHINE\\Software\\Microsoft\\Windows NT\\CurrentVersion\\Winlogon -> PasswordExpiryWarning -> 2;","r:HKEY_LOCAL_MACHINE\\Software\\Microsoft\\Windows NT\\CurrentVersion\\Winlogon -> PasswordExpiryWarning -> 3;","r:HKEY_LOCAL_MACHINE\\Software\\Microsoft\\Windows NT\\CurrentVersion\\Winlogon -> PasswordExpiryWarning -> 4;","r:HKEY_LOCAL_MACHINE\\Software\\Microsoft\\Windows NT\\CurrentVersion\\Winlogon -> PasswordExpiryWarning -> 0F;","r:HKEY_LOCAL_MACHINE\\Software\\Microsoft\\Windows NT\\CurrentVersion\\Winlogon -> PasswordExpiryWarning -> r:1\\w;","r:HKEY_LOCAL_MACHINE\\Software\\Microsoft\\Windows NT\\CurrentVersion\\Winlogon -> PasswordExpiryWarning -> r:2\\w;","r:HKEY_LOCAL_MACHINE\\Software\\Microsoft\\Windows NT\\CurrentVersion\\Winlogon -> PasswordExpiryWarning -> r:3\\w;","r:HKEY_LOCAL_MACHINE\\Software\\Microsoft\\Windows NT\\CurrentVersion\\Winlogon -> PasswordExpiryWarning -> r:4\\w;","r:HKEY_LOCAL_MACHINE\\Software\\Microsoft\\Windows NT\\CurrentVersion\\Winlogon -> PasswordExpiryWarning -> r:5\\w;","r:HKEY_LOCAL_MACHINE\\Software\\Microsoft\\Windows NT\\CurrentVersion\\Winlogon -> PasswordExpiryWarning -> r:6\\w;","r:HKEY_LOCAL_MACHINE\\Software\\Microsoft\\Windows NT\\CurrentVersion\\Winlogon -> PasswordExpiryWarning -> r:7\\w;","r:HKEY_LOCAL_MACHINE\\Software\\Microsoft\\Windows NT\\CurrentVersion\\Winlogon -> PasswordExpiryWarning -> r:8\\w;","r:HKEY_LOCAL_MACHINE\\Software\\Microsoft\\Windows NT\\CurrentVersion\\Winlogon -> PasswordExpiryWarning -> r:9\\w;","r:HKEY_LOCAL_MACHINE\\Software\\Microsoft\\Windows NT\\CurrentVersion\\Winlogon -> PasswordExpiryWarning -> r:\\D\\w;","r:HKEY_LOCAL_MACHINE\\Software\\Microsoft\\Windows NT\\CurrentVersion\\Winlogon -> PasswordExpiryWarning -> r:\\w\\w\\w+;"],"registry":"HKEY_LOCAL_MACHINE\\Software\\Microsoft\\Windows NT\\CurrentVersion\\Winlogon","result":"passed"}}
sca.type: check
sca.scan_id: 1324549878
sca.policy: CIS benchmark for Windows 2012 R2 Domain Controller L1
sca.check.id: 8018
sca.check.title: Ensure 'Interactive logon: Prompt user to change password before expiration' is set to 'between 5 and 14 days'
sca.check.description: This policy setting determines how far in advance users are warned that their password will expire. It is recommended that you configure this policy setting to at least 5 days but no more than 14 days to sufficiently warn users when their passwords will expire.  The recommended state for this setting is: between 5 and 14 days.
sca.check.rationale: It is recommended that user passwords be configured to expire periodically. Users will need to be warned that their passwords are going to expire, or they may inadvertently be locked out of the computer when their passwords expire. This condition could lead to confusion for users who access the network locally, or make it impossible for users to access your organization's network through dial-up or virtual private network (VPN) connections.
sca.check.remediation: To establish the recommended configuration via GP, set the following UI path to a value between 5 and 14 days: Computer Configuration\Policies\Windows Settings\Security Settings\Local Policies\Security Options\Interactive logon: Prompt user to change password before expiration
sca.check.compliance.cis: 2.3.7.7
sca.check.compliance.cis_csc: 16
sca.check.registry: ["HKEY_LOCAL_MACHINE\\Software\\Microsoft\\Windows NT\\CurrentVersion\\Winlogon"]
sca.check.result: passed


** Alert 1557752705.4102649: - sca,gdpr_IV_35.7.d
2019 May 13 15:05:05 (win2012) any->sca
Rule: 19007 (level 7) -> 'CIS benchmark for Windows 2012 R2 Domain Controller L1: Ensure 'Interactive logon: Smart card removal behavior' is set to 'Lock Workstation' or higher'
{"type":"check","id":1324549878,"policy":"CIS benchmark for Windows 2012 R2 Domain Controller L1","policy_id":"cis_win2012r2_domainL1","check":{"id":8019,"title":"Ensure 'Interactive logon: Smart card removal behavior' is set to 'Lock Workstation' or higher","description":"This policy setting determines what happens when the smart card for a logged-on user is removed from the smart card reader.  The recommended state for this setting is: Lock Workstation. Configuring this setting to Force Logoff or Disconnect if a Remote Desktop Services session also conforms to the benchmark.","rationale":"Users sometimes forget to lock their workstations when they are away from them, allowing the possibility for malicious users to access their computers. If smart cards are used for authentication, the computer should automatically lock itself when the card is removed to ensure that only the user with the smart card is accessing resources using those credentials.","remediation":"To establish the recommended configuration via GP, set the following UI path to Lock Workstation (or, if applicable for your environment, Force Logoff or Disconnect if a Remote Desktop Services session): Computer Configuration\\Policies\\Windows Settings\\Security Settings\\Local Policies\\Security Options\\Interactive logon: Smart card removal behavior","compliance":{"cis":"2.3.7.9","cis_csc":"16.5"},"rules":["r:HKEY_LOCAL_MACHINE\\Software\\Microsoft\\Windows NT\\CurrentVersion\\Winlogon -> ScRemoveOption -> 0;","r:HKEY_LOCAL_MACHINE\\Software\\Microsoft\\Windows NT\\CurrentVersion\\Winlogon -> !ScRemoveOption;"],"registry":"HKEY_LOCAL_MACHINE\\Software\\Microsoft\\Windows NT\\CurrentVersion\\Winlogon","result":"failed"}}
sca.type: check
sca.scan_id: 1324549878
sca.policy: CIS benchmark for Windows 2012 R2 Domain Controller L1
sca.check.id: 8019
sca.check.title: Ensure 'Interactive logon: Smart card removal behavior' is set to 'Lock Workstation' or higher
sca.check.description: This policy setting determines what happens when the smart card for a logged-on user is removed from the smart card reader.  The recommended state for this setting is: Lock Workstation. Configuring this setting to Force Logoff or Disconnect if a Remote Desktop Services session also conforms to the benchmark.
sca.check.rationale: Users sometimes forget to lock their workstations when they are away from them, allowing the possibility for malicious users to access their computers. If smart cards are used for authentication, the computer should automatically lock itself when the card is removed to ensure that only the user with the smart card is accessing resources using those credentials.
sca.check.remediation: To establish the recommended configuration via GP, set the following UI path to Lock Workstation (or, if applicable for your environment, Force Logoff or Disconnect if a Remote Desktop Services session): Computer Configuration\Policies\Windows Settings\Security Settings\Local Policies\Security Options\Interactive logon: Smart card removal behavior
sca.check.compliance.cis: 2.3.7.9
sca.check.compliance.cis_csc: 16.5
sca.check.registry: ["HKEY_LOCAL_MACHINE\\Software\\Microsoft\\Windows NT\\CurrentVersion\\Winlogon"]
sca.check.result: failed

** Alert 1557752706.4364164: - sca,gdpr_IV_35.7.d
2019 May 13 15:05:06 (win2012) any->sca
Rule: 19009 (level 3) -> 'CIS benchmark for Windows 2012 R2 Domain Controller L1: Ensure 'MSS: (AutoAdminLogon) Enable Automatic Logon (not recommended)' is set to 'Disabled''
{"type":"check","id":1324549878,"policy":"CIS benchmark for Windows 2012 R2 Domain Controller L1","policy_id":"cis_win2012r2_domainL1","check":{"id":8085,"title":"Ensure 'MSS: (AutoAdminLogon) Enable Automatic Logon (not recommended)' is set to 'Disabled'","description":"This setting is separate from the Welcome screen feature in Windows XP and Windows Vista; if that feature is disabled, this setting is not disabled. If you configure a computer for automatic logon, anyone who can physically gain access to the computer can also gain access to everything that is on the computer, including any network or networks to which the computer is connected. Also, if you enable automatic logon, the password is stored in the registry in plaintext, and the specific registry key that stores this value is remotely readable by the Authenticated Users group.  The recommended state for this setting is: Disabled.","rationale":"If you configure a computer for automatic logon, anyone who can physically gain access to the computer can also gain access to everything that is on the computer, including any network or networks that the computer is connected to. Also, if you enable automatic logon, the password is stored in the registry in plaintext. The specific registry key that stores this setting is remotely readable by the Authenticated Users group. As a result, this entry is appropriate only if the computer is physically secured and if you ensure that untrusted users cannot remotely see the registry.","remediation":"To establish the recommended configuration via GP, set the following UI path to Disabled: Computer Configuration\\Policies\\Administrative Templates\\MSS (Legacy)\\MSS: (AutoAdminLogon) Enable Automatic Logon (not recommended) Note: This Group Policy path does not exist by default. An additional Group Policy template (MSS-legacy.admx/adml) is required - it is available from this TechNet blog post: The MSS settings – Microsoft Security Guidance blog","compliance":{"cis":"18.4.1","cis_csc":"16"},"rules":["r:HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Winlogon -> AutoAdminLogon -> !0;"],"references":"https://support.microsoft.com/en-us/help/324737/how-to-turn-on-automatic-logon-in-windows,https://blogs.technet.microsoft.com/secguide/2016/10/02/the-mss-settings/","registry":"HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Winlogon","status":"Not applicable","reason":"Key 'AutoAdminLogon' not found for registry 'HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Winlogon'"}}
sca.type: check
sca.scan_id: 1324549878
sca.policy: CIS benchmark for Windows 2012 R2 Domain Controller L1
sca.check.id: 8085
sca.check.title: Ensure 'MSS: (AutoAdminLogon) Enable Automatic Logon (not recommended)' is set to 'Disabled'
sca.check.description: This setting is separate from the Welcome screen feature in Windows XP and Windows Vista; if that feature is disabled, this setting is not disabled. If you configure a computer for automatic logon, anyone who can physically gain access to the computer can also gain access to everything that is on the computer, including any network or networks to which the computer is connected. Also, if you enable automatic logon, the password is stored in the registry in plaintext, and the specific registry key that stores this value is remotely readable by the Authenticated Users group.  The recommended state for this setting is: Disabled.
sca.check.rationale: If you configure a computer for automatic logon, anyone who can physically gain access to the computer can also gain access to everything that is on the computer, including any network or networks that the computer is connected to. Also, if you enable automatic logon, the password is stored in the registry in plaintext. The specific registry key that stores this setting is remotely readable by the Authenticated Users group. As a result, this entry is appropriate only if the computer is physically secured and if you ensure that untrusted users cannot remotely see the registry.
sca.check.remediation: To establish the recommended configuration via GP, set the following UI path to Disabled: Computer Configuration\Policies\Administrative Templates\MSS (Legacy)\MSS: (AutoAdminLogon) Enable Automatic Logon (not recommended) Note: This Group Policy path does not exist by default. An additional Group Policy template (MSS-legacy.admx/adml) is required - it is available from this TechNet blog post: The MSS settings – Microsoft Security Guidance blog
sca.check.compliance.cis: 18.4.1
sca.check.compliance.cis_csc: 16
sca.check.references: https://support.microsoft.com/en-us/help/324737/how-to-turn-on-automatic-logon-in-windows,https://blogs.technet.microsoft.com/secguide/2016/10/02/the-mss-settings/
sca.check.registry: ["HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Winlogon"]
sca.check.status: Not applicable
sca.check.reason: Key 'AutoAdminLogon' not found for registry 'HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Winlogon'


** Alert 1557752706.4392727: - sca,gdpr_IV_35.7.d
2019 May 13 15:05:06 (win2012) any->sca
Rule: 19009 (level 3) -> 'CIS benchmark for Windows 2012 R2 Domain Controller L1: Ensure 'MSS: (ScreenSaverGracePeriod) The time in seconds before the screen saver grace period expires (0 recommended)' is set to 'Enabled: 5 or fewer seconds''
{"type":"check","id":1324549878,"policy":"CIS benchmark for Windows 2012 R2 Domain Controller L1","policy_id":"cis_win2012r2_domainL1","check":{"id":8091,"title":"Ensure 'MSS: (ScreenSaverGracePeriod) The time in seconds before the screen saver grace period expires (0 recommended)' is set to 'Enabled: 5 or fewer seconds'","description":"Windows includes a grace period between when the screen saver is launched and when the console is actually locked automatically when screen saver locking is enabled.  The recommended state for this setting is: Enabled: 5 or fewer seconds.","rationale":"The default grace period that is allowed for user movement before the screen saver lock takes effect is five seconds. If you leave the default grace period configuration, your computer is vulnerable to a potential attack from someone who could approach the console and attempt to log on to the computer before the lock takes effect. An entry to the registry can be made to adjust the length of the grace period.","remediation":"To establish the recommended configuration via GP, set the following UI path to Enabled: 5 or fewer seconds: Computer Configuration\\Policies\\Administrative Templates\\MSS (Legacy)\\MSS: (ScreenSaverGracePeriod) The time in seconds before the screen saver grace period expires (0 recommended) Note: This Group Policy path does not exist by default. An additional Group Policy template (MSS-legacy.admx/adml) is required - it is available from this TechNet blog post: The MSS settings – Microsoft Security Guidance blog","compliance":{"cis":"18.4.9","cis_csc":"16.5"},"rules":["r:HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Winlogon -> ScreenSaverGracePeriod -> 6;","r:HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Winlogon -> ScreenSaverGracePeriod -> 7;","r:HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Winlogon -> ScreenSaverGracePeriod -> 8;","r:HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Winlogon -> ScreenSaverGracePeriod -> 9;","r:HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Winlogon -> ScreenSaverGracePeriod -> r:\\w\\w+;"],"references":"https://blogs.technet.microsoft.com/secguide/2016/10/02/the-mss-settings/","registry":"HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Winlogon","status":"Not applicable","reason":"Key 'ScreenSaverGracePeriod' not found for registry 'HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Winlogon'"}}
sca.type: check
sca.scan_id: 1324549878
sca.policy: CIS benchmark for Windows 2012 R2 Domain Controller L1
sca.check.id: 8091
sca.check.title: Ensure 'MSS: (ScreenSaverGracePeriod) The time in seconds before the screen saver grace period expires (0 recommended)' is set to 'Enabled: 5 or fewer seconds'
sca.check.description: Windows includes a grace period between when the screen saver is launched and when the console is actually locked automatically when screen saver locking is enabled.  The recommended state for this setting is: Enabled: 5 or fewer seconds.
sca.check.rationale: The default grace period that is allowed for user movement before the screen saver lock takes effect is five seconds. If you leave the default grace period configuration, your computer is vulnerable to a potential attack from someone who could approach the console and attempt to log on to the computer before the lock takes effect. An entry to the registry can be made to adjust the length of the grace period.
sca.check.remediation: To establish the recommended configuration via GP, set the following UI path to Enabled: 5 or fewer seconds: Computer Configuration\Policies\Administrative Templates\MSS (Legacy)\MSS: (ScreenSaverGracePeriod) The time in seconds before the screen saver grace period expires (0 recommended) Note: This Group Policy path does not exist by default. An additional Group Policy template (MSS-legacy.admx/adml) is required - it is available from this TechNet blog post: The MSS settings – Microsoft Security Guidance blog
sca.check.compliance.cis: 18.4.9
sca.check.compliance.cis_csc: 16.5
sca.check.references: https://blogs.technet.microsoft.com/secguide/2016/10/02/the-mss-settings/
sca.check.registry: ["HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Winlogon"]
sca.check.status: Not applicable
sca.check.reason: Key 'ScreenSaverGracePeriod' not found for registry 'HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Winlogon'
```

SQL output:
```
select id,result,reason,status from sca_check where  policy_id = 'cis_win2012r2_domainL1' and id IN (8005,8018,8019,8085,8091);
8005||Key 'AllocateDASD' not found for registry 'HKEY_LOCAL_MACHINE\Software\Microsoft\Windows NT\CurrentVersion\Winlogon'|Not applicable
8018|passed||
8019|failed||
8085||Key 'AutoAdminLogon' not found for registry 'HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Winlogon'|Not applicable
8091||Key 'ScreenSaverGracePeriod' not found for registry 'HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Winlogon'|Not applicable
```

- [x] windows/cis_win2012r2_memberL1_rcl.yml

- Affected checks: 9114,9115,9116,9136,9137,9138,9139,9140,9141,9142

Alerts generated:
```
** Alert 1557745313.2792821: - sca,gdpr_IV_35.7.d
2019 May 13 13:01:53 (win2012) any->sca
Rule: 19009 (level 3) -> 'CIS benchmark for Windows 2012 R2 Member Server L1: Ensure 'Configure Offer Remote Assistance' is set to 'Disabled''
{"type":"check","id":38126879,"policy":"CIS benchmark for Windows 2012 R2 Member Server L1","policy_id":"cis_win2012r2_memberL1","check":{"id":9114,"title":"Ensure 'Configure Offer Remote Assistance' is set to 'Disabled'","description":"This policy setting allows you to turn on or turn off Offer (Unsolicited) Remote Assistance on this computer.  Help desk and support personnel will not be able to proactively offer assistance, although they can still respond to user assistance requests.  The recommended state for this setting is: Disabled","rationale":"A user might be tricked and accept an unsolicited Remote Assistance offer from a malicious user.","remediation":"To establish the recommended configuration via GP, set the following UI path to Disabled: Computer Configuration\\Policies\\Administrative Templates\\System\\Remote Assistance\\Configure Offer Remote Assistance Note: This Group Policy path may not exist by default. It is provided by the Group Policy template RemoteAssistance.admx/adml that is included with the Microsoft Windows 8.0 & Server 2012 (non-R2) Administrative Templates (or newer).","compliance":{"cis":"18.8.35.1","cis_csc":"9.1"},"rules":["r:HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\Microsoft\\Windows NT\\Terminal Services -> fAllowUnsolicited -> !0;"],"registry":"HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\Microsoft\\Windows NT\\Terminal Services","status":"Not applicable","reason":"Key 'fAllowUnsolicited' not found for registry 'HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\Microsoft\\Windows NT\\Terminal Services'"}}
sca.type: check
sca.scan_id: 38126879
sca.policy: CIS benchmark for Windows 2012 R2 Member Server L1
sca.check.id: 9114
sca.check.title: Ensure 'Configure Offer Remote Assistance' is set to 'Disabled'
sca.check.description: This policy setting allows you to turn on or turn off Offer (Unsolicited) Remote Assistance on this computer.  Help desk and support personnel will not be able to proactively offer assistance, although they can still respond to user assistance requests.  The recommended state for this setting is: Disabled
sca.check.rationale: A user might be tricked and accept an unsolicited Remote Assistance offer from a malicious user.
sca.check.remediation: To establish the recommended configuration via GP, set the following UI path to Disabled: Computer Configuration\Policies\Administrative Templates\System\Remote Assistance\Configure Offer Remote Assistance Note: This Group Policy path may not exist by default. It is provided by the Group Policy template RemoteAssistance.admx/adml that is included with the Microsoft Windows 8.0 & Server 2012 (non-R2) Administrative Templates (or newer).
sca.check.compliance.cis: 18.8.35.1
sca.check.compliance.cis_csc: 9.1
sca.check.registry: ["HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\Microsoft\\Windows NT\\Terminal Services"]
sca.check.status: Not applicable
sca.check.reason: Key 'fAllowUnsolicited' not found for registry 'HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Terminal Services'


** Alert 1557745313.2796070: - sca,gdpr_IV_35.7.d
2019 May 13 13:01:53 (win2012) any->sca
Rule: 19009 (level 3) -> 'CIS benchmark for Windows 2012 R2 Member Server L1: Ensure 'Configure Solicited Remote Assistance' is set to 'Disabled''
{"type":"check","id":38126879,"policy":"CIS benchmark for Windows 2012 R2 Member Server L1","policy_id":"cis_win2012r2_memberL1","check":{"id":9115,"title":"Ensure 'Configure Solicited Remote Assistance' is set to 'Disabled'","description":"This policy setting allows you to turn on or turn off Solicited (Ask for) Remote Assistance on this computer.  The recommended state for this setting is: Disabled.","rationale":"There is slight risk that a rogue administrator will gain access to another user's desktop session, however, they cannot connect to a user's computer unannounced or control it without permission from the user. When an expert tries to connect, the user can still choose to deny the connection or give the expert view-only privileges. The user must explicitly click the Yes button to allow the expert to remotely control the workstation.","remediation":"To establish the recommended configuration via GP, set the following UI path to Disabled: Computer Configuration\\Policies\\Administrative Templates\\System\\Remote Assistance\\Configure Solicited Remote Assistance Note: This Group Policy path may not exist by default. It is provided by the Group Policy template RemoteAssistance.admx/adml that is included with the Microsoft Windows 8.0 & Server 2012 (non-R2) Administrative Templates (or newer).","compliance":{"cis":"18.8.35.2","cis_csc":"5.1"},"rules":["r:HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\Microsoft\\Windows NT\\Terminal Services -> fAllowToGetHelp -> !0;","r:HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\Microsoft\\Windows NT\\Terminal Services -> !fAllowToGetHelp;"],"registry":"HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\Microsoft\\Windows NT\\Terminal Services","status":"Not applicable","reason":"Key 'fAllowToGetHelp' not found for registry 'HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\Microsoft\\Windows NT\\Terminal Services'"}}
sca.type: check
sca.scan_id: 38126879
sca.policy: CIS benchmark for Windows 2012 R2 Member Server L1
sca.check.id: 9115
sca.check.title: Ensure 'Configure Solicited Remote Assistance' is set to 'Disabled'
sca.check.description: This policy setting allows you to turn on or turn off Solicited (Ask for) Remote Assistance on this computer.  The recommended state for this setting is: Disabled.
sca.check.rationale: There is slight risk that a rogue administrator will gain access to another user's desktop session, however, they cannot connect to a user's computer unannounced or control it without permission from the user. When an expert tries to connect, the user can still choose to deny the connection or give the expert view-only privileges. The user must explicitly click the Yes button to allow the expert to remotely control the workstation.
sca.check.remediation: To establish the recommended configuration via GP, set the following UI path to Disabled: Computer Configuration\Policies\Administrative Templates\System\Remote Assistance\Configure Solicited Remote Assistance Note: This Group Policy path may not exist by default. It is provided by the Group Policy template RemoteAssistance.admx/adml that is included with the Microsoft Windows 8.0 & Server 2012 (non-R2) Administrative Templates (or newer).
sca.check.compliance.cis: 18.8.35.2
sca.check.compliance.cis_csc: 5.1
sca.check.registry: ["HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\Microsoft\\Windows NT\\Terminal Services"]
sca.check.status: Not applicable
sca.check.reason: Key 'fAllowToGetHelp' not found for registry 'HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Terminal Services'


indows NT\\Rpc -> !EnableAuthEpResolution;"],"references":"https://support.microsoft.com/en-us/help/3073942/rpc-endpoint-mapper-client-authentication-prevents-users-and-groups-fr","registry":"HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\Microsoft\\Windows NT\\Rpc","status":"Not applicable","reason":"Unable to read registry 'HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\Microsoft\\Windows NT\\Rpc' (The system cannot find the file specified. )"}}
sca.type: check
sca.scan_id: 38126879
sca.policy: CIS benchmark for Windows 2012 R2 Member Server L1
sca.check.id: 9116
sca.check.title: Ensure 'Enable RPC Endpoint Mapper Client Authentication' is set to 'Enabled'
sca.check.description: This policy setting controls whether RPC clients authenticate with the Endpoint Mapper Service when the call they are making contains authentication information. The Endpoint Mapper Service on computers running Windows NT4 (all service packs) cannot process authentication information supplied in this manner. This policy setting can cause a specific issue with 1-way forest trusts if it is applied to the trusting domain DCs (see Microsoft KB3073942), so we do not recommend applying it to Domain Controllers.  Note: This policy will not be in effect until the system is rebooted.  The recommended state for this setting is: Enabled.
sca.check.rationale: Anonymous access to RPC services could result in accidental disclosure of information to unauthenticated users.
sca.check.remediation: To establish the recommended configuration via GP, set the following UI path to Enabled: Computer Configuration\Policies\Administrative Templates\System\Remote Procedure Call\Enable RPC Endpoint Mapper Client Authentication Note: This Group Policy path may not exist by default. It is provided by the Group Policy template RPC.admx/adml that is included with the Microsoft Windows 8.0 & Server 2012 (non-R2) Administrative Templates (or newer).
sca.check.compliance.cis: 18.8.36.1
sca.check.compliance.cis_csc: 9.1
sca.check.references: https://support.microsoft.com/en-us/help/3073942/rpc-endpoint-mapper-client-authentication-prevents-users-and-groups-fr
sca.check.registry: ["HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\Microsoft\\Windows NT\\Rpc"]
sca.check.status: Not applicable
sca.check.reason: Unable to read registry 'HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Rpc' (The system cannot find the file specified. )

** Alert 1557745314.2880615: - sca,gdpr_IV_35.7.d
2019 May 13 13:01:54 (win2012) any->sca
Rule: 19009 (level 3) -> 'CIS benchmark for Windows 2012 R2 Member Server L1: Ensure 'Do not allow passwords to be saved' is set to 'Enabled''
{"type":"check","id":38126879,"policy":"CIS benchmark for Windows 2012 R2 Member Server L1","policy_id":"cis_win2012r2_memberL1","check":{"id":9136,"title":"Ensure 'Do not allow passwords to be saved' is set to 'Enabled'","description":"This policy setting helps prevent Remote Desktop clients from saving passwords on a computer.  The recommended state for this setting is: Enabled.  Note: If this policy setting was previously configured as Disabled or Not configured, any previously saved passwords will be deleted the first time a Remote Desktop client disconnects from any server.","rationale":"An attacker with physical access to the computer may be able to break the protection guarding saved passwords. An attacker who compromises a user's account and connects to their computer could use saved passwords to gain access to additional hosts.","remediation":"To establish the recommended configuration via GP, set the following UI path to Enabled: Computer Configuration\\Policies\\Administrative Templates\\Windows Components\\Remote Desktop Services\\Remote Desktop Connection Client\\Do not allow passwords to be saved Note: This Group Policy path is provided by the Group Policy template TerminalServer.admx/adml that is included with all versions of the Microsoft Windows Administrative Templates.","compliance":{"cis":"18.9.58.2.2","cis_csc":"16.4"},"rules":["r:HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\Microsoft\\Windows NT\\Terminal Services -> DisablePasswordSaving -> !1;","r:HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\Microsoft\\Windows NT\\Terminal Services -> !DisablePasswordSaving;"],"registry":"HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\Microsoft\\Windows NT\\Terminal Services","status":"Not applicable","reason":"Key 'DisablePasswordSaving' not found for registry 'HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\Microsoft\\Windows NT\\Terminal Services'"}}
sca.type: check
sca.scan_id: 38126879
sca.policy: CIS benchmark for Windows 2012 R2 Member Server L1
sca.check.id: 9136
sca.check.title: Ensure 'Do not allow passwords to be saved' is set to 'Enabled'
sca.check.description: This policy setting helps prevent Remote Desktop clients from saving passwords on a computer.  The recommended state for this setting is: Enabled.  Note: If this policy setting was previously configured as Disabled or Not configured, any previously saved passwords will be deleted the first time a Remote Desktop client disconnects from any server.
sca.check.rationale: An attacker with physical access to the computer may be able to break the protection guarding saved passwords. An attacker who compromises a user's account and connects to their computer could use saved passwords to gain access to additional hosts.
sca.check.remediation: To establish the recommended configuration via GP, set the following UI path to Enabled: Computer Configuration\Policies\Administrative Templates\Windows Components\Remote Desktop Services\Remote Desktop Connection Client\Do not allow passwords to be saved Note: This Group Policy path is provided by the Group Policy template TerminalServer.admx/adml that is included with all versions of the Microsoft Windows Administrative Templates.
sca.check.compliance.cis: 18.9.58.2.2
sca.check.compliance.cis_csc: 16.4
sca.check.registry: ["HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\Microsoft\\Windows NT\\Terminal Services"]
sca.check.status: Not applicable
sca.check.reason: Key 'DisablePasswordSaving' not found for registry 'HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Terminal Services'

** Alert 1557745314.2884379: - sca,gdpr_IV_35.7.d
2019 May 13 13:01:54 (win2012) any->sca
Rule: 19009 (level 3) -> 'CIS benchmark for Windows 2012 R2 Member Server L1: Ensure 'Do not allow drive redirection' is set to 'Enabled''
{"type":"check","id":38126879,"policy":"CIS benchmark for Windows 2012 R2 Member Server L1","policy_id":"cis_win2012r2_memberL1","check":{"id":9137,"title":"Ensure 'Do not allow drive redirection' is set to 'Enabled'","description":"This policy setting prevents users from sharing the local drives on their client computers to Remote Desktop Servers that they access. Mapped drives appear in the session folder tree in Windows Explorer in the following format: \\\\TSClient\\<driveletter>$ If local drives are shared they are left vulnerable to intruders who want to exploit the data that is stored on them.  The recommended state for this setting is: Enabled.","rationale":"Data could be forwarded from the user's Remote Desktop Services session to the user's local computer without any direct user interaction. Malicious software already present on a compromised server would have direct and stealthy disk access to the user's local computer during the Remote Desktop session.","remediation":"To establish the recommended configuration via GP, set the following UI path to Enabled: Computer Configuration\\Policies\\Administrative Templates\\Windows Components\\Remote Desktop Services\\Remote Desktop Session Host\\Device and Resource Redirection\\Do not allow drive redirection Note: This Group Policy path is provided by the Group Policy template TerminalServer.admx/adml that is included with all versions of the Microsoft Windows Administrative Templates.","compliance":{"cis":"18.9.58.3.3.2","cis_csc":"13"},"rules":["r:HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\Microsoft\\Windows NT\\Terminal Services -> fDisableCdm -> !1;","r:HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\Microsoft\\Windows NT\\Terminal Services -> !fDisableCdm;"],"registry":"HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\Microsoft\\Windows NT\\Terminal Services","status":"Not applicable","reason":"Key 'fDisableCdm' not found for registry 'HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\Microsoft\\Windows NT\\Terminal Services'"}}
sca.type: check
sca.scan_id: 38126879
sca.policy: CIS benchmark for Windows 2012 R2 Member Server L1
sca.check.id: 9137
sca.check.title: Ensure 'Do not allow drive redirection' is set to 'Enabled'
sca.check.description: This policy setting prevents users from sharing the local drives on their client computers to Remote Desktop Servers that they access. Mapped drives appear in the session folder tree in Windows Explorer in the following format: \\TSClient\<driveletter>$ If local drives are shared they are left vulnerable to intruders who want to exploit the data that is stored on them.  The recommended state for this setting is: Enabled.
sca.check.rationale: Data could be forwarded from the user's Remote Desktop Services session to the user's local computer without any direct user interaction. Malicious software already present on a compromised server would have direct and stealthy disk access to the user's local computer during the Remote Desktop session.
sca.check.remediation: To establish the recommended configuration via GP, set the following UI path to Enabled: Computer Configuration\Policies\Administrative Templates\Windows Components\Remote Desktop Services\Remote Desktop Session Host\Device and Resource Redirection\Do not allow drive redirection Note: This Group Policy path is provided by the Group Policy template TerminalServer.admx/adml that is included with all versions of the Microsoft Windows Administrative Templates.
sca.check.compliance.cis: 18.9.58.3.3.2
sca.check.compliance.cis_csc: 13
sca.check.registry: ["HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\Microsoft\\Windows NT\\Terminal Services"]
sca.check.status: Not applicable
sca.check.reason: Key 'fDisableCdm' not found for registry 'HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Terminal Services'

** Alert 1557745314.2888403: - sca,gdpr_IV_35.7.d
2019 May 13 13:01:54 (win2012) any->sca
Rule: 19009 (level 3) -> 'CIS benchmark for Windows 2012 R2 Member Server L1: Ensure 'Always prompt for password upon connection' is set to 'Enabled''
{"type":"check","id":38126879,"policy":"CIS benchmark for Windows 2012 R2 Member Server L1","policy_id":"cis_win2012r2_memberL1","check":{"id":9138,"title":"Ensure 'Always prompt for password upon connection' is set to 'Enabled'","description":"This policy setting specifies whether Remote Desktop Services always prompts the client computer for a password upon connection. You can use this policy setting to enforce a password prompt for users who log on to Remote Desktop Services, even if they already provided the password in the Remote Desktop Connection client.  The recommended state for this setting is: Enabled.","rationale":"Users have the option to store both their username and password when they create a new Remote Desktop Connection shortcut. If the server that runs Remote Desktop Services allows users who have used this feature to log on to the server but not enter their password, then it is possible that an attacker who has gained physical access to the user's computer could connect to a Remote Desktop Server through the Remote Desktop Connection shortcut, even though they may not know the user's password.","remediation":"To establish the recommended configuration via GP, set the following UI path to Enabled: Computer Configuration\\Policies\\Administrative Templates\\Windows Components\\Remote Desktop Services\\Remote Desktop Session Host\\Security\\Always prompt for password upon connection Note: This Group Policy path is provided by the Group Policy template TerminalServer.admx/adml that is included with all versions of the Microsoft Windows Administrative Templates.  Note #2: In the Microsoft Windows Vista Administrative Templates, this setting was named Always prompt client for password upon connection, but it was renamed starting with the Windows Server 2008 (non-R2) Administrative Templates.","compliance":{"cis":"18.9.58.3.9.1","cis_csc":"16.14"},"rules":["r:HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\Microsoft\\Windows NT\\Terminal Services -> fPromptForPassword -> !1;","r:HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\Microsoft\\Windows NT\\Terminal Services -> !fPromptForPassword;"],"registry":"HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\Microsoft\\Windows NT\\Terminal Services","status":"Not applicable","reason":"Key 'fPromptForPassword' not found for registry 'HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\Microsoft\\Windows NT\\Terminal Services'"}}
sca.type: check
sca.scan_id: 38126879
sca.policy: CIS benchmark for Windows 2012 R2 Member Server L1
sca.check.id: 9138
sca.check.title: Ensure 'Always prompt for password upon connection' is set to 'Enabled'
sca.check.description: This policy setting specifies whether Remote Desktop Services always prompts the client computer for a password upon connection. You can use this policy setting to enforce a password prompt for users who log on to Remote Desktop Services, even if they already provided the password in the Remote Desktop Connection client.  The recommended state for this setting is: Enabled.
sca.check.rationale: Users have the option to store both their username and password when they create a new Remote Desktop Connection shortcut. If the server that runs Remote Desktop Services allows users who have used this feature to log on to the server but not enter their password, then it is possible that an attacker who has gained physical access to the user's computer could connect to a Remote Desktop Server through the Remote Desktop Connection shortcut, even though they may not know the user's password.
sca.check.remediation: To establish the recommended configuration via GP, set the following UI path to Enabled: Computer Configuration\Policies\Administrative Templates\Windows Components\Remote Desktop Services\Remote Desktop Session Host\Security\Always prompt for password upon connection Note: This Group Policy path is provided by the Group Policy template TerminalServer.admx/adml that is included with all versions of the Microsoft Windows Administrative Templates.  Note #2: In the Microsoft Windows Vista Administrative Templates, this setting was named Always prompt client for password upon connection, but it was renamed starting with the Windows Server 2008 (non-R2) Administrative Templates.
sca.check.compliance.cis: 18.9.58.3.9.1
sca.check.compliance.cis_csc: 16.14
sca.check.registry: ["HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\Microsoft\\Windows NT\\Terminal Services"]
sca.check.status: Not applicable
sca.check.reason: Key 'fPromptForPassword' not found for registry 'HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Terminal Services'

** Alert 1557745314.2893224: - sca,gdpr_IV_35.7.d
2019 May 13 13:01:54 (win2012) any->sca
Rule: 19009 (level 3) -> 'CIS benchmark for Windows 2012 R2 Member Server L1: Ensure 'Require secure RPC communication' is set to 'Enabled''
{"type":"check","id":38126879,"policy":"CIS benchmark for Windows 2012 R2 Member Server L1","policy_id":"cis_win2012r2_memberL1","check":{"id":9139,"title":"Ensure 'Require secure RPC communication' is set to 'Enabled'","description":"This policy setting allows you to specify whether Remote Desktop Services requires secure Remote Procedure Call (RPC) communication with all clients or allows unsecured communication.  You can use this policy setting to strengthen the security of RPC communication with clients by allowing only authenticated and encrypted requests.  The recommended state for this setting is: Enabled.","rationale":"Allowing unsecure RPC communication can exposes the server to man in the middle attacks and data disclosure attacks.","remediation":"To establish the recommended configuration via GP, set the following UI path to Enabled: Computer Configuration\\Policies\\Administrative Templates\\Windows Components\\Remote Desktop Services\\Remote Desktop Session Host\\Security\\Require secure RPC communication Note: This Group Policy path is provided by the Group Policy template TerminalServer.admx/adml that is included with all versions of the Microsoft Windows Administrative Templates.","compliance":{"cis":"18.9.58.3.9.2","cis_csc":"3.4"},"rules":["r:HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\Microsoft\\Windows NT\\Terminal Services -> fEncryptRPCTraffic -> !1;","r:HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\Microsoft\\Windows NT\\Terminal Services -> !fEncryptRPCTraffic;"],"registry":"HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\Microsoft\\Windows NT\\Terminal Services","status":"Not applicable","reason":"Key 'fEncryptRPCTraffic' not found for registry 'HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\Microsoft\\Windows NT\\Terminal Services'"}}
sca.type: check
sca.scan_id: 38126879
sca.policy: CIS benchmark for Windows 2012 R2 Member Server L1
sca.check.id: 9139
sca.check.title: Ensure 'Require secure RPC communication' is set to 'Enabled'
sca.check.description: This policy setting allows you to specify whether Remote Desktop Services requires secure Remote Procedure Call (RPC) communication with all clients or allows unsecured communication.  You can use this policy setting to strengthen the security of RPC communication with clients by allowing only authenticated and encrypted requests.  The recommended state for this setting is: Enabled.
sca.check.rationale: Allowing unsecure RPC communication can exposes the server to man in the middle attacks and data disclosure attacks.
sca.check.remediation: To establish the recommended configuration via GP, set the following UI path to Enabled: Computer Configuration\Policies\Administrative Templates\Windows Components\Remote Desktop Services\Remote Desktop Session Host\Security\Require secure RPC communication Note: This Group Policy path is provided by the Group Policy template TerminalServer.admx/adml that is included with all versions of the Microsoft Windows Administrative Templates.
sca.check.compliance.cis: 18.9.58.3.9.2
sca.check.compliance.cis_csc: 3.4
sca.check.registry: ["HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\Microsoft\\Windows NT\\Terminal Services"]
sca.check.status: Not applicable
sca.check.reason: Key 'fEncryptRPCTraffic' not found for registry 'HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Terminal Services'

** Alert 1557745314.2896787: - sca,gdpr_IV_35.7.d
2019 May 13 13:01:54 (win2012) any->sca
Rule: 19009 (level 3) -> 'CIS benchmark for Windows 2012 R2 Member Server L1: Ensure 'Set client connection encryption level' is set to 'Enabled: High Level''
{"type":"check","id":38126879,"policy":"CIS benchmark for Windows 2012 R2 Member Server L1","policy_id":"cis_win2012r2_memberL1","check":{"id":9140,"title":"Ensure 'Set client connection encryption level' is set to 'Enabled: High Level'","description":"This policy setting specifies whether to require the use of a specific encryption level to secure communications between client computers and RD Session Host servers during Remote Desktop Protocol (RDP) connections. This policy only applies when you are using native RDP encryption. However, native RDP encryption (as opposed to SSL encryption) is not recommended. This policy does not apply to SSL encryption.  The recommended state for this setting is: Enabled: High Level.","rationale":"If Remote Desktop client connections that use low level encryption are allowed, it is more likely that an attacker will be able to decrypt any captured Remote Desktop Services network traffic.","remediation":"To establish the recommended configuration via GP, set the following UI path to Enabled: High Level: Computer Configuration\\Policies\\Administrative Templates\\Windows Components\\Remote Desktop Services\\Remote Desktop Session Host\\Security\\Set client connection encryption level Note: This Group Policy path is provided by the Group Policy template TerminalServer.admx/adml that is included with all versions of the Microsoft Windows Administrative Templates.","compliance":{"cis":"18.9.58.3.9.3","cis_csc":"3.4"},"rules":["r:HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\Microsoft\\Windows NT\\Terminal Services -> MinEncryptionLevel -> !3;"],"registry":"HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\Microsoft\\Windows NT\\Terminal Services","status":"Not applicable","reason":"Key 'MinEncryptionLevel' not found for registry 'HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\Microsoft\\Windows NT\\Terminal Services'"}}
sca.type: check
sca.scan_id: 38126879
sca.policy: CIS benchmark for Windows 2012 R2 Member Server L1
sca.check.id: 9140
sca.check.title: Ensure 'Set client connection encryption level' is set to 'Enabled: High Level'
sca.check.description: This policy setting specifies whether to require the use of a specific encryption level to secure communications between client computers and RD Session Host servers during Remote Desktop Protocol (RDP) connections. This policy only applies when you are using native RDP encryption. However, native RDP encryption (as opposed to SSL encryption) is not recommended. This policy does not apply to SSL encryption.  The recommended state for this setting is: Enabled: High Level.
sca.check.rationale: If Remote Desktop client connections that use low level encryption are allowed, it is more likely that an attacker will be able to decrypt any captured Remote Desktop Services network traffic.
sca.check.remediation: To establish the recommended configuration via GP, set the following UI path to Enabled: High Level: Computer Configuration\Policies\Administrative Templates\Windows Components\Remote Desktop Services\Remote Desktop Session Host\Security\Set client connection encryption level Note: This Group Policy path is provided by the Group Policy template TerminalServer.admx/adml that is included with all versions of the Microsoft Windows Administrative Templates.
sca.check.compliance.cis: 18.9.58.3.9.3
sca.check.compliance.cis_csc: 3.4
sca.check.registry: ["HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\Microsoft\\Windows NT\\Terminal Services"]
sca.check.status: Not applicable
sca.check.reason: Key 'MinEncryptionLevel' not found for registry 'HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Terminal Services'


** Alert 1557745314.2900663: - sca,gdpr_IV_35.7.d
2019 May 13 13:01:54 (win2012) any->sca
Rule: 19009 (level 3) -> 'CIS benchmark for Windows 2012 R2 Member Server L1: Ensure 'Do not delete temp folders upon exit' is set to 'Disabled''
{"type":"check","id":38126879,"policy":"CIS benchmark for Windows 2012 R2 Member Server L1","policy_id":"cis_win2012r2_memberL1","check":{"id":9141,"title":"Ensure 'Do not delete temp folders upon exit' is set to 'Disabled'","description":"This policy setting specifies whether Remote Desktop Services retains a user's per-session temporary folders at logoff.  The recommended state for this setting is: Disabled.","rationale":"Sensitive information could be contained inside the temporary folders and visible to other administrators that log into the system.","remediation":"To establish the recommended configuration via GP, set the following UI path to Disabled: Computer Configuration\\Policies\\Administrative Templates\\Windows Components\\Remote Desktop Services\\Remote Desktop Session Host\\Temporary Folders\\Do not delete temp folders upon exit Note: This Group Policy path is provided by the Group Policy template TerminalServer.admx/adml that is included with all versions of the Microsoft Windows Administrative Templates.  Note #2: In older Microsoft Windows Administrative Templates, this setting was named Do not delete temp folder upon exit, but it was renamed starting with the Windows 8.0 & Server 2012 (non-R2) Administrative Templates.","compliance":{"cis":"18.9.58.3.11.1","cis_csc":"14.4"},"rules":["r:HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\Microsoft\\Windows NT\\Terminal Services -> DeleteTempDirsOnExit -> !1;"],"registry":"HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\Microsoft\\Windows NT\\Terminal Services","status":"Not applicable","reason":"Key 'DeleteTempDirsOnExit' not found for registry 'HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\Microsoft\\Windows NT\\Terminal Services'"}}
sca.type: check
sca.scan_id: 38126879
sca.policy: CIS benchmark for Windows 2012 R2 Member Server L1
sca.check.id: 9141
sca.check.title: Ensure 'Do not delete temp folders upon exit' is set to 'Disabled'
sca.check.description: This policy setting specifies whether Remote Desktop Services retains a user's per-session temporary folders at logoff.  The recommended state for this setting is: Disabled.
sca.check.rationale: Sensitive information could be contained inside the temporary folders and visible to other administrators that log into the system.
sca.check.remediation: To establish the recommended configuration via GP, set the following UI path to Disabled: Computer Configuration\Policies\Administrative Templates\Windows Components\Remote Desktop Services\Remote Desktop Session Host\Temporary Folders\Do not delete temp folders upon exit Note: This Group Policy path is provided by the Group Policy template TerminalServer.admx/adml that is included with all versions of the Microsoft Windows Administrative Templates.  Note #2: In older Microsoft Windows Administrative Templates, this setting was named Do not delete temp folder upon exit, but it was renamed starting with the Windows 8.0 & Server 2012 (non-R2) Administrative Templates.
sca.check.compliance.cis: 18.9.58.3.11.1
sca.check.compliance.cis_csc: 14.4
sca.check.registry: ["HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\Microsoft\\Windows NT\\Terminal Services"]
sca.check.status: Not applicable
sca.check.reason: Key 'DeleteTempDirsOnExit' not found for registry 'HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Terminal Services'

** Alert 1557745323.2913660: - sca,gdpr_IV_35.7.d
2019 May 13 13:02:03 (win2012) any->sca
Rule: 19009 (level 3) -> 'CIS benchmark for Windows 2012 R2 Member Server L1: Ensure 'Do not use temporary folders per session' is set to 'Disabled''
{"type":"check","id":38126879,"policy":"CIS benchmark for Windows 2012 R2 Member Server L1","policy_id":"cis_win2012r2_memberL1","check":{"id":9142,"title":"Ensure 'Do not use temporary folders per session' is set to 'Disabled'","description":"By default, Remote Desktop Services creates a separate temporary folder on the RD Session Host server for each active session that a user maintains on the RD Session Host server. The temporary folder is created on the RD Session Host server in a Temp folder under the user's profile folder and is named with the sessionid. This temporary folder is used to store individual temporary files.  To reclaim disk space, the temporary folder is deleted when the user logs off from a session.  The recommended state for this setting is: Disabled.","rationale":"Disabling this setting keeps the cached data independent for each session, both reducing the chance of problems from shared cached data between sessions, and keeping possibly sensitive data separate to each user session.","remediation":"To establish the recommended configuration via GP, set the following UI path to Disabled: Computer Configuration\\Policies\\Administrative Templates\\Windows Components\\Remote Desktop Services\\Remote Desktop Session Host\\Temporary Folders\\Do not use temporary folders per session Note: This Group Policy path is provided by the Group Policy template TerminalServer.admx/adml that is included with all versions of the Microsoft Windows Administrative Templates.","compliance":{"cis":"18.9.58.3.11.2","cis_csc":"14.4"},"rules":["r:HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\Microsoft\\Windows NT\\Terminal Services -> PerSessionTempDir -> !1;"],"registry":"HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\Microsoft\\Windows NT\\Terminal Services","status":"Not applicable","reason":"Key 'PerSessionTempDir' not found for registry 'HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\Microsoft\\Windows NT\\Terminal Services'"}}
sca.type: check
sca.scan_id: 38126879
sca.policy: CIS benchmark for Windows 2012 R2 Member Server L1
sca.check.id: 9142
sca.check.title: Ensure 'Do not use temporary folders per session' is set to 'Disabled'
sca.check.description: By default, Remote Desktop Services creates a separate temporary folder on the RD Session Host server for each active session that a user maintains on the RD Session Host server. The temporary folder is created on the RD Session Host server in a Temp folder under the user's profile folder and is named with the sessionid. This temporary folder is used to store individual temporary files.  To reclaim disk space, the temporary folder is deleted when the user logs off from a session.  The recommended state for this setting is: Disabled.
sca.check.rationale: Disabling this setting keeps the cached data independent for each session, both reducing the chance of problems from shared cached data between sessions, and keeping possibly sensitive data separate to each user session.
sca.check.remediation: To establish the recommended configuration via GP, set the following UI path to Disabled: Computer Configuration\Policies\Administrative Templates\Windows Components\Remote Desktop Services\Remote Desktop Session Host\Temporary Folders\Do not use temporary folders per session Note: This Group Policy path is provided by the Group Policy template TerminalServer.admx/adml that is included with all versions of the Microsoft Windows Administrative Templates.
sca.check.compliance.cis: 18.9.58.3.11.2
sca.check.compliance.cis_csc: 14.4
sca.check.registry: ["HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\Microsoft\\Windows NT\\Terminal Services"]
sca.check.status: Not applicable
sca.check.reason: Key 'PerSessionTempDir' not found for registry 'HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Terminal Services'
```

SQL output:
```
select id,result,reason,status from sca_check where policy_id = 'cis_win2012r2_memberL1' and id IN (9114,9115,9116,9136,9137,9138,9139,9140,9141,9142);
9114||Key 'fAllowUnsolicited' not found for registry 'HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Terminal Services'|Not applicable
9115||Key 'fAllowToGetHelp' not found for registry 'HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Terminal Services'|Not applicable
9116||Unable to read registry 'HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Rpc' (The system cannot find the file specified. )|Not applicable
9136||Key 'DisablePasswordSaving' not found for registry 'HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Terminal Services'|Not applicable
9137||Key 'fDisableCdm' not found for registry 'HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Terminal Services'|Not applicable
9138||Key 'fPromptForPassword' not found for registry 'HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Terminal Services'|Not applicable
9139||Key 'fEncryptRPCTraffic' not found for registry 'HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Terminal Services'|Not applicable
9140||Key 'MinEncryptionLevel' not found for registry 'HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Terminal Services'|Not applicable
9141||Key 'DeleteTempDirsOnExit' not found for registry 'HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Terminal Services'|Not applicable
9142||Key 'PerSessionTempDir' not found for registry 'HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Terminal Services'|Not applicable

```
- [x] windows/win_audit_rcl.yml 

- Affected checks: 2507

Alerts generated:
```
** Alert 1557744894.2271921: - sca,gdpr_IV_35.7.d
2019 May 13 12:54:54 (win2012) any->sca
Rule: 19009 (level 3) -> 'Benchmark for Windows audit: Automatic Logon enabled'
{"type":"check","id":821865997,"policy":"Benchmark for Windows audit","policy_id":"win_audit","check":{"id":2507,"title":"Automatic Logon enabled","compliance":{"pci_dss":"10.6.1"},"rules":["r:HKLM\\Software\\Microsoft\\Windows NT\\CurrentVersion\\Winlogon -> DefaultPassword;","r:HKLM\\Software\\Microsoft\\Windows NT\\CurrentVersion\\Winlogon -> AutoAdminLogon -> 1;"],"registry":"HKLM\\Software\\Microsoft\\Windows NT\\CurrentVersion\\Winlogon","status":"Not applicable","reason":"Key 'AutoAdminLogon' not found for registry 'HKLM\\Software\\Microsoft\\Windows NT\\CurrentVersion\\Winlogon'"}}
sca.type: check
sca.scan_id: 821865997
sca.policy: Benchmark for Windows audit
sca.check.id: 2507
sca.check.title: Automatic Logon enabled
sca.check.compliance.pci_dss: 10.6.1
sca.check.registry: ["HKLM\\Software\\Microsoft\\Windows NT\\CurrentVersion\\Winlogon"]
sca.check.status: Not applicable
sca.check.reason: Key 'AutoAdminLogon' not found for registry 'HKLM\Software\Microsoft\Windows NT\CurrentVersion\Winlogon'
```

SQL output:

```
select id,result,reason,status from sca_check where id = 2507;
2507||Key 'AutoAdminLogon' not found for registry 'HKLM\Software\Microsoft\Windows NT\CurrentVersion\Winlogon'|Not applicable
```