### PR TITLE
Fix Microsoft Antimalware and Eventlog rules' channels

### DIFF
--- a/rules/0575-win-base_rules.xml
+++ b/rules/0575-win-base_rules.xml
@@ -64,15 +64,15 @@
   </rule>
 
   <rule id="60007" level="0">
-    <if_sid>60000</if_sid>
-    <field name="win.system.channel">^Microsoft-Windows-Eventlog</field>
+    <if_sid>60001</if_sid>
+    <field name="win.system.providerName">^Microsoft-Windows-Eventlog</field>
     <options>no_full_log</options>
     <description>Group of rules for Windows Eventlog</description>
   </rule>
 
   <rule id="60008" level="0">
-    <if_sid>60000</if_sid>
-    <field name="win.system.channel">^Microsoft Antimalware</field>
+    <if_sid>60002</if_sid>
+    <field name="win.system.providerName">^Microsoft Antimalware</field>
     <options>no_full_log</options>
     <description>Group of Microsoft Security Essentials rules</description>
   </rule>


### PR DESCRIPTION
This PR fixes: https://github.com/wazuh/wazuh-ruleset/issues/396

The rule 60007 was not filtering by the right channel. It has been changed to filter by `Security`, as `Microsoft-Windows-Eventlog` is the provider name.
Also, rule 60008 has been changed for the same reason. A `Security Essentials` event looks like this:
```
{
   "win":{
      "system":{
         "providerName":"Microsoft Antimalware",
         "eventID":"2010",
         "level":"4",
         "task":"0",
         "keywords":"0x80000000000000",
         "systemTime":"2019-05-15T09:19:30.000000000Z",
         "eventRecordID":"1311",
         "channel":"System",
         "computer":"user-PC",
         "severityValue":"INFORMATION",
         "message":"Microsoft Antimalware used Dynamic Signature Service to retrieve additional signatures to help protect your machine."
      },
      "eventdata":{
         "data":"%%860, 4.10.209.0, 1.293.1636.0, 2, %%801, 1.1.15900.4, 2, %%863, c:\\ProgramData\\Microsoft\\Microsoft Antimalware\\Scans\\RtSigs\\data\\f646ed823bbfd0fb8a9df8d13ff55466eb6158b0, 1.293.1636.1, 3, %%865, 1.293.1636.1"
      }
   }
}
```
The channel is `System` and the provider name is `Microsoft Antimalware`.

These rules' filtering fields and parent rule have been changed for the right ones.