### PR TITLE
Remove tailing single quote from audit.res

### DIFF
--- a/decoders/0040-auditd_decoders.xml
+++ b/decoders/0040-auditd_decoders.xml
@@ -342,6 +342,6 @@ type=TEST_GENERIC msg=audit(1234567890.123:1234): addr=10.10.10.10 ses=20 exe="l
 
 <decoder name="auditd-generic">
     <parent>auditd</parent>
-    <regex>res=(\S+)</regex>
+    <regex>res=(\w+)</regex>
     <order>audit.res</order>
 </decoder>


### PR DESCRIPTION
The auditd decoder field 'audit.res' includes an unwanted tailing single quote when it is defined inside a msg='...' construct as is normal with current Redhat/CentOS.  For the below log, audit.res is extracted as 
	success'
instead of 
	success

type=USER_LOGIN msg=audit(1559060902.765:1916): pid=23239 uid=0 auid=0 ses=8 subj=unconfined_u:unconfined_r:unconfined_t:s0-s0:c0.c1023 msg='op=login id=0 exe="/usr/sbin/sshd" hostname=name.host.addr=43.45.126.244 terminal=/dev/pts/0 res=success'

In the final decoder section of /var/ossec/ruleset/decoders/0040-auditd_decoders.xml, changing the regex from res=(\S+) to res=(\w+) seems to fix this issue cleanly.  I think it is safe as I am not aware of any non-alphanumeric values being valid for this field.   I have only ever seen audit.res values of success, failed, 0, or 1.