### PR TITLE
Added new rule to the "0580-win-security_rules.xml" file

### DIFF
--- a/rules/0580-win-security_rules.xml
+++ b/rules/0580-win-security_rules.xml
@@ -155,12 +155,12 @@
   </rule>
 
   <rule id="60117" level="9">
-    <if_sid>60103</if_sid>
-    <field name="win.system.eventID">^517$|^1102$</field>
-    <description>Windows audit log was cleared</description>
-    <options>no_full_log</options>
-    <group>logs_cleared,pci_dss_10.6.1,gpg13_10.1,gdpr_IV_35.7.d,</group>
-  </rule>
+   <if_sid>60100</if_sid>
+   <field name="win.system.eventID">^1102$</field>
+   <description>Windows audit log was cleared</description>
+   <options>no_full_log</options>
+   <group>logs_cleared,pci_dss_10.6.1,gpg13_10.1,gdpr_IV_35.7.d,</group>
+</rule>
 
   <rule id="60118" level="3">
     <if_sid>60106</if_sid>
@@ -1024,11 +1024,6 @@
     <options>no_full_log</options>
   </rule>
   
-   <rule id="60226" level="8">
-    <if_sid>60100</if_sid>
-    <field name="win.system.eventID">^1102$</field>
-    <description>The audit log was cleared.</description>    
-    <options>no_full_log</options>
-  </rule>
+  
 
 </group>

--- a/rules/0580-win-security_rules.xml
+++ b/rules/0580-win-security_rules.xml
@@ -155,12 +155,12 @@
   </rule>
 
   <rule id="60117" level="9">
-   <if_sid>60100</if_sid>
-   <field name="win.system.eventID">^1102$</field>
-   <description>Windows audit log was cleared</description>
-   <options>no_full_log</options>
-   <group>logs_cleared,pci_dss_10.6.1,gpg13_10.1,gdpr_IV_35.7.d,</group>
-</rule>
+    <if_sid>60100</if_sid>
+    <field name="win.system.eventID">^1102$</field>
+    <description>Windows audit log was cleared</description>
+    <options>no_full_log</options>
+    <group>logs_cleared,pci_dss_10.6.1,gpg13_10.1,gdpr_IV_35.7.d,</group>
+  </rule>
 
   <rule id="60118" level="3">
     <if_sid>60106</if_sid>
@@ -1023,7 +1023,5 @@
     <description>IPsec Services encountered a potentially serious failure</description>
     <options>no_full_log</options>
   </rule>
-  
-  
 
 </group>

--- a/rules/0580-win-security_rules.xml
+++ b/rules/0580-win-security_rules.xml
@@ -1023,5 +1023,12 @@
     <description>IPsec Services encountered a potentially serious failure</description>
     <options>no_full_log</options>
   </rule>
+  
+   <rule id="60226" level="8">
+    <if_sid>60100</if_sid>
+    <field name="win.system.eventID">^1102$</field>
+    <description>The audit log was cleared.</description>    
+    <options>no_full_log</options>
+  </rule>
 
 </group>


### PR DESCRIPTION
Hi team,

I have added a new rule to catch the event which ID is 1102 and the description is: The audit log was cleared.

Regards,

Miguel Casares