### PR TITLE
Extract the srcip and more infos from one postfix message.

### DIFF
--- a/decoders/0220-postfix_decoders.xml
+++ b/decoders/0220-postfix_decoders.xml
@@ -49,3 +49,10 @@
   <regex>^warning: (\S+):|warning: Illegal address syntax from unknown[(\S+)]|warning: hostname \S+ does not resolve to address (\S+): </regex>
   <order>srcip</order>
 </decoder>
+
+<decoder name="postfix-too-many-errors">
+  <parent>postfix</parent>
+  <prematch>^too many errors after</prematch>
+  <regex>^too many errors after (\S+) from (\.+)[(\.+)]$</regex>
+  <order>action,srchost,srcip</order>
+</decoder>


### PR DESCRIPTION
There is already an example in the postfix decoder:

https://github.com/wazuh/wazuh-ruleset/blob/902723baf4c514eecdb56baed8946293077156ea/decoders/0220-postfix_decoders.xml#L21

so extract this info accordingly. Instead of the "unknown" i have seen the hostname of the external system in the message:

```
May 28 14:05:00 hostname postfix/smtpd[30818]: too many errors after RCPT from example.com[192.168.0.1]


**Phase 1: Completed pre-decoding.
       full event: 'May 28 14:05:00 hostname postfix/smtpd[30818]: too many errors after RCPT from example.com[192.168.0.1]'
       timestamp: 'May 28 14:05:00'
       hostname: 'hostname'
       program_name: 'postfix/smtpd'
       log: 'too many errors after RCPT from example.com[192.168.0.1]'

**Phase 2: Completed decoding.
       decoder: 'postfix'
       action: 'RCPT'
       srchost: 'example.com'
       srcip: '192.168.0.1'

**Phase 3: Completed filtering (rules).
       Rule id: '3335'
       Level: '6'
       Description: 'Postfix: too many errors after RCPT from unkown'
**Alert to be generated.
```