### PR TITLE
Updated IPv4-dependent regexp in ownCloud decoders.

### DIFF
--- a/decoders/0435-owncloud_decoders.xml
+++ b/decoders/0435-owncloud_decoders.xml
@@ -53,21 +53,21 @@
 <decoder name="owncloud-failed1">
   <parent>owncloud</parent>
   <prematch>Login failed: user </prematch>
-  <regex offset="after_prematch">^'(\w+)' , wrong password, IP:(\d+.\d+.\d+.\d+)</regex>
+  <regex offset="after_prematch">^'(\w+)' , wrong password, IP:(\S+)"</regex>
   <order>user, srcip</order>
 </decoder>
 
 <decoder name="owncloud-failed2">
   <parent>owncloud</parent>
   <prematch>Login failed: </prematch>
-  <regex offset="after_prematch">^'(\w+)' \(Remote IP: '(\d+.\d+.\d+.\d+)</regex>
+  <regex offset="after_prematch">^'(\w+)' \(Remote IP: '(\S+)'|\)</regex>
   <order>user, srcip</order>
 </decoder>
 
 <decoder name="owncloud-malicious">
   <parent>owncloud</parent>
   <prematch>Passed filename is not valid, might be malicious </prematch>
-  <regex offset="after_prematch">;ip:"(\d+.\d+.\d+.\d+)|;ip:\\"(\d+.\d+.\d+.\d+)</regex>
+  <regex offset="after_prematch">;ip:"(\S+.)"|;ip:\\"(\S+)\\"</regex>
   <order>srcip</order>
 </decoder>
 


### PR DESCRIPTION
Same as https://github.com/ossec/ossec-hids/pull/1697 + https://github.com/ossec/ossec-hids/pull/1724 + https://github.com/ossec/ossec-hids/pull/1725

See the decoder.xml for example log entries.