### PR TITLE
Fix some NIST 800 53 mappings

### DIFF
--- a/rules/0015-ossec_rules.xml
+++ b/rules/0015-ossec_rules.xml
@@ -36,7 +36,7 @@
     <options>alert_by_email</options>
     <match>Agent started</match>
     <description>Ossec agent started.</description>
-    <group>pci_dss_10.6.1,pci_dss_10.2.6,gpg13_10.1,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.6,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>pci_dss_10.6.1,pci_dss_10.2.6,gpg13_10.1,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.6,nist_800_53_IA.10,nist_800_53_AU.5,</group>
   </rule>
 
   <rule id="504" level="3">
@@ -44,7 +44,7 @@
     <options>alert_by_email</options>
     <match>Agent disconnected</match>
     <description>Ossec agent disconnected.</description>
-    <group>pci_dss_10.6.1,pci_dss_10.2.6,gpg13_10.1,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.6,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>pci_dss_10.6.1,pci_dss_10.2.6,gpg13_10.1,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.6,nist_800_53_IA.10,nist_800_53_AU.5,</group>
   </rule>
 
   <rule id="505" level="3">
@@ -52,7 +52,7 @@
     <options>alert_by_email</options>
     <match>Agent removed</match>
     <description>Ossec agent removed.</description>
-    <group>pci_dss_10.6.1,pci_dss_10.2.6,gpg13_10.1,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.6,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>pci_dss_10.6.1,pci_dss_10.2.6,gpg13_10.1,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.6,nist_800_53_IA.10,nist_800_53_AU.5,</group>
   </rule>
 
   <rule id="509" level="0">
@@ -174,7 +174,7 @@
     <match>ossec: output: 'netstat listening ports</match>
     <check_diff />
     <description>Listened ports status (netstat) changed (new port opened or closed).</description>
-    <group>pci_dss_10.2.7,pci_dss_10.6.1,gpg13_10.1,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,nist_800_53_AU.6,</group>
+    <group>pci_dss_10.2.7,pci_dss_10.6.1,gpg13_10.1,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AU.6,</group>
   </rule>
 
   <rule id="534" level="1">
@@ -233,14 +233,14 @@
     <category>ossec</category>
     <decoded_as>hostinfo_modified</decoded_as>
     <description>Host information changed.</description>
-    <group>hostinfo,pci_dss_10.2.7,gpg13_4.13,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>hostinfo,pci_dss_10.2.7,gpg13_4.13,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_IA.10,</group>
   </rule>
 
   <rule id="581" level="8">
     <category>ossec</category>
     <decoded_as>hostinfo_new</decoded_as>
     <description>Host information added.</description>
-    <group>hostinfo,pci_dss_10.2.7,gpg13_4.13,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>hostinfo,pci_dss_10.2.7,gpg13_4.13,hipaa_164.312.b,nist_800_53_IA.10,</group>
   </rule>
 
 
@@ -256,7 +256,7 @@
     <if_sid>500</if_sid>
     <match>^ossec: File size reduced</match>
     <description>Log file size reduced.</description>
-    <group>attacks,pci_dss_10.5.2,pci_dss_11.4,gpg13_10.1,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.9,nist_800_53_SC.7,</group>
+    <group>attacks,pci_dss_10.5.2,pci_dss_11.4,gpg13_10.1,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.9,nist_800_53_IA.10,</group>
   </rule>
 
   <rule id="593" level="9">
@@ -306,7 +306,7 @@
     <field name="script">firewall-drop.sh</field>
     <field name="type">add</field>
     <description>Host Blocked by firewall-drop.sh Active Response</description>
-    <group>active_response,pci_dss_11.4,gpg13_4.13,gdpr_IV_35.7.d,nist_800_53_SC.7,</group>
+    <group>active_response,pci_dss_11.4,gpg13_4.13,gdpr_IV_35.7.d,nist_800_53_IA.10,</group>
   </rule>
 
   <rule id="602" level="3">
@@ -314,7 +314,7 @@
     <field name="script">firewall-drop.sh</field>
     <field name="type">delete</field>
     <description>Host Unblocked by firewall-drop.sh Active Response</description>
-    <group>active_response,pci_dss_11.4,gpg13_4.13,gdpr_IV_35.7.d,nist_800_53_SC.7,</group>
+    <group>active_response,pci_dss_11.4,gpg13_4.13,gdpr_IV_35.7.d,nist_800_53_IA.10,</group>
   </rule>
 
   <rule id="603" level="3">
@@ -322,7 +322,7 @@
     <field name="script">host-deny.sh</field>
     <field name="type">add</field>
     <description>Host Blocked by host-deny.sh Active Response</description>
-    <group>active_response,pci_dss_11.4,gpg13_4.13,gdpr_IV_35.7.d,nist_800_53_SC.7,</group>
+    <group>active_response,pci_dss_11.4,gpg13_4.13,gdpr_IV_35.7.d,nist_800_53_IA.10,</group>
   </rule>
 
   <rule id="604" level="3">
@@ -330,7 +330,7 @@
     <field name="script">host-deny.sh</field>
     <field name="type">delete</field>
     <description>Host Unblocked by host-deny.sh Active Response</description>
-    <group>active_response,pci_dss_11.4,gpg13_4.13,gdpr_IV_35.7.d,nist_800_53_SC.7,</group>
+    <group>active_response,pci_dss_11.4,gpg13_4.13,gdpr_IV_35.7.d,nist_800_53_IA.10,</group>
   </rule>
 
   <rule id="605" level="3">
@@ -338,7 +338,7 @@
     <field name="script">route-null</field>
     <field name="type">add</field>
     <description>Host Blocked by $(script) Active Response</description>
-    <group>active_response,pci_dss_11.4,gpg13_4.13,gdpr_IV_35.7.d,nist_800_53_SC.7,</group>
+    <group>active_response,pci_dss_11.4,gpg13_4.13,gdpr_IV_35.7.d,nist_800_53_IA.10,</group>
   </rule>
 
   <rule id="606" level="3">
@@ -346,13 +346,13 @@
     <field name="script">route-null</field>
     <field name="type">delete</field>
     <description>Host Unblocked by $(script) Active Response</description>
-    <group>active_response,pci_dss_11.4,gpg13_4.13,gdpr_IV_35.7.d,nist_800_53_SC.7,</group>
+    <group>active_response,pci_dss_11.4,gpg13_4.13,gdpr_IV_35.7.d,nist_800_53_IA.10,</group>
   </rule>
 
   <rule id="607" level="3">
     <if_sid>600</if_sid>
     <description>Active response: $(script) - $(type)</description>
-    <group>active_response,pci_dss_11.4,gdpr_IV_35.7.d,nist_800_53_SC.7,</group>
+    <group>active_response,pci_dss_11.4,gdpr_IV_35.7.d,nist_800_53_IA.10,</group>
   </rule>
 
   <rule id="700" level="0">

--- a/rules/0020-syslog_rules.xml
+++ b/rules/0020-syslog_rules.xml
@@ -156,7 +156,7 @@
   <rule id="2504" level="9">
     <match>ILLEGAL ROOT LOGIN|ROOT LOGIN REFUSED</match>
     <description>syslog: Illegal root login. </description>
-    <group>invalid_login,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_10.2.2,gpg13_7.8,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,nist_800_53_IA.10,nist_800_53_AC.6,</group>
+    <group>invalid_login,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_10.2.2,gpg13_7.8,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,nist_800_53_AC.6,</group>
   </rule>
 
   <rule id="2505" level="3">
@@ -394,7 +394,7 @@
     <if_sid>2832</if_sid>
     <match>^(root)</match>
     <description>Root's crontab entry changed.</description>
-    <group>pci_dss_10.2.7,pci_dss_10.6.1,pci_dss_10.2.2,gpg13_4.13,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AU.6,nist_800_53_IA.10,nist_800_53_AC.6,</group>
+    <group>pci_dss_10.2.7,pci_dss_10.6.1,pci_dss_10.2.2,gpg13_4.13,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AU.6,nist_800_53_AC.6,</group>
   </rule>
 
 </group> <!-- SYSLOG,CRON -->
@@ -472,25 +472,25 @@
   <rule id="5901" level="8">
     <match>^new group</match>
     <description>New group added to the system</description>
-    <group>pci_dss_10.2.7,pci_dss_10.2.5,pci_dss_8.1.2,gpg13_4.13,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,hipaa_164.312.a.2.I,hipaa_164.312.a.2.II,nist_800_53_IA.10,nist_800_53_IA.10,nist_800_53_AC.7,nist_800_53_AC.2,nist_800_53_IA.4,</group>
+    <group>pci_dss_10.2.7,pci_dss_10.2.5,pci_dss_8.1.2,gpg13_4.13,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,hipaa_164.312.a.2.I,hipaa_164.312.a.2.II,nist_800_53_IA.10,nist_800_53_AC.7,nist_800_53_AC.2,nist_800_53_IA.4,</group>
   </rule>
 
   <rule id="5902" level="8">
     <match>^new user|^new account added</match>
     <description>New user added to the system</description>
-    <group>pci_dss_10.2.7,pci_dss_10.2.5,pci_dss_8.1.2,gpg13_4.13,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,hipaa_164.312.a.2.I,hipaa_164.312.a.2.II,nist_800_53_IA.10,nist_800_53_IA.10,nist_800_53_AC.7,nist_800_53_AC.2,nist_800_53_IA.4,</group>
+    <group>pci_dss_10.2.7,pci_dss_10.2.5,pci_dss_8.1.2,gpg13_4.13,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,hipaa_164.312.a.2.I,hipaa_164.312.a.2.II,nist_800_53_IA.10,nist_800_53_AC.7,nist_800_53_AC.2,nist_800_53_IA.4,</group>
   </rule>
 
   <rule id="5903" level="3">
     <match>^delete user|^account deleted|^remove group</match>
     <description>Group (or user) deleted from the system</description>
-    <group>pci_dss_10.2.7,pci_dss_10.2.5,pci_dss_8.1.2,gpg13_4.13,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,hipaa_164.312.a.2.I,hipaa_164.312.a.2.II,nist_800_53_IA.10,nist_800_53_IA.10,nist_800_53_AC.7,nist_800_53_AC.2,nist_800_53_IA.4,</group>
+    <group>pci_dss_10.2.7,pci_dss_10.2.5,pci_dss_8.1.2,gpg13_4.13,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,hipaa_164.312.a.2.I,hipaa_164.312.a.2.II,nist_800_53_IA.10,nist_800_53_AC.7,nist_800_53_AC.2,nist_800_53_IA.4,</group>
   </rule>
 
   <rule id="5904" level="8">
     <match>^changed user</match>
     <description>Information from the user was changed</description>
-    <group>pci_dss_10.2.7,pci_dss_10.2.5,pci_dss_8.1.2,gpg13_4.13,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,hipaa_164.312.a.2.I,hipaa_164.312.a.2.II,nist_800_53_IA.10,nist_800_53_IA.10,nist_800_53_AC.7,nist_800_53_AC.2,nist_800_53_IA.4,</group>
+    <group>pci_dss_10.2.7,pci_dss_10.2.5,pci_dss_8.1.2,gpg13_4.13,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,hipaa_164.312.a.2.I,hipaa_164.312.a.2.II,nist_800_53_IA.10,nist_800_53_AC.7,nist_800_53_AC.2,nist_800_53_IA.4,</group>
   </rule>
 
   <rule id="5905" level="0">
@@ -520,7 +520,7 @@
     <if_sid>5400</if_sid>
     <regex> ; USER=root ; COMMAND=| ; USER=root ; TSID=\S+ ; COMMAND=</regex>
     <description>Successful sudo to ROOT executed</description>
-    <group>pci_dss_10.2.5,pci_dss_10.2.2,gpg13_7.6,gpg13_7.8,gpg13_7.13,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,nist_800_53_IA.10,nist_800_53_AC.6,</group>
+    <group>pci_dss_10.2.5,pci_dss_10.2.2,gpg13_7.6,gpg13_7.8,gpg13_7.13,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,nist_800_53_AC.6,</group>
   </rule>
 
   <rule id="5403" level="4">
@@ -541,7 +541,7 @@
     <if_sid>5400</if_sid>
     <match>user NOT in sudoers</match>
     <description>Unauthorized user attempted to use sudo.</description>
-    <group>pci_dss_10.2.2,pci_dss_10.2.5,gpg13_7.8,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.6,nist_800_53_IA.10,nist_800_53_AC.7,</group>
+    <group>pci_dss_10.2.2,pci_dss_10.2.5,gpg13_7.8,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.6,nist_800_53_AC.7,</group>
   </rule>
 
   <rule id="5406" level="5">

--- a/rules/0020-syslog_rules.xml
+++ b/rules/0020-syslog_rules.xml
@@ -19,7 +19,7 @@
   <rule id="1001" level="2">
     <match>^Couldn't open /etc/securetty</match>
     <description>File missing. Root access unrestricted.</description>
-    <group>pci_dss_10.2.4,gpg13_4.1,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>pci_dss_10.2.4,gpg13_4.1,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,</group>
   </rule>
 
   <rule id="1002" level="2">
@@ -135,14 +135,14 @@
     <match>authinternal failed|Failed to authorize|</match>
     <match>Wrong password given for|login failed|Auth: Login incorrect|</match>
     <match>Failed to authenticate user</match>
-    <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.8,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.8,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,</group>
     <description>syslog: User authentication failure.</description>
   </rule>
 
   <rule id="2502" level="10">
     <match>more authentication failures;|REPEATED login failures</match>
     <description>syslog: User missed the password more than one time</description>
-    <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.8,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.8,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,</group>
   </rule>
 
   <rule id="2503" level="5">
@@ -150,25 +150,25 @@
     <regex>^libwrap refused connection|</regex>
     <regex>Connection from \S+ denied</regex>
     <description>syslog: Connection blocked by Tcp Wrappers.</description>
-    <group>access_denied,pci_dss_10.2.4,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>access_denied,pci_dss_10.2.4,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,</group>
   </rule>
 
   <rule id="2504" level="9">
     <match>ILLEGAL ROOT LOGIN|ROOT LOGIN REFUSED</match>
     <description>syslog: Illegal root login. </description>
-    <group>invalid_login,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_10.2.2,gpg13_7.8,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>invalid_login,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_10.2.2,gpg13_7.8,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,nist_800_53_IA.10,nist_800_53_AC.6,</group>
   </rule>
 
   <rule id="2505" level="3">
     <match>^ROOT LOGIN  on</match>
     <description>syslog: Physical root login.</description>
-    <group>pci_dss_10.2.2,gpg13_7.8,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>pci_dss_10.2.2,gpg13_7.8,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.6,</group>
   </rule>
 
   <rule id="2506" level="3">
     <match>^Authentication passed</match>
     <description>syslog: Pop3 Authentication passed.</description>
-    <group>pci_dss_10.2.5,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>pci_dss_10.2.5,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,</group>
   </rule>
 
   <rule id="2507" level="0">
@@ -189,7 +189,7 @@
     <same_id />
     <match>RESULT tag=97 err=49</match>
     <description>OpenLDAP authentication failed.</description>
-    <group>pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,</group>
   </rule>
 
 </group> <!-- SYSLOG,ACESSCONTROL -->
@@ -283,7 +283,7 @@
     <regex>Promiscuous mode enabled|</regex>
     <regex>device \S+ entered promiscuous mode</regex>
     <description>Interface entered in promiscuous(sniffing) mode.</description>
-    <group>promisc,pci_dss_10.6.1,pci_dss_11.4,gpg13_4.13,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.6,nist_800_53_SC.7,</group>
+    <group>promisc,pci_dss_10.6.1,pci_dss_11.4,gpg13_4.13,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.6,nist_800_53_IA.10,</group>
   </rule>
 
   <rule id="5105" level="0">
@@ -387,14 +387,14 @@
     <if_sid>2830</if_sid>
     <match>REPLACE</match>
     <description>Crontab entry changed.</description>
-    <group>pci_dss_10.2.7,pci_dss_10.6.1,gpg13_4.13,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,nist_800_53_AU.6,</group>
+    <group>pci_dss_10.2.7,pci_dss_10.6.1,gpg13_4.13,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AU.6,</group>
   </rule>
 
   <rule id="2833" level="8">
     <if_sid>2832</if_sid>
     <match>^(root)</match>
     <description>Root's crontab entry changed.</description>
-    <group>pci_dss_10.2.7,pci_dss_10.6.1,pci_dss_10.2.2,gpg13_4.13,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,nist_800_53_AU.6,</group>
+    <group>pci_dss_10.2.7,pci_dss_10.6.1,pci_dss_10.2.2,gpg13_4.13,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AU.6,nist_800_53_IA.10,nist_800_53_AC.6,</group>
   </rule>
 
 </group> <!-- SYSLOG,CRON -->
@@ -412,14 +412,14 @@
    <if_sid>5300</if_sid>
    <match>authentication failure; |failed|BAD su|^-</match>
    <description>User missed the password to change UID (user id).</description>
-   <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.8,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+   <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.8,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,</group>
   </rule>
 
   <rule id="5302" level="9">
     <if_sid>5301</if_sid>
     <user>^root</user>
     <description>User missed the password to change UID to root.</description>
-    <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.8,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.8,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,</group>
   </rule>
 
   <rule id="5303" level="3">
@@ -427,7 +427,7 @@
     <regex>session opened for user root|^'su root'|</regex>
     <regex>^+ \S+ \S+\proot$|^\S+ to root on|^SU \S+ \S+ + \S+ \S+-root$</regex>
     <description>User successfully changed UID to root.</description>
-    <group>authentication_success,pci_dss_10.2.5,gpg13_7.6,gpg13_7.8,gpg13_7.9,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>authentication_success,pci_dss_10.2.5,gpg13_7.6,gpg13_7.8,gpg13_7.9,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,</group>
   </rule>
 
   <rule id="5304" level="3">
@@ -435,7 +435,7 @@
     <regex>session opened for user|succeeded for|</regex>
     <regex>^+|^\S+ to |^SU \S+ \S+ + </regex>
     <description>User successfully changed UID.</description>
-    <group>authentication_success,pci_dss_10.2.5,gpg13_7.6,gpg13_7.8,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>authentication_success,pci_dss_10.2.5,gpg13_7.6,gpg13_7.8,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,</group>
   </rule>
 
   <rule id="5305" level="4">
@@ -472,25 +472,25 @@
   <rule id="5901" level="8">
     <match>^new group</match>
     <description>New group added to the system</description>
-    <group>pci_dss_10.2.7,pci_dss_10.2.5,pci_dss_8.1.2,gpg13_4.13,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,hipaa_164.312.a.2.I,hipaa_164.312.a.2.II,nist_800_53_AU.3.1,nist_800_53_IA.10,nist_800_53_AC.2,nist_800_53_IA.4,</group>
+    <group>pci_dss_10.2.7,pci_dss_10.2.5,pci_dss_8.1.2,gpg13_4.13,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,hipaa_164.312.a.2.I,hipaa_164.312.a.2.II,nist_800_53_IA.10,nist_800_53_IA.10,nist_800_53_AC.7,nist_800_53_AC.2,nist_800_53_IA.4,</group>
   </rule>
 
   <rule id="5902" level="8">
     <match>^new user|^new account added</match>
     <description>New user added to the system</description>
-    <group>pci_dss_10.2.7,pci_dss_10.2.5,pci_dss_8.1.2,gpg13_4.13,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,hipaa_164.312.a.2.I,hipaa_164.312.a.2.II,nist_800_53_AU.3.1,nist_800_53_IA.10,nist_800_53_AC.2,nist_800_53_IA.4,</group>
+    <group>pci_dss_10.2.7,pci_dss_10.2.5,pci_dss_8.1.2,gpg13_4.13,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,hipaa_164.312.a.2.I,hipaa_164.312.a.2.II,nist_800_53_IA.10,nist_800_53_IA.10,nist_800_53_AC.7,nist_800_53_AC.2,nist_800_53_IA.4,</group>
   </rule>
 
   <rule id="5903" level="3">
     <match>^delete user|^account deleted|^remove group</match>
     <description>Group (or user) deleted from the system</description>
-    <group>pci_dss_10.2.7,pci_dss_10.2.5,pci_dss_8.1.2,gpg13_4.13,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,hipaa_164.312.a.2.I,hipaa_164.312.a.2.II,nist_800_53_AU.3.1,nist_800_53_IA.10,nist_800_53_AC.2,nist_800_53_IA.4,</group>
+    <group>pci_dss_10.2.7,pci_dss_10.2.5,pci_dss_8.1.2,gpg13_4.13,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,hipaa_164.312.a.2.I,hipaa_164.312.a.2.II,nist_800_53_IA.10,nist_800_53_IA.10,nist_800_53_AC.7,nist_800_53_AC.2,nist_800_53_IA.4,</group>
   </rule>
 
   <rule id="5904" level="8">
     <match>^changed user</match>
     <description>Information from the user was changed</description>
-    <group>pci_dss_10.2.7,pci_dss_10.2.5,pci_dss_8.1.2,gpg13_4.13,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,hipaa_164.312.a.2.I,hipaa_164.312.a.2.II,nist_800_53_AU.3.1,nist_800_53_IA.10,nist_800_53_AC.2,nist_800_53_IA.4,</group>
+    <group>pci_dss_10.2.7,pci_dss_10.2.5,pci_dss_8.1.2,gpg13_4.13,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,hipaa_164.312.a.2.I,hipaa_164.312.a.2.II,nist_800_53_IA.10,nist_800_53_IA.10,nist_800_53_AC.7,nist_800_53_AC.2,nist_800_53_IA.4,</group>
   </rule>
 
   <rule id="5905" level="0">
@@ -513,14 +513,14 @@
     <if_sid>5400</if_sid>
     <match>incorrect password attempt</match>
     <description>Failed attempt to run sudo</description>
-    <group>pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.8,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.8,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,</group>
   </rule>
 
   <rule id="5402" level="3">
     <if_sid>5400</if_sid>
     <regex> ; USER=root ; COMMAND=| ; USER=root ; TSID=\S+ ; COMMAND=</regex>
     <description>Successful sudo to ROOT executed</description>
-    <group>pci_dss_10.2.5,pci_dss_10.2.2,gpg13_7.6,gpg13_7.8,gpg13_7.13,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>pci_dss_10.2.5,pci_dss_10.2.2,gpg13_7.6,gpg13_7.8,gpg13_7.13,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,nist_800_53_IA.10,nist_800_53_AC.6,</group>
   </rule>
 
   <rule id="5403" level="4">
@@ -534,21 +534,21 @@
     <if_sid>5401</if_sid>
     <match>3 incorrect password attempts</match>
     <description>Three failed attempts to run sudo</description>
-    <group>pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.8,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.8,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,</group>
   </rule>
 
   <rule id="5405" level="5">
     <if_sid>5400</if_sid>
     <match>user NOT in sudoers</match>
     <description>Unauthorized user attempted to use sudo.</description>
-    <group>pci_dss_10.2.2,pci_dss_10.2.5,gpg13_7.8,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>pci_dss_10.2.2,pci_dss_10.2.5,gpg13_7.8,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.6,nist_800_53_IA.10,nist_800_53_AC.7,</group>
   </rule>
 
   <rule id="5406" level="5">
     <if_sid>5400</if_sid>
     <match>command not allowed</match>
     <description>Sudo: Command not allowed</description>
-    <group>pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.8,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.8,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,</group>
   </rule>
 
 </group> <!-- SYSLOG, SUDO -->
@@ -625,21 +625,21 @@
      <if_sid>2900</if_sid>
      <field name="dpkg_status">^status installed$</field>
      <description>New dpkg (Debian Package) installed.</description>
-     <group>config_changed,pci_dss_10.6.1,pci_dss_10.2.7,gpg13_4.10,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.6,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+     <group>config_changed,pci_dss_10.6.1,pci_dss_10.2.7,gpg13_4.10,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.6,nist_800_53_IA.10,</group>
    </rule>
 
    <rule id="2903" level="7">
      <if_sid>2900</if_sid>
      <field name="dpkg_status">^remove$|^purge$</field>
      <description>Dpkg (Debian Package) removed.</description>
-     <group>config_changed,pci_dss_10.6.1,pci_dss_10.2.7,gpg13_4.10,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.6,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+     <group>config_changed,pci_dss_10.6.1,pci_dss_10.2.7,gpg13_4.10,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.6,nist_800_53_IA.10,</group>
    </rule>
 
    <rule id="2904" level="7">
      <if_sid>2900</if_sid>
      <field name="dpkg_status">^status half-configured$</field>
      <description>Dpkg (Debian Package) half configured.</description>
-     <group>config_changed,pci_dss_10.6.1,pci_dss_10.2.7,gpg13_4.10,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.6,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+     <group>config_changed,pci_dss_10.6.1,pci_dss_10.2.7,gpg13_4.10,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.6,nist_800_53_IA.10,</group>
    </rule>
 </group>
 
@@ -659,21 +659,21 @@
   <rule id="2932" level="7">
     <if_sid>2930,2931</if_sid>
     <match>^Installed</match>
-    <group>config_changed,pci_dss_10.6.1,pci_dss_10.2.7,gpg13_4.10,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.6,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>config_changed,pci_dss_10.6.1,pci_dss_10.2.7,gpg13_4.10,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.6,nist_800_53_IA.10,</group>
     <description>New Yum package installed.</description>
   </rule>
 
   <rule id="2933" level="7">
     <if_sid>2930,2931</if_sid>
     <match>^Updated</match>
-    <group>config_changed,pci_dss_10.6.1,pci_dss_10.2.7,gpg13_4.10,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.6,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>config_changed,pci_dss_10.6.1,pci_dss_10.2.7,gpg13_4.10,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.6,nist_800_53_IA.10,</group>
     <description>Yum package updated.</description>
   </rule>
 
   <rule id="2934" level="7">
     <if_sid>2930,2931</if_sid>
     <match>^Erased</match>
-    <group>config_changed,pci_dss_10.6.1,pci_dss_10.2.7,gpg13_4.10,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.6,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>config_changed,pci_dss_10.6.1,pci_dss_10.2.7,gpg13_4.10,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.6,nist_800_53_IA.10,</group>
     <description>Yum package deleted.</description>
   </rule>
 

--- a/rules/0025-sendmail_rules.xml
+++ b/rules/0025-sendmail_rules.xml
@@ -25,7 +25,7 @@
     <match>reject=451 4.1.8 </match>
     <description>sendmail: Sender domain does not have any valid </description>
     <description>MX record (Requested action aborted).</description>
-    <group>spam,pci_dss_11.4,gdpr_IV_35.7.d,nist_800_53_SC.7,</group>
+    <group>spam,pci_dss_11.4,gdpr_IV_35.7.d,nist_800_53_IA.10,</group>
   </rule>
 
   <rule id="3103" level="6">
@@ -33,7 +33,7 @@
     <match>reject=550 5.0.0 |reject=553 5.3.0</match>
     <description>sendmail: Rejected by access list </description>
     <description>(55x: Requested action not taken).</description>
-    <group>spam,pci_dss_11.4,gdpr_IV_35.7.d,nist_800_53_SC.7,</group>
+    <group>spam,pci_dss_11.4,gdpr_IV_35.7.d,nist_800_53_IA.10,</group>
   </rule>
 
   <rule id="3104" level="6">
@@ -41,7 +41,7 @@
     <match>reject=550 5.7.1 </match>
     <description>sendmail: Attempt to use mail server as relay </description>
     <description>(550: Requested action not taken).</description>
-    <group>spam,pci_dss_11.4,gdpr_IV_35.7.d,nist_800_53_SC.7,</group>
+    <group>spam,pci_dss_11.4,gdpr_IV_35.7.d,nist_800_53_IA.10,</group>
   </rule>
 
   <rule id="3105" level="5">
@@ -49,7 +49,7 @@
     <match>reject=553 5.1.8 </match>
     <description>sendmail: Sender domain is not found </description>
     <description> (553: Requested action not taken).</description>
-    <group>spam,pci_dss_11.4,gdpr_IV_35.7.d,nist_800_53_SC.7,</group>
+    <group>spam,pci_dss_11.4,gdpr_IV_35.7.d,nist_800_53_IA.10,</group>
   </rule>
 
   <rule id="3106" level="5">
@@ -57,7 +57,7 @@
     <match>reject=553 5.5.4 </match>
     <description>sendmail: Sender address does not have domain </description>
     <description>(553: Requested action not taken).</description>
-    <group>spam,pci_dss_11.4,gdpr_IV_35.7.d,nist_800_53_SC.7,</group>
+    <group>spam,pci_dss_11.4,gdpr_IV_35.7.d,nist_800_53_IA.10,</group>
   </rule>
 
   <rule id="3107" level="4">
@@ -69,7 +69,7 @@
     <if_sid>3100</if_sid>
     <match>rejecting commands from</match>
     <description>sendmail: Sendmail rejected due to pre-greeting.</description>
-    <group>spam,pci_dss_11.4,gdpr_IV_35.7.d,nist_800_53_SC.7,</group>
+    <group>spam,pci_dss_11.4,gdpr_IV_35.7.d,nist_800_53_IA.10,</group>
   </rule>
 
   <rule id="3109" level="8">
@@ -84,7 +84,7 @@
     <same_source_ip />
     <description>sendmail: Sender domain has bogus MX record. </description>
     <description>It should not be sending e-mail.</description>
-    <group>multiple_spam,pci_dss_11.4,gdpr_IV_35.7.d,nist_800_53_SC.7,</group>
+    <group>multiple_spam,pci_dss_11.4,gdpr_IV_35.7.d,nist_800_53_IA.10,</group>
   </rule>
 
   <rule id="3152" level="6" frequency="8" timeframe="120">
@@ -92,14 +92,14 @@
     <same_source_ip />
     <description>sendmail: Multiple attempts to send e-mail from a </description>
     <description>previously rejected sender (access).</description>
-    <group>multiple_spam,pci_dss_11.4,gdpr_IV_35.7.d,nist_800_53_SC.7,</group>
+    <group>multiple_spam,pci_dss_11.4,gdpr_IV_35.7.d,nist_800_53_IA.10,</group>
   </rule>
 
   <rule id="3153" level="6" frequency="8" timeframe="120">
     <if_matched_sid>3104</if_matched_sid>
     <same_source_ip />
     <description>sendmail: Multiple relaying attempts of spam.</description>
-    <group>multiple_spam,pci_dss_11.4,gdpr_IV_35.7.d,nist_800_53_SC.7,</group>
+    <group>multiple_spam,pci_dss_11.4,gdpr_IV_35.7.d,nist_800_53_IA.10,</group>
   </rule>
 
   <rule id="3154" level="10" frequency="8" timeframe="120">
@@ -107,7 +107,7 @@
     <same_source_ip />
     <description>sendmail: Multiple attempts to send e-mail </description>
     <description>from invalid/unknown sender domain.</description>
-    <group>multiple_spam,pci_dss_11.4,gdpr_IV_35.7.d,nist_800_53_SC.7,</group>
+    <group>multiple_spam,pci_dss_11.4,gdpr_IV_35.7.d,nist_800_53_IA.10,</group>
   </rule>
 
   <rule id="3155" level="10" frequency="8" timeframe="120">
@@ -115,21 +115,21 @@
     <same_source_ip />
     <description>sendmail: Multiple attempts to send e-mail from </description>
     <description>invalid/unknown sender.</description>
-    <group>multiple_spam,pci_dss_11.4,gdpr_IV_35.7.d,nist_800_53_SC.7,</group>
+    <group>multiple_spam,pci_dss_11.4,gdpr_IV_35.7.d,nist_800_53_IA.10,</group>
   </rule>
 
   <rule id="3156" level="10" frequency="12" timeframe="120">
     <if_matched_sid>3107</if_matched_sid>
     <same_source_ip />
     <description>sendmail: Multiple rejected e-mails from same source ip.</description>
-    <group>multiple_spam,pci_dss_11.4,gdpr_IV_35.7.d,nist_800_53_SC.7,</group>
+    <group>multiple_spam,pci_dss_11.4,gdpr_IV_35.7.d,nist_800_53_IA.10,</group>
   </rule>
 
   <rule id="3158" level="10" frequency="8" timeframe="120">
     <if_matched_sid>3108</if_matched_sid>
     <same_source_ip />
     <description>sendmail: Multiple pre-greetings rejects.</description>
-    <group>multiple_spam,pci_dss_11.4,gdpr_IV_35.7.d,nist_800_53_SC.7,</group>
+    <group>multiple_spam,pci_dss_11.4,gdpr_IV_35.7.d,nist_800_53_IA.10,</group>
   </rule>
 
 
@@ -145,7 +145,7 @@
      <match>^sender check failed|^sender check tempfailed</match>
      <description>sendmail: SMF-SAV sendmail milter unable to verify </description>
      <description>address (REJECTED).</description>
-     <group>smf-sav,spam,pci_dss_11.4,gdpr_IV_35.7.d,nist_800_53_SC.7,</group>
+     <group>smf-sav,spam,pci_dss_11.4,gdpr_IV_35.7.d,nist_800_53_IA.10,</group>
    </rule>
 
 </group>

--- a/rules/0030-postfix_rules.xml
+++ b/rules/0030-postfix_rules.xml
@@ -21,7 +21,7 @@
     <id>^554$</id>
     <description>Postfix: Attempt to use mail server as relay </description>
     <description>(client host rejected).</description>
-    <group>spam,pci_dss_10.6.1,pci_dss_11.4,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.6,nist_800_53_SC.7,</group>
+    <group>spam,pci_dss_10.6.1,pci_dss_11.4,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.6,nist_800_53_IA.10,</group>
   </rule>
 
   <rule id="3302" level="6">
@@ -29,7 +29,7 @@
     <id>^550$</id>
     <description>Postfix: Rejected by access list </description>
     <description>(Requested action not taken).</description>
-    <group>spam,pci_dss_10.6.1,pci_dss_11.4,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.6,nist_800_53_SC.7,</group>
+    <group>spam,pci_dss_10.6.1,pci_dss_11.4,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.6,nist_800_53_IA.10,</group>
   </rule>
 
   <rule id="3303" level="5">
@@ -37,7 +37,7 @@
     <id>^450$</id>
     <description>Postfix: Sender domain is not found </description>
     <description>(450: Requested mail action not taken).</description>
-    <group>spam,pci_dss_10.6.1,pci_dss_11.4,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.6,nist_800_53_SC.7,</group>
+    <group>spam,pci_dss_10.6.1,pci_dss_11.4,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.6,nist_800_53_IA.10,</group>
   </rule>
 
   <rule id="3304" level="5">
@@ -45,7 +45,7 @@
     <id>^503$</id>
     <description>Postfix: Improper use of SMTP command pipelining </description>
     <description>(503: Bad sequence of commands).</description>
-    <group>spam,pci_dss_10.6.1,pci_dss_11.4,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.6,nist_800_53_SC.7,</group>
+    <group>spam,pci_dss_10.6.1,pci_dss_11.4,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.6,nist_800_53_IA.10,</group>
   </rule>
 
   <rule id="3305" level="5">
@@ -53,14 +53,14 @@
     <id>^504$</id>
     <description>Postfix: Recipient address must contain FQDN </description>
     <description>(504: Command parameter not implemented).</description>
-    <group>spam,pci_dss_10.6.1,pci_dss_11.4,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.6,nist_800_53_SC.7,</group>
+    <group>spam,pci_dss_10.6.1,pci_dss_11.4,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.6,nist_800_53_IA.10,</group>
   </rule>
 
   <rule id="3306" level="6">
     <if_sid>3301, 3302</if_sid>
     <match> blocked using </match>
     <description>Postfix: IP Address black-listed by anti-spam (blocked).</description>
-    <group>spam,pci_dss_10.6.1,pci_dss_11.4,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.6,nist_800_53_SC.7,</group>
+    <group>spam,pci_dss_10.6.1,pci_dss_11.4,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.6,nist_800_53_IA.10,</group>
   </rule>
 
   <rule id="3320" level="0">
@@ -80,7 +80,7 @@
     <if_sid>3320</if_sid>
     <match> authentication failed</match>
     <description>Postfix SASL authentication failure.</description>
-    <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,</group>
   </rule>
 
   <rule id="3331" level="10" ignore="120">
@@ -101,7 +101,7 @@
     <if_sid>3320</if_sid>
     <match>^too many </match>
     <description>Postfix: too many errors after RCPT from unkown</description>
-    <group>spam,pci_dss_10.6.1,pci_dss_11.4,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.6,nist_800_53_SC.7,</group>
+    <group>spam,pci_dss_10.6.1,pci_dss_11.4,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.6,nist_800_53_IA.10,</group>
   </rule>
 
   <rule id="3333" level="7">
@@ -115,7 +115,7 @@
     <if_matched_sid>3301</if_matched_sid>
     <same_source_ip />
     <description>Postfix: Multiple relaying attempts of spam.</description>
-    <group>multiple_spam,pci_dss_10.6.1,pci_dss_11.4,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.6,nist_800_53_SC.7,</group>
+    <group>multiple_spam,pci_dss_10.6.1,pci_dss_11.4,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.6,nist_800_53_IA.10,</group>
   </rule>
 
   <rule id="3352" level="6" frequency="$POSTFIX_FREQ" timeframe="120">
@@ -123,7 +123,7 @@
     <same_source_ip />
     <description>Postfix: Multiple attempts to send e-mail from a </description>
     <description>rejected sender IP (access).</description>
-    <group>multiple_spam,pci_dss_10.6.1,pci_dss_11.4,hipaa_164.312.b,nist_800_53_AU.6,nist_800_53_SC.7,</group>
+    <group>multiple_spam,pci_dss_10.6.1,pci_dss_11.4,hipaa_164.312.b,nist_800_53_AU.6,nist_800_53_IA.10,</group>
   </rule>
 
   <rule id="3353" level="10" frequency="$POSTFIX_FREQ" timeframe="120">
@@ -131,7 +131,7 @@
     <same_source_ip />
     <description>Postfix: Multiple attempts to send e-mail from </description>
     <description>invalid/unknown sender domain.</description>
-    <group>multiple_spam,pci_dss_10.6.1,pci_dss_11.4,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.6,nist_800_53_SC.7,</group>
+    <group>multiple_spam,pci_dss_10.6.1,pci_dss_11.4,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.6,nist_800_53_IA.10,</group>
   </rule>
 
   <rule id="3354" level="12" frequency="$POSTFIX_FREQ" timeframe="120">
@@ -139,7 +139,7 @@
     <same_source_ip />
     <description>Postfix: Multiple misuse of SMTP service </description>
     <description>(bad sequence of commands).</description>
-    <group>multiple_spam,pci_dss_10.6.1,pci_dss_11.4,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.6,nist_800_53_SC.7,</group>
+    <group>multiple_spam,pci_dss_10.6.1,pci_dss_11.4,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.6,nist_800_53_IA.10,</group>
   </rule>
 
   <rule id="3355" level="10" frequency="$POSTFIX_FREQ" timeframe="120">
@@ -147,7 +147,7 @@
     <same_source_ip />
     <description>Postfix: Multiple attempts to send e-mail to </description>
     <description>invalid recipient or from unknown sender domain.</description>
-    <group>multiple_spam,pci_dss_10.6.1,pci_dss_11.4,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.6,nist_800_53_SC.7,</group>
+    <group>multiple_spam,pci_dss_10.6.1,pci_dss_11.4,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.6,nist_800_53_IA.10,</group>
   </rule>
 
   <rule id="3356" level="10" frequency="$POSTFIX_FREQ" timeframe="120" ignore="30">
@@ -155,14 +155,14 @@
     <same_source_ip />
     <description>Postfix: Multiple attempts to send e-mail from </description>
     <description>black-listed IP address (blocked).</description>
-    <group>multiple_spam,pci_dss_10.6.1,pci_dss_11.4,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.6,nist_800_53_SC.7,</group>
+    <group>multiple_spam,pci_dss_10.6.1,pci_dss_11.4,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.6,nist_800_53_IA.10,</group>
   </rule>
 
   <rule id="3357" level="10" frequency="8" timeframe="120" ignore="60">
     <if_matched_sid>3332</if_matched_sid>
     <same_source_ip />
     <description>Postfix: Multiple SASL authentication failures.</description>
-    <group>authentication_failures,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,nist_800_53_SC.7,</group>
+    <group>authentication_failures,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,nist_800_53_IA.10,</group>
   </rule>
 
   <rule id="3390" level="0">
@@ -179,21 +179,21 @@
     <if_sid>3395</if_sid>
     <match>verification</match>
     <description>Postfix: hostname verification failed</description>
-    <group>spam,pci_dss_10.6.1,pci_dss_11.4,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.6,nist_800_53_SC.7,</group>
+    <group>spam,pci_dss_10.6.1,pci_dss_11.4,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.6,nist_800_53_IA.10,</group>
   </rule>
 
   <rule id="3397" level="6">
     <if_sid>3395</if_sid>
     <match>RBL</match>
     <description>Postfix: RBL lookup error: Host or domain name not found</description>
-    <group>spam,pci_dss_10.6.1,pci_dss_11.4,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.6,nist_800_53_SC.7,</group>
+    <group>spam,pci_dss_10.6.1,pci_dss_11.4,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.6,nist_800_53_IA.10,</group>
   </rule>
 
   <rule id="3398" level="6">
     <if_sid>3395</if_sid>
     <match>MAIL|does not resolve to address</match>
     <description>Postfix: Illegal address from unknown sender</description>
-    <group>spam,pci_dss_10.6.1,pci_dss_11.4,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.6,nist_800_53_SC.7,</group>
+    <group>spam,pci_dss_10.6.1,pci_dss_11.4,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.6,nist_800_53_IA.10,</group>
   </rule>
 
   <!--

--- a/rules/0030-postfix_rules.xml
+++ b/rules/0030-postfix_rules.xml
@@ -162,7 +162,7 @@
     <if_matched_sid>3332</if_matched_sid>
     <same_source_ip />
     <description>Postfix: Multiple SASL authentication failures.</description>
-    <group>authentication_failures,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,nist_800_53_IA.10,</group>
+    <group>authentication_failures,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,</group>
   </rule>
 
   <rule id="3390" level="0">

--- a/rules/0040-imapd_rules.xml
+++ b/rules/0040-imapd_rules.xml
@@ -19,28 +19,28 @@
     <if_sid>3600</if_sid>
     <match>Login failed user=|AUTHENTICATE LOGIN failure</match>
     <description>Imapd user login failed.</description>
-    <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,</group>
   </rule>
 
   <rule id="3602" level="3">
     <if_sid>3600</if_sid>
     <match>Authenticated user=</match>
     <description>Imapd user login.</description>
-    <group>authentication_success,pci_dss_10.2.5,gpg13_7.1,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>authentication_success,pci_dss_10.2.5,gpg13_7.1,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,</group>
   </rule>
 
   <rule id="3603" level="0">
     <if_sid>3600</if_sid>
     <match>Logout user=</match>
     <description>Imapd user logout.</description>
-    <group>pci_dss_10.2.5,gpg13_7.1,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>pci_dss_10.2.5,gpg13_7.1,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,</group>
   </rule>
 
   <rule id="3651" level="10" frequency="$IMAPD_FREQ" timeframe="120">
     <if_matched_sid>3601</if_matched_sid>
     <same_source_ip />
     <description>Imapd Multiple failed logins from same source ip.</description>
-    <group>authentication_failures,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,nist_800_53_SC.7,</group>
+    <group>authentication_failures,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,nist_800_53_IA.10,</group>
   </rule>
 
 </group>

--- a/rules/0040-imapd_rules.xml
+++ b/rules/0040-imapd_rules.xml
@@ -40,7 +40,7 @@
     <if_matched_sid>3601</if_matched_sid>
     <same_source_ip />
     <description>Imapd Multiple failed logins from same source ip.</description>
-    <group>authentication_failures,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,nist_800_53_IA.10,</group>
+    <group>authentication_failures,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,</group>
   </rule>
 
 </group>

--- a/rules/0055-courier_rules.xml
+++ b/rules/0055-courier_rules.xml
@@ -24,7 +24,7 @@
     <if_sid>3900</if_sid>
     <match>^LOGIN FAILED,| FAILED:</match>
     <description>Courier (imap/pop3) authentication failed.</description>
-    <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,</group>
   </rule>
 
   <rule id="3903" level="0">
@@ -38,13 +38,13 @@
     <if_sid>3900</if_sid>
     <match>^LOGIN,</match>
     <description>Courier (imap/pop3) authentication success.</description>
-    <group>authentication_success,pci_dss_10.2.5,gpg13_7.1,gpg13_7.2,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>authentication_success,pci_dss_10.2.5,gpg13_7.1,gpg13_7.2,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,</group>
   </rule>
 
   <rule id="3910" level="10" frequency="12" timeframe="30">
     <if_matched_sid>3902</if_matched_sid>
     <description>Courier brute force (multiple failed logins).</description>
-    <group>authentication_failures,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,nist_800_53_SC.7,</group>
+    <group>authentication_failures,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,nist_800_53_IA.10,</group>
     <same_source_ip />
   </rule>
 
@@ -52,6 +52,6 @@
     <if_matched_sid>3901</if_matched_sid>
     <same_source_ip />
     <description>Courier: Multiple connection attempts from same source.</description>
-    <group>recon,pci_dss_10.6.1,pci_dss_11.4,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.6,nist_800_53_SC.7,</group>
+    <group>recon,pci_dss_10.6.1,pci_dss_11.4,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.6,nist_800_53_IA.10,</group>
   </rule>
 </group>

--- a/rules/0055-courier_rules.xml
+++ b/rules/0055-courier_rules.xml
@@ -44,7 +44,7 @@
   <rule id="3910" level="10" frequency="12" timeframe="30">
     <if_matched_sid>3902</if_matched_sid>
     <description>Courier brute force (multiple failed logins).</description>
-    <group>authentication_failures,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,nist_800_53_IA.10,</group>
+    <group>authentication_failures,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,</group>
     <same_source_ip />
   </rule>
 

--- a/rules/0065-pix_rules.xml
+++ b/rules/0065-pix_rules.xml
@@ -89,7 +89,7 @@
     <if_sid>4313</if_sid>
     <id>^4-401004</id>
     <description>PIX: Attempt to connect from a blocked (shunned) IP.</description>
-    <group>access_denied,pci_dss_10.2.4,pci_dss_11.4,gpg13_4.12,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,nist_800_53_IA.10,</group>
+    <group>access_denied,pci_dss_10.2.4,pci_dss_11.4,gpg13_4.12,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,</group>
   </rule>
 
   <rule id="4327" level="8">
@@ -226,7 +226,7 @@
   <rule id="4386" level="10" frequency="10" timeframe="240">
     <if_matched_sid>4334</if_matched_sid>
     <description>PIX: Multiple AAA (VPN) authentication failures.</description>
-    <group>authentication_failures,pci_dss_11.4,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_IA.10,nist_800_53_AC.7,</group>
+    <group>authentication_failures,pci_dss_11.4,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,</group>
     <same_source_ip />
   </rule>
 </group>

--- a/rules/0065-pix_rules.xml
+++ b/rules/0065-pix_rules.xml
@@ -53,21 +53,21 @@
     <if_sid>4314</if_sid>
     <id>^6-605004</id>
     <description>PIX: Failed login attempt.</description>
-    <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.8,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.8,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,</group>
   </rule>
 
   <rule id="4322" level="3">
     <if_sid>4314</if_sid>
     <id>^5-502103</id>
     <description>PIX: Privilege changed.</description>
-    <group>pci_dss_10.2.7,pci_dss_10.6.1,gpg13_7.9,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,nist_800_53_AU.6,</group>
+    <group>pci_dss_10.2.7,pci_dss_10.6.1,gpg13_7.9,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AU.6,</group>
   </rule>
 
   <rule id="4323" level="3">
     <if_sid>4314</if_sid>
     <id>^6-605005</id>
     <description>PIX: Successful login.</description>
-    <group>authentication_success,pci_dss_10.2.5,gpg13_7.8,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>authentication_success,pci_dss_10.2.5,gpg13_7.8,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,</group>
   </rule>
 
   <rule id="4324" level="9">
@@ -75,7 +75,7 @@
     <id>^6-308001</id>
     <description>PIX: Password mismatch while running 'enable' </description>
     <description>on the PIX.</description>
-    <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.8,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.8,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,</group>
   </rule>
 
   <rule id="4325" level="8">
@@ -89,7 +89,7 @@
     <if_sid>4313</if_sid>
     <id>^4-401004</id>
     <description>PIX: Attempt to connect from a blocked (shunned) IP.</description>
-    <group>access_denied,pci_dss_10.2.4,pci_dss_11.4,gpg13_4.12,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,nist_800_53_SC.7,</group>
+    <group>access_denied,pci_dss_10.2.4,pci_dss_11.4,gpg13_4.12,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,nist_800_53_IA.10,</group>
   </rule>
 
   <rule id="4327" level="8">
@@ -126,28 +126,28 @@
   <rule id="4333" level="8">
     <if_sid>4330, 4331, 4332</if_sid>
     <description>PIX: Attack in progress detected</description>
-    <group>ids,pci_dss_11.4,gpg13_4.12,gdpr_IV_35.7.d,nist_800_53_SC.7,</group>
+    <group>ids,pci_dss_11.4,gpg13_4.12,gdpr_IV_35.7.d,nist_800_53_IA.10,</group>
   </rule>
 
   <rule id="4334" level="5">
     <if_sid>4314</if_sid>
     <id>^6-113005</id>
     <description>PIX: AAA (VPN) authentication failed.</description>
-    <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,</group>
   </rule>
 
   <rule id="4335" level="3">
     <if_sid>4314</if_sid>
     <id>^6-113004</id>
     <description>PIX: AAA (VPN) authentication successful.</description>
-    <group>authentication_success,pci_dss_10.2.5,gpg13_7.1,gpg13_7.2,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>authentication_success,pci_dss_10.2.5,gpg13_7.1,gpg13_7.2,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,</group>
   </rule>
 
   <rule id="4336" level="8">
     <if_sid>4314</if_sid>
     <id>^6-113006</id>
     <description>PIX: AAA (VPN) user locked out.</description>
-    <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,gpg13_7.5,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,gpg13_7.5,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,</group>
   </rule>
 
   <rule id="4337" level="8">
@@ -169,14 +169,14 @@
     <if_sid>4314</if_sid>
     <id>^5-111003</id>
     <description>PIX: Firewall configuration deleted.</description>
-    <group>config_changed,pci_dss_1.1.1,pci_dss_10.4,gpg13_4.13,gdpr_IV_35.7.d,hipaa_164.312.a.1,hipaa_164.312.b,nist_800_53_CM.3,nist_800_53_AU.8,</group>
+    <group>config_changed,pci_dss_1.1.1,pci_dss_10.4,gpg13_4.13,gdpr_IV_35.7.d,hipaa_164.312.a.1,hipaa_164.312.b,nist_800_53_CM.3,nist_800_53_CM.5,nist_800_53_AU.8,</group>
   </rule>
 
   <rule id="4340" level="8">
     <if_sid>4314</if_sid>
     <id>^5-111005|^5-111004|^5-111002|^5-111007</id>
     <description>PIX: Firewall configuration changed.</description>
-    <group>config_changed,pci_dss_1.1.1,pci_dss_10.4,gpg13_4.13,gdpr_IV_35.7.d,hipaa_164.312.a.1,hipaa_164.312.b,nist_800_53_CM.3,nist_800_53_AU.8,</group>
+    <group>config_changed,pci_dss_1.1.1,pci_dss_10.4,gpg13_4.13,gdpr_IV_35.7.d,hipaa_164.312.a.1,hipaa_164.312.b,nist_800_53_CM.3,nist_800_53_CM.5,nist_800_53_AU.8,</group>
   </rule>
 
   <rule id="4341" level="3">
@@ -189,25 +189,25 @@
     <if_sid>4314</if_sid>
     <id>^5-502101|^5-502102</id>
     <description>PIX: User created or modified on the Firewall.</description>
-    <group>adduser,account_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_4.13,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.a.2.I,hipaa_164.312.a.2.II,hipaa_164.312.b,nist_800_53_AC.2,nist_800_53_IA.4,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>adduser,account_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_4.13,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.a.2.I,hipaa_164.312.a.2.II,hipaa_164.312.b,nist_800_53_AC.2,nist_800_53_IA.4,nist_800_53_IA.10,nist_800_53_AC.7,</group>
   </rule>
 
   <rule id="4380" level="10" frequency="8" timeframe="360">
     <if_matched_sid>4310</if_matched_sid>
     <description>Multiple PIX alert messages.</description>
-    <group>pci_dss_10.6.1,pci_dss_11.4,gpg13_4.12,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.6,nist_800_53_SC.7,</group>
+    <group>pci_dss_10.6.1,pci_dss_11.4,gpg13_4.12,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.6,nist_800_53_IA.10,</group>
   </rule>
 
   <rule id="4381" level="10" frequency="8" timeframe="360">
     <if_matched_sid>4311</if_matched_sid>
     <description>PIX: Multiple critical messages.</description>
-    <group>pci_dss_10.6.1,pci_dss_11.4,gpg13_4.1,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.6,nist_800_53_SC.7,</group>
+    <group>pci_dss_10.6.1,pci_dss_11.4,gpg13_4.1,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.6,nist_800_53_IA.10,</group>
   </rule>
 
   <rule id="4382" level="10" frequency="10" timeframe="120">
     <if_matched_sid>4312</if_matched_sid>
     <description>PIX: Multiple error messages.</description>
-    <group>system_error,pci_dss_10.6.1,pci_dss_11.4,gpg13_4.3,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.6,nist_800_53_SC.7,</group>
+    <group>system_error,pci_dss_10.6.1,pci_dss_11.4,gpg13_4.3,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.6,nist_800_53_IA.10,</group>
   </rule>
 
   <rule id="4383" level="10" frequency="10" timeframe="120">
@@ -220,13 +220,13 @@
     <if_matched_sid>4333</if_matched_sid>
     <same_source_ip />
     <description>PIX: Multiple attack in progress messages.</description>
-    <group>pci_dss_10.6.1,pci_dss_11.4,gpg13_4.12,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.6,nist_800_53_SC.7,</group>
+    <group>pci_dss_10.6.1,pci_dss_11.4,gpg13_4.12,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.6,nist_800_53_IA.10,</group>
   </rule>
 
   <rule id="4386" level="10" frequency="10" timeframe="240">
     <if_matched_sid>4334</if_matched_sid>
     <description>PIX: Multiple AAA (VPN) authentication failures.</description>
-    <group>authentication_failures,pci_dss_11.4,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_SC.7,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>authentication_failures,pci_dss_11.4,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_IA.10,nist_800_53_AC.7,</group>
     <same_source_ip />
   </rule>
 </group>

--- a/rules/0070-netscreenfw_rules.xml
+++ b/rules/0070-netscreenfw_rules.xml
@@ -56,28 +56,28 @@
     <if_sid>4501</if_sid>
     <id>^00002</id>
     <description>Netscreen firewall: Successfull admin login</description>
-    <group>authentication_success,pci_dss_10.2.5,pci_dss_10.2.2,gpg13_7.8,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>authentication_success,pci_dss_10.2.5,pci_dss_10.2.2,gpg13_7.8,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,nist_800_53_IA.10,nist_800_53_AC.6,</group>
   </rule>
 
   <rule id="4507" level="8">
     <if_sid>4502</if_sid>
     <id>^00515</id>
     <description>Netscreen firewall: Successfull admin login</description>
-    <group>authentication_success,pci_dss_10.2.5,pci_dss_10.2.2,gpg13_7.8,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>authentication_success,pci_dss_10.2.5,pci_dss_10.2.2,gpg13_7.8,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,nist_800_53_IA.10,nist_800_53_AC.6,</group>
   </rule>
 
   <rule id="4508" level="8">
     <if_sid>4501</if_sid>
     <id>^00018</id>
     <description>Netscreen firewall: policy changed.</description>
-    <group>config_changed,pci_dss_1.1.1,gpg13_4.12,gdpr_IV_35.7.d,hipaa_164.312.a.1,nist_800_53_CM.3,</group>
+    <group>config_changed,pci_dss_1.1.1,gpg13_4.12,gdpr_IV_35.7.d,hipaa_164.312.a.1,nist_800_53_CM.3,nist_800_53_CM.5,</group>
   </rule>
 
   <rule id="4509" level="8">
     <if_sid>4504</if_sid>
     <id>^00767</id>
     <description>Netscreen firewall: configuration changed.</description>
-    <group>config_changed,pci_dss_1.1.1,gpg13_4.12,gdpr_IV_35.7.d,hipaa_164.312.a.1,nist_800_53_CM.3,</group>
+    <group>config_changed,pci_dss_1.1.1,gpg13_4.12,gdpr_IV_35.7.d,hipaa_164.312.a.1,nist_800_53_CM.3,nist_800_53_CM.5,</group>
   </rule>
 
   <rule id="4550" level="10" frequency="6" timeframe="180" ignore="60">
@@ -85,7 +85,7 @@
     <same_source_ip />
     <description>Netscreen firewall: Multiple critical messages from </description>
     <description>same source IP.</description>
-    <group>pci_dss_1.4,pci_dss_10.6.1,pci_dss_11.4,gpg13_4.1,gdpr_IV_35.7.d,hipaa_164.312.a.1,hipaa_164.312.b,nist_800_53_SC.7,nist_800_53_AU.6,</group>
+    <group>pci_dss_1.4,pci_dss_10.6.1,pci_dss_11.4,gpg13_4.1,gdpr_IV_35.7.d,hipaa_164.312.a.1,hipaa_164.312.b,nist_800_53_SC.7,nist_800_53_AU.6,nist_800_53_IA.10,</group>
   </rule>
 
   <rule id="4551" level="10" frequency="8" timeframe="180" ignore="60">
@@ -98,7 +98,7 @@
     <same_source_ip />
     <description>Netscreen firewall: Multiple alert messages from </description>
     <description>same source IP.</description>
-    <group>pci_dss_1.4,pci_dss_10.6.1,pci_dss_11.4,gpg13_4.12,gdpr_IV_35.7.d,hipaa_164.312.a.1,hipaa_164.312.b,nist_800_53_SC.7,nist_800_53_AU.6,</group>
+    <group>pci_dss_1.4,pci_dss_10.6.1,pci_dss_11.4,gpg13_4.12,gdpr_IV_35.7.d,hipaa_164.312.a.1,hipaa_164.312.b,nist_800_53_SC.7,nist_800_53_AU.6,nist_800_53_IA.10,</group>
   </rule>
 
   <rule id="4553" level="10" frequency="10" timeframe="100" ignore="60">

--- a/rules/0070-netscreenfw_rules.xml
+++ b/rules/0070-netscreenfw_rules.xml
@@ -56,14 +56,14 @@
     <if_sid>4501</if_sid>
     <id>^00002</id>
     <description>Netscreen firewall: Successfull admin login</description>
-    <group>authentication_success,pci_dss_10.2.5,pci_dss_10.2.2,gpg13_7.8,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,nist_800_53_IA.10,nist_800_53_AC.6,</group>
+    <group>authentication_success,pci_dss_10.2.5,pci_dss_10.2.2,gpg13_7.8,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,nist_800_53_AC.6,</group>
   </rule>
 
   <rule id="4507" level="8">
     <if_sid>4502</if_sid>
     <id>^00515</id>
     <description>Netscreen firewall: Successfull admin login</description>
-    <group>authentication_success,pci_dss_10.2.5,pci_dss_10.2.2,gpg13_7.8,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,nist_800_53_IA.10,nist_800_53_AC.6,</group>
+    <group>authentication_success,pci_dss_10.2.5,pci_dss_10.2.2,gpg13_7.8,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,nist_800_53_AC.6,</group>
   </rule>
 
   <rule id="4508" level="8">

--- a/rules/0075-cisco-ios_rules.xml
+++ b/rules/0075-cisco-ios_rules.xml
@@ -70,21 +70,21 @@
     <if_sid>4715</if_sid>
     <id>^%SYS-5-CONFIG</id>
     <description>Cisco IOS router configuration changed.</description>
-    <group>config_changed,pci_dss_10.2.7,gpg13_3.7,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>config_changed,pci_dss_10.2.7,gpg13_3.7,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_IA.10,</group>
   </rule>
 
   <rule id="4722" level="3">
     <if_sid>4715</if_sid>
     <id>^%SEC_LOGIN-5-LOGIN_SUCCESS</id>
     <description>Cisco IOS: Successful login to the router.</description>
-    <group>authentication_success,pci_dss_10.2.5,gpg13_3.6,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>authentication_success,pci_dss_10.2.5,gpg13_3.6,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,</group>
   </rule>
 
   <rule id="4724" level="9">
     <if_sid>4714</if_sid>
     <id>^%SEC_LOGIN-4-LOGIN_FAILED</id>
     <description>Cisco IOS: Failed login to the router.</description>
-    <group>authentication_failed,pci_dss_10.2.5,pci_dss_10.2.4,gpg13_3.6,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>authentication_failed,pci_dss_10.2.5,pci_dss_10.2.4,gpg13_3.6,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,</group>
   </rule>
 
 </group>

--- a/rules/0080-sonicwall_rules.xml
+++ b/rules/0080-sonicwall_rules.xml
@@ -62,14 +62,14 @@
     <if_sid>4806</if_sid>
     <id>^236$</id>
     <description>SonicWall: Firewall administrator login.</description>
-    <group>authentication_success,pci_dss_10.2.5,gpg13_3.6,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>authentication_success,pci_dss_10.2.5,gpg13_3.6,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,</group>
   </rule>
 
   <rule id="4811" level="9">
     <if_sid>4801</if_sid>
     <id>^30$|^32$</id>
     <description>SonicWall: Firewall authentication failure.</description>
-    <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_3.6,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_3.6,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,</group>
   </rule>
 
   <rule id="4850" level="10" frequency="8" timeframe="120" ignore="60">

--- a/rules/0085-pam_rules.xml
+++ b/rules/0085-pam_rules.xml
@@ -17,28 +17,28 @@
     <if_sid>5500</if_sid>
     <match>session opened for user </match>
     <description>PAM: Login session opened.</description>
-    <group>authentication_success,pci_dss_10.2.5,gpg13_7.8,gpg13_7.9,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>authentication_success,pci_dss_10.2.5,gpg13_7.8,gpg13_7.9,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,</group>
   </rule>
 
   <rule id="5502" level="3">
     <if_sid>5500</if_sid>
     <match>session closed for user </match>
     <description>PAM: Login session closed.</description>
-    <group>pci_dss_10.2.5,gpg13_7.8,gpg13_7.9,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>pci_dss_10.2.5,gpg13_7.8,gpg13_7.9,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,</group>
   </rule>
 
   <rule id="5503" level="5">
     <if_sid>5500</if_sid>
     <match>authentication failure; logname=</match>
     <description>PAM: User login failed.</description>
-    <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.8,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.8,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,</group>
   </rule>
 
   <rule id="5504" level="5">
     <if_sid>5500</if_sid>
     <match>check pass; user unknown</match>
     <description>PAM: Attempt to login with an invalid user.</description>
-    <group>invalid_login,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.8,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>invalid_login,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.8,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,</group>
   </rule>
 
   <!-- Ignoring Annoying Ubuntu/debian cron login events. -->
@@ -66,7 +66,7 @@
     <if_matched_sid>5503</if_matched_sid>
     <same_source_ip />
     <description>PAM: Multiple failed logins in a small period of time.</description>
-    <group>authentication_failures,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gpg13_7.8,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,nist_800_53_SC.7,</group>
+    <group>authentication_failures,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gpg13_7.8,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,nist_800_53_IA.10,</group>
   </rule>
 
   <rule id="5552" level="0">
@@ -92,7 +92,7 @@
   <rule id="5555" level="3">
     <match>: password changed for</match>
     <description>PAM: User changed password.</description>
-    <group>pci_dss_8.1.2,pci_dss_10.2.5,gpg13_4.13,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.a.2.I,hipaa_164.312.a.2.II,hipaa_164.312.b,nist_800_53_AC.2,nist_800_53_IA.4,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>pci_dss_8.1.2,pci_dss_10.2.5,gpg13_4.13,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.a.2.I,hipaa_164.312.a.2.II,hipaa_164.312.b,nist_800_53_AC.2,nist_800_53_IA.4,nist_800_53_IA.10,nist_800_53_AC.7,</group>
   </rule>
 
   <rule id="5556" level="0">
@@ -104,7 +104,7 @@
     <if_sid>5556</if_sid>
     <match>password check failed </match>
     <description>unix_chkpwd: Password check failed.</description>
-    <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_4.3,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_4.3,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,</group>
   </rule>
 
 </group>

--- a/rules/0085-pam_rules.xml
+++ b/rules/0085-pam_rules.xml
@@ -66,7 +66,7 @@
     <if_matched_sid>5503</if_matched_sid>
     <same_source_ip />
     <description>PAM: Multiple failed logins in a small period of time.</description>
-    <group>authentication_failures,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gpg13_7.8,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,nist_800_53_IA.10,</group>
+    <group>authentication_failures,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gpg13_7.8,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,</group>
   </rule>
 
   <rule id="5552" level="0">

--- a/rules/0095-sshd_rules.xml
+++ b/rules/0095-sshd_rules.xml
@@ -18,7 +18,7 @@
     <match>Bad protocol version identification</match>
     <description>sshd: Possible attack on the ssh server </description>
     <description>(or version gathering).</description>
-    <group>pci_dss_11.4,gpg13_4.12,gdpr_IV_35.7.d,nist_800_53_SC.7,</group>
+    <group>pci_dss_11.4,gpg13_4.12,gdpr_IV_35.7.d,nist_800_53_IA.10,</group>
   </rule>
 
   <rule id="5702" level="5">
@@ -26,7 +26,7 @@
     <match>^reverse mapping</match>
     <regex>failed - POSSIBLE BREAK</regex>
     <description>sshd: Reverse lookup error (bad ISP or attack).</description>
-    <group>pci_dss_11.4,gpg13_4.12,gdpr_IV_35.7.d,nist_800_53_SC.7,</group>
+    <group>pci_dss_11.4,gpg13_4.12,gdpr_IV_35.7.d,nist_800_53_IA.10,</group>
   </rule>
 
   <rule id="5703" level="10" frequency="6" timeframe="360">
@@ -34,7 +34,7 @@
     <same_source_ip />
     <description>sshd: Possible breakin attempt </description>
     <description>(high number of reverse lookup errors).</description>
-    <group>pci_dss_11.4,gpg13_4.12,gdpr_IV_35.7.d,nist_800_53_SC.7,</group>
+    <group>pci_dss_11.4,gpg13_4.12,gdpr_IV_35.7.d,nist_800_53_IA.10,</group>
   </rule>
 
   <rule id="5704" level="4">
@@ -47,21 +47,21 @@
     <if_matched_sid>5704</if_matched_sid>
     <description>sshd: Possible scan or breakin attempt </description>
     <description>(high number of login timeouts).</description>
-    <group>pci_dss_11.4,gpg13_4.12,gdpr_IV_35.7.d,nist_800_53_SC.7,</group>
+    <group>pci_dss_11.4,gpg13_4.12,gdpr_IV_35.7.d,nist_800_53_IA.10,</group>
   </rule>
 
   <rule id="5706" level="6">
     <if_sid>5700</if_sid>
     <match>Did not receive identification string from</match>
     <description>sshd: insecure connection attempt (scan).</description>
-    <group>recon,pci_dss_11.4,gpg13_4.12,gdpr_IV_35.7.d,nist_800_53_SC.7,</group>
+    <group>recon,pci_dss_11.4,gpg13_4.12,gdpr_IV_35.7.d,nist_800_53_IA.10,</group>
   </rule>
 
   <rule id="5707" level="14">
     <if_sid>5700</if_sid>
     <match>fatal: buffer_get_string: bad string</match>
     <description>sshd: OpenSSH challenge-response exploit.</description>
-    <group>exploit_attempt,pci_dss_11.4,pci_dss_6.2,gpg13_4.12,gdpr_IV_35.7.d,nist_800_53_SC.7,nist_800_53_MA.2,</group>
+    <group>exploit_attempt,pci_dss_11.4,pci_dss_6.2,gpg13_4.12,gdpr_IV_35.7.d,nist_800_53_IA.10,nist_800_53_SI.2,</group>
   </rule>
 
   <rule id="5709" level="0">
@@ -76,7 +76,7 @@
     <if_sid>5700</if_sid>
     <match>illegal user|invalid user</match>
     <description>sshd: Attempt to login using a non-existent user</description>
-    <group>invalid_login,authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_10.6.1,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,nist_800_53_AU.6,</group>
+    <group>invalid_login,authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_10.6.1,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,nist_800_53_AU.6,</group>
   </rule>
 
   <rule id="5711" level="0">
@@ -93,7 +93,7 @@
     <description>sshd: brute force trying to get access to </description>
     <description>the system.</description>
     <same_source_ip />
-    <group>authentication_failures,pci_dss_11.4,pci_dss_10.2.4,pci_dss_10.2.5,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_SC.7,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>authentication_failures,pci_dss_11.4,pci_dss_10.2.4,pci_dss_10.2.5,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_IA.10,nist_800_53_AC.7,</group>
   </rule>
 
   <rule id="5713" level="6">
@@ -108,21 +108,21 @@
     <description>sshd: SSH CRC-32 Compensation attack</description>
     <info type="cve">2001-0144</info>
     <info type="link">http://www.securityfocus.com/bid/2347/info/</info>
-    <group>exploit_attempt,pci_dss_11.4,pci_dss_6.2,gpg13_4.12,gdpr_IV_35.7.d,nist_800_53_SC.7,nist_800_53_MA.2,</group>
+    <group>exploit_attempt,pci_dss_11.4,pci_dss_6.2,gpg13_4.12,gdpr_IV_35.7.d,nist_800_53_IA.10,nist_800_53_SI.2,</group>
   </rule>
 
   <rule id="5715" level="3">
     <if_sid>5700</if_sid>
     <match>^Accepted|authenticated.$</match>
     <description>sshd: authentication success.</description>
-    <group>authentication_success,pci_dss_10.2.5,gpg13_7.1,gpg13_7.2,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>authentication_success,pci_dss_10.2.5,gpg13_7.1,gpg13_7.2,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,</group>
   </rule>
 
   <rule id="5716" level="5">
     <if_sid>5700</if_sid>
     <match>^Failed|^error: PAM: Authentication</match>
     <description>sshd: authentication failed.</description>
-    <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,</group>
   </rule>
 
   <rule id="5717" level="4">
@@ -135,20 +135,20 @@
     <if_sid>5700</if_sid>
     <match>not allowed because</match>
     <description>sshd: Attempt to login using a denied user.</description>
-    <group>invalid_login,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>invalid_login,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,</group>
   </rule>
 
   <rule id="5719" level="10" frequency="8" timeframe="120" ignore="60">
     <if_matched_sid>5718</if_matched_sid>
     <description>sshd: Multiple access attempts using a denied user.</description>
-    <group>invalid_login,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,nist_800_53_SC.7,</group>
+    <group>invalid_login,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,nist_800_53_IA.10,</group>
   </rule>
 
   <rule id="5720" level="10" frequency="8">
     <if_matched_sid>5716</if_matched_sid>
     <same_source_ip />
     <description>sshd: Multiple authentication failures.</description>
-    <group>authentication_failures,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,nist_800_53_SC.7,</group>
+    <group>authentication_failures,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,nist_800_53_IA.10,</group>
   </rule>
 
   <rule id="5721" level="0">
@@ -161,7 +161,7 @@
     <if_sid>5700</if_sid>
     <match>Connection closed</match>
     <description>sshd: ssh connection closed.</description>
-    <group>pci_dss_10.2.5,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>pci_dss_10.2.5,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,</group>
   </rule>
 
   <rule id="5723" level="0">
@@ -204,7 +204,7 @@
     <match>Authentication service cannot retrieve user credentials</match>
     <info>May be related to PAM module errors.</info>
     <description>sshd: Authentication services were not able to retrieve user credentials.</description>
-    <group>authentication_failed,pci_dss_10.2.5,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>authentication_failed,pci_dss_10.2.5,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,</group>
   </rule>
 
   <rule id="5729" level="0">
@@ -224,7 +224,7 @@
     <if_sid>5700</if_sid>
     <match>AKASSH_Version_Mapper1.</match>
     <description>sshd: SSH Scanning.</description>
-    <group>recon,pci_dss_11.4,gdpr_IV_35.7.d,nist_800_53_SC.7,</group>
+    <group>recon,pci_dss_11.4,gdpr_IV_35.7.d,nist_800_53_IA.10,</group>
   </rule>
 
   <rule id="5732" level="0">
@@ -237,7 +237,7 @@
     <if_sid>5700</if_sid>
     <match>Invalid credentials</match>
     <description>sshd: User entered incorrect password.</description>
-    <group>authentication_failures,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>authentication_failures,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,</group>
   </rule>
 
   <rule id="5734" level="0">
@@ -271,7 +271,7 @@
     <if_sid>5700</if_sid>
     <match>set_loginuid failed opening loginuid$</match>
     <description>sshd: pam_loginuid could not open loginuid.</description>
-    <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,</group>
   </rule>
 
   <rule id="5739" level="4">

--- a/rules/0095-sshd_rules.xml
+++ b/rules/0095-sshd_rules.xml
@@ -93,7 +93,7 @@
     <description>sshd: brute force trying to get access to </description>
     <description>the system.</description>
     <same_source_ip />
-    <group>authentication_failures,pci_dss_11.4,pci_dss_10.2.4,pci_dss_10.2.5,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_IA.10,nist_800_53_AC.7,</group>
+    <group>authentication_failures,pci_dss_11.4,pci_dss_10.2.4,pci_dss_10.2.5,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,</group>
   </rule>
 
   <rule id="5713" level="6">
@@ -141,14 +141,14 @@
   <rule id="5719" level="10" frequency="8" timeframe="120" ignore="60">
     <if_matched_sid>5718</if_matched_sid>
     <description>sshd: Multiple access attempts using a denied user.</description>
-    <group>invalid_login,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,nist_800_53_IA.10,</group>
+    <group>invalid_login,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,</group>
   </rule>
 
   <rule id="5720" level="10" frequency="8">
     <if_matched_sid>5716</if_matched_sid>
     <same_source_ip />
     <description>sshd: Multiple authentication failures.</description>
-    <group>authentication_failures,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,nist_800_53_IA.10,</group>
+    <group>authentication_failures,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,</group>
   </rule>
 
   <rule id="5721" level="0">

--- a/rules/0100-solaris_bsm_rules.xml
+++ b/rules/0100-solaris_bsm_rules.xml
@@ -29,27 +29,27 @@
     <if_sid>6102</if_sid>
     <match>^login</match>
     <description>Solaris: Login session succeeded.</description>
-    <group>authentication_success,pci_dss_10.2.5,gpg13_7.8,gpg13_7.9,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>authentication_success,pci_dss_10.2.5,gpg13_7.8,gpg13_7.9,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,</group>
   </rule>
 
   <rule id="6104" level="5">
     <if_sid>6101</if_sid>
     <match>^login</match>
     <description>Solaris: Login session failed.</description>
-    <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.8,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.8,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,</group>
   </rule>
 
   <rule id="6105" level="3">
     <if_sid>6102</if_sid>
     <match>^su </match>
     <description>Solaris: User successfully changed UID.</description>
-    <group>authentication_success,pci_dss_10.2.5,gpg13_7.8,gpg13_7.9,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>authentication_success,pci_dss_10.2.5,gpg13_7.8,gpg13_7.9,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,</group>
   </rule>
 
   <rule id="6106" level="5">
     <if_sid>6103</if_sid>
     <match>^su </match>
     <description>Solaris: User failed to change UID (user id).</description>
-    <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.8,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.8,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,</group>
   </rule>
 </group>

--- a/rules/0105-asterisk_rules.xml
+++ b/rules/0105-asterisk_rules.xml
@@ -38,42 +38,42 @@
     <if_sid>6201</if_sid>
     <match>Wrong password</match>
     <description>Asterisk: Login session failed.</description>
-    <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,</group>
   </rule>
 
   <rule id="6211" level="5">
     <if_sid>6201</if_sid>
     <match>Username/auth name mismatch</match>
     <description>Asterisk: Login session failed (invalid user).</description>
-    <group>invalid_login,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>invalid_login,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,</group>
   </rule>
 
   <rule id="6212" level="5">
     <if_sid>6201</if_sid>
     <match>No matching peer found</match>
     <description>Asterisk: Login session failed (invalid extension).</description>
-    <group>invalid_login,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>invalid_login,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,</group>
   </rule>
 
   <rule id="6250" level="10" frequency="8" timeframe="300">
     <if_matched_sid>6211</if_matched_sid>
     <same_source_ip />
     <description>Asterisk: Multiple failed logins (user enumeration in process).</description>
-    <group>pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,nist_800_53_SC.7,</group>
+    <group>pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,nist_800_53_IA.10,</group>
   </rule>
 
   <rule id="6251" level="10" frequency="8" timeframe="300">
     <if_matched_sid>6210</if_matched_sid>
     <same_source_ip />
     <description>Asterisk: Multiple failed logins.</description>
-    <group>pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,nist_800_53_SC.7,</group>
+    <group>pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,nist_800_53_IA.10,</group>
   </rule>
 
   <rule id="6252" level="10" frequency="8" timeframe="300">
     <if_matched_sid>6212</if_matched_sid>
     <same_source_ip />
     <description>Asterisk: Extension enumeration.</description>
-    <group>pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,nist_800_53_SC.7,</group>
+    <group>pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,nist_800_53_IA.10,</group>
   </rule>
 
   <!--From Javi Benito jabi.benito@gmail.com-->
@@ -82,7 +82,7 @@
     <if_sid>6201</if_sid>
     <match>No registration for peer</match>
     <description>Asterisk: Login session failed (invalid iax user).</description>
-    <group>invalid_login,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>invalid_login,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,</group>
   </rule>
 
   <!--From Javi Benito jabi.benito@gmail.com-->
@@ -90,7 +90,7 @@
     <if_matched_sid>6253</if_matched_sid>
     <same_source_ip />
     <description>Asterisk: Extension IAX Enumeration.</description>
-    <group>pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,nist_800_53_SC.7,</group>
+    <group>pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,nist_800_53_IA.10,</group>
   </rule>
 
   <!--From Javi Benito jabi.benito@gmail.com-->
@@ -98,7 +98,7 @@
     <if_sid>6202</if_sid>
     <match>Don't know how to respond via</match>
     <description>Asterisk: Possible Registration Hijacking.</description>
-    <group>invalid_login,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,nist_800_53_SC.7,</group>
+    <group>invalid_login,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,nist_800_53_IA.10,</group>
   </rule>
 
   <!--From Javi Benito jabi.benito@gmail.com-->
@@ -106,7 +106,7 @@
     <if_sid>6201</if_sid>
     <match>failed MD5 authentication</match>
     <description>Asterisk: IAX peer Wrong Password.</description>
-    <group>invalid_login,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>invalid_login,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,</group>
   </rule>
 
   <!--From Javi Benito jabi.benito@gmail.com-->
@@ -114,7 +114,7 @@
     <if_matched_sid>6256</if_matched_sid>
     <same_source_ip />
     <description>Asterisk: Multiple failed logins.</description>
-    <group>pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,nist_800_53_SC.7,</group>
+    <group>pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,nist_800_53_IA.10,</group>
   </rule>
 
 </group>

--- a/rules/0105-asterisk_rules.xml
+++ b/rules/0105-asterisk_rules.xml
@@ -59,21 +59,21 @@
     <if_matched_sid>6211</if_matched_sid>
     <same_source_ip />
     <description>Asterisk: Multiple failed logins (user enumeration in process).</description>
-    <group>pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,nist_800_53_IA.10,</group>
+    <group>pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,</group>
   </rule>
 
   <rule id="6251" level="10" frequency="8" timeframe="300">
     <if_matched_sid>6210</if_matched_sid>
     <same_source_ip />
     <description>Asterisk: Multiple failed logins.</description>
-    <group>pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,nist_800_53_IA.10,</group>
+    <group>pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,</group>
   </rule>
 
   <rule id="6252" level="10" frequency="8" timeframe="300">
     <if_matched_sid>6212</if_matched_sid>
     <same_source_ip />
     <description>Asterisk: Extension enumeration.</description>
-    <group>pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,nist_800_53_IA.10,</group>
+    <group>pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,</group>
   </rule>
 
   <!--From Javi Benito jabi.benito@gmail.com-->
@@ -90,7 +90,7 @@
     <if_matched_sid>6253</if_matched_sid>
     <same_source_ip />
     <description>Asterisk: Extension IAX Enumeration.</description>
-    <group>pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,nist_800_53_IA.10,</group>
+    <group>pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,</group>
   </rule>
 
   <!--From Javi Benito jabi.benito@gmail.com-->
@@ -98,7 +98,7 @@
     <if_sid>6202</if_sid>
     <match>Don't know how to respond via</match>
     <description>Asterisk: Possible Registration Hijacking.</description>
-    <group>invalid_login,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,nist_800_53_IA.10,</group>
+    <group>invalid_login,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,</group>
   </rule>
 
   <!--From Javi Benito jabi.benito@gmail.com-->
@@ -114,7 +114,7 @@
     <if_matched_sid>6256</if_matched_sid>
     <same_source_ip />
     <description>Asterisk: Multiple failed logins.</description>
-    <group>pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,nist_800_53_IA.10,</group>
+    <group>pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,</group>
   </rule>
 
 </group>

--- a/rules/0110-ms_dhcp_rules.xml
+++ b/rules/0110-ms_dhcp_rules.xml
@@ -59,21 +59,21 @@ ID,Date,Time,Description,IP Address,Host Name,MAC Address
 	<if_sid>6300</if_sid>
 	<id>^00</id>
     <description>MS-DHCP: The log was started.</description>
-    <group>service_start,pci_dss_10.2.6,gpg13_4.14,gpg13_10.1,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>service_start,pci_dss_10.2.6,gpg13_4.14,gpg13_10.1,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AU.5,</group>
   </rule>
 
   <rule id="6302" level="3">
 	<if_sid>6300</if_sid>
 	<id>^01</id>
     <description>MS-DHCP: The log was stopped.</description>
-    <group>service_availability,pci_dss_10.2.6,gpg13_4.14,gpg13_10.1,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>service_availability,pci_dss_10.2.6,gpg13_4.14,gpg13_10.1,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AU.5,</group>
   </rule>
 
   <rule id="6303" level="10">
 	<if_sid>6300</if_sid>
 	<id>^02</id>
     <description>MS-DHCP: The log was temporarily paused due to low disk space.</description>
-    <group>system_error,pci_dss_10.2.6,gpg13_4.14,gpg13_10.1,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>system_error,pci_dss_10.2.6,gpg13_4.14,gpg13_10.1,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AU.5,</group>
   </rule>
 
   <rule id="6304" level="0">
@@ -343,7 +343,7 @@ Server 2008 IPv6 Event ID  Meaning
 	<if_sid>6350</if_sid>
 	<id>^11012</id>
     <description>MS-DHCP: Audit log paused.</description>
-    <group>service_availability,pci_dss_10.1,pci_dss_10.2.6,gpg13_10.1,gdpr_IV_30.1.g,hipaa_164.312.b,nist_800_53_AU.1,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>service_availability,pci_dss_10.1,pci_dss_10.2.6,gpg13_10.1,gdpr_IV_30.1.g,hipaa_164.312.b,nist_800_53_AU.12,nist_800_53_IA.10,nist_800_53_AU.5,</group>
   </rule>
 
 

--- a/rules/0115-arpwatch_rules.xml
+++ b/rules/0115-arpwatch_rules.xml
@@ -25,7 +25,7 @@
     <if_sid>7200</if_sid>
     <match>flip flop </match>
     <description>Arpwatch: "flip flop" message. IP address/MAC relation changing too often.</description>
-    <group>ip_spoof,pci_dss_1.3.4,pci_dss_11.4,gdpr_IV_35.7.d,hipaa_164.312.a.1,nist_800_53_CA.3,nist_800_53_SC.7,nist_800_53_SC.7,</group>
+    <group>ip_spoof,pci_dss_1.3.4,pci_dss_11.4,gdpr_IV_35.7.d,hipaa_164.312.a.1,nist_800_53_CA.3,nist_800_53_IA.10,</group>
   </rule>
 
   <rule id="7203" level="3">
@@ -39,7 +39,7 @@
     <if_sid>7200</if_sid>
     <match>changed ethernet address </match>
     <description>Arpwatch: Changed network interface for ip address.</description>
-    <group>ip_spoof,pci_dss_1.3.4,pci_dss_11.4,gdpr_IV_35.7.d,hipaa_164.312.a.1,nist_800_53_CA.3,nist_800_53_SC.7,nist_800_53_SC.7,</group>
+    <group>ip_spoof,pci_dss_1.3.4,pci_dss_11.4,gdpr_IV_35.7.d,hipaa_164.312.a.1,nist_800_53_CA.3,nist_800_53_IA.10,</group>
   </rule>
 
   <rule id="7205" level="0">
@@ -72,7 +72,7 @@
     <if_sid>7200</if_sid>
     <match>ethernet mismatch</match>
     <description>Arpwatch: Possible arpspoofing attempt.</description>
-    <group>ip_spoof,pci_dss_1.3.4,pci_dss_11.4,gdpr_IV_35.7.d,hipaa_164.312.a.1,nist_800_53_CA.3,nist_800_53_SC.7,nist_800_53_SC.7,</group>
+    <group>ip_spoof,pci_dss_1.3.4,pci_dss_11.4,gdpr_IV_35.7.d,hipaa_164.312.a.1,nist_800_53_CA.3,nist_800_53_IA.10,</group>
   </rule>
 
 </group>

--- a/rules/0120-symantec-av_rules.xml
+++ b/rules/0120-symantec-av_rules.xml
@@ -22,7 +22,7 @@
   <rule id="7310" level="9">
     <if_sid>7300, 7301</if_sid>
     <id>^5$|^17$</id>
-    <group>virus,pci_dss_5.1,pci_dss_5.2,pci_dss_11.4,gpg13_4.2,gdpr_IV_35.7.d,nist_800_53_SI.5,nist_800_53_SC.7,</group>
+    <group>virus,pci_dss_5.1,pci_dss_5.2,pci_dss_11.4,gpg13_4.2,gdpr_IV_35.7.d,nist_800_53_SI.3,nist_800_53_IA.10,</group>
     <description>Symantec-AV: Virus detected.</description>
   </rule>
 
@@ -30,7 +30,7 @@
     <if_sid>7300, 7301</if_sid>
     <id>^2$|^3$|^4$|^13$</id>
     <description>Symantec-AV: Virus scan updated,started or stopped.</description>
-    <group>pci_dss_5.1,pci_dss_10.6.1,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_SI.5,nist_800_53_AU.6,</group>
+    <group>pci_dss_5.1,pci_dss_10.6.1,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_SI.3,nist_800_53_AU.6,</group>
   </rule>
 
 </group>

--- a/rules/0125-symantec-ws_rules.xml
+++ b/rules/0125-symantec-ws_rules.xml
@@ -17,21 +17,21 @@
     <if_sid>7400</if_sid>
     <id>^3=2,2=1</id>
     <description>Symantec-WS: Login failed accessing the web proxy.</description>
-    <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_71,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_71,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,</group>
   </rule>
 
   <rule id="7415" level="3">
     <if_sid>7400</if_sid>
     <id>^3=1,2=1</id>
     <description>Symantec-WS: Login success accessing the web proxy.</description>
-    <group>authentication_success,pci_dss_10.2.5,gpg13_7.1,gpg13_7.2,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>authentication_success,pci_dss_10.2.5,gpg13_7.1,gpg13_7.2,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,</group>
   </rule>
 
   <rule id="7420" level="3">
     <if_sid>7415</if_sid>
     <user>virtadmin</user>
     <description>Symantec-WS: Admin Login success to the web proxy.</description>
-    <group>authentication_success,pci_dss_10.2.5,gpg13_7.1,gpg13_7.2,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>authentication_success,pci_dss_10.2.5,gpg13_7.1,gpg13_7.2,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,</group>
   </rule>
 
   <!-- Example alerting using the url (event id 2=27 is for web access

--- a/rules/0130-trend-osce_rules.xml
+++ b/rules/0130-trend-osce_rules.xml
@@ -16,14 +16,14 @@
   <rule id="7610" level="5">
     <if_sid>7600</if_sid>
     <id>^0|$|^1$|^2$|^33|^10$|^11$|^12$</id>
-    <group>virus,pci_dss_5.1,pci_dss_5.2,pci_dss_11.4,gpg13_4.2,gdpr_IV_35.7.d,nist_800_53_SI.5,nist_800_53_SC.7,</group>
+    <group>virus,pci_dss_5.1,pci_dss_5.2,pci_dss_11.4,gpg13_4.2,gdpr_IV_35.7.d,nist_800_53_SI.3,nist_800_53_IA.10,</group>
     <description>Trend: Virus detected and cleaned/quarantined/removed</description>
   </rule>
 
   <rule id="7611" level="9">
     <if_sid>7600</if_sid>
     <id>^5$|^6$|^7$|^8$|^14$|^15$|^16$</id>
-    <group>virus,pci_dss_5.1,pci_dss_5.2,pci_dss_11.4,gpg13_4.2,gdpr_IV_35.7.d,nist_800_53_SI.5,nist_800_53_SC.7,</group>
+    <group>virus,pci_dss_5.1,pci_dss_5.2,pci_dss_11.4,gpg13_4.2,gdpr_IV_35.7.d,nist_800_53_SI.3,nist_800_53_IA.10,</group>
     <description>Trend: Virus detected and unable to clean up.</description>
   </rule>
 
@@ -31,13 +31,13 @@
     <if_sid>7600</if_sid>
     <id>^4$|^13$</id>
     <description>Trend: Virus scan completed with no errors detected.</description>
-    <group>pci_dss_5.1,gdpr_IV_35.7.d,nist_800_53_SI.5,</group>
+    <group>pci_dss_5.1,gdpr_IV_35.7.d,nist_800_53_SI.3,</group>
   </rule>
 
   <rule id="7613" level="5">
     <if_sid>7600</if_sid>
     <id>^25$</id>
     <description>Trend: Virus scan passed by found potential security risk.</description>
-    <group>pci_dss_5.1,pci_dss_5.2,pci_dss_11.4,gdpr_IV_35.7.d,gdpr_IV_32.2,nist_800_53_SI.5,nist_800_53_SC.7,</group>
+    <group>pci_dss_5.1,pci_dss_5.2,pci_dss_11.4,gdpr_IV_35.7.d,gdpr_IV_32.2,nist_800_53_SI.3,nist_800_53_IA.10,</group>
   </rule>
 </group>

--- a/rules/0135-hordeimp_rules.xml
+++ b/rules/0135-hordeimp_rules.xml
@@ -43,21 +43,21 @@
     <if_sid>9302</if_sid>
     <match>Login success for </match>
     <description>Horde IMP successful login.</description>
-    <group>authentication_success,pci_dss_10.2.5,gpg13_7.1,gpg13_7.2,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>authentication_success,pci_dss_10.2.5,gpg13_7.1,gpg13_7.2,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,</group>
   </rule>
 
   <rule id="9306" level="5">
     <if_sid>9303</if_sid>
     <match>FAILED LOGIN </match>
     <description>Horde IMP Failed login.</description>
-    <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,</group>
   </rule>
 
   <rule id="9351" level="10" frequency="8" timeframe="120">
     <if_matched_sid>9306</if_matched_sid>
     <same_source_ip />
     <description>Horde brute force (multiple failed logins).</description>
-    <group>authentication_failures,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,nist_800_53_SC.7,</group>
+    <group>authentication_failures,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,nist_800_53_IA.10,</group>
   </rule>
 
   <rule id="9352" level="10" frequency="6" timeframe="320">

--- a/rules/0135-hordeimp_rules.xml
+++ b/rules/0135-hordeimp_rules.xml
@@ -57,7 +57,7 @@
     <if_matched_sid>9306</if_matched_sid>
     <same_source_ip />
     <description>Horde brute force (multiple failed logins).</description>
-    <group>authentication_failures,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,nist_800_53_IA.10,</group>
+    <group>authentication_failures,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,</group>
   </rule>
 
   <rule id="9352" level="10" frequency="6" timeframe="320">

--- a/rules/0140-roundcube_rules.xml
+++ b/rules/0140-roundcube_rules.xml
@@ -32,6 +32,6 @@
     <if_matched_sid>9401</if_matched_sid>
     <same_source_ip />
     <description>Roundcube brute force (multiple failed logins).</description>
-    <group>authentication_failures,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,nist_800_53_IA.10,</group>
+    <group>authentication_failures,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,</group>
   </rule>
 </group>

--- a/rules/0140-roundcube_rules.xml
+++ b/rules/0140-roundcube_rules.xml
@@ -18,20 +18,20 @@
     <if_sid>9400</if_sid>
     <match>failed (LOGIN)| Login failed | Authentication failed| Failed login </match>
     <description>Roundcube authentication failed.</description>
-    <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,</group>
   </rule>
 
   <rule id="9402" level="3">
     <if_sid>9400</if_sid>
     <match>Successful login</match>
     <description>Roundcube authentication succeeded.</description>
-    <group>authentication_success,pci_dss_10.2.5,gpg13_7.1,gpg13_7.2,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>authentication_success,pci_dss_10.2.5,gpg13_7.1,gpg13_7.2,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,</group>
   </rule>
 
   <rule id="9403" level="10" frequency="8" timeframe="120">
     <if_matched_sid>9401</if_matched_sid>
     <same_source_ip />
     <description>Roundcube brute force (multiple failed logins).</description>
-    <group>authentication_failures,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,nist_800_53_SC.7,</group>
+    <group>authentication_failures,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,nist_800_53_IA.10,</group>
   </rule>
 </group>

--- a/rules/0145-wordpress_rules.xml
+++ b/rules/0145-wordpress_rules.xml
@@ -17,14 +17,14 @@
     <if_sid>9500</if_sid>
     <match>User authentication failed</match>
     <description>Wordpress authentication failed.</description>
-    <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,</group>
   </rule>
 
   <rule id="9502" level="3">
     <if_sid>9500</if_sid>
     <match>User logged in</match>
     <description>Wordpress authentication succeeded.</description>
-    <group>authentication_success,pci_dss_10.2.5,gpg13_7.1,gpg13_7.2,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>authentication_success,pci_dss_10.2.5,gpg13_7.1,gpg13_7.2,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,</group>
   </rule>
 
   <rule id="9503" level="3">
@@ -49,14 +49,14 @@
     <if_sid>9500</if_sid>
     <match>Warning: IDS:</match>
     <description>Attack against Wordpress detected.</description>
-    <group>pci_dss_11.4,gdpr_IV_35.7.d,nist_800_53_SC.7,</group>
+    <group>pci_dss_11.4,gdpr_IV_35.7.d,nist_800_53_IA.10,</group>
   </rule>
 
   <rule id="9551" level="10">
     <if_matched_sid>9501</if_matched_sid>
     <same_source_ip />
     <description>Multiple wordpress authentication failures.</description>
-    <group>authentication_failures,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,nist_800_53_SC.7,</group>
+    <group>authentication_failures,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,nist_800_53_IA.10,</group>
   </rule>
 
 </group>

--- a/rules/0145-wordpress_rules.xml
+++ b/rules/0145-wordpress_rules.xml
@@ -56,7 +56,7 @@
     <if_matched_sid>9501</if_matched_sid>
     <same_source_ip />
     <description>Multiple wordpress authentication failures.</description>
-    <group>authentication_failures,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,nist_800_53_IA.10,</group>
+    <group>authentication_failures,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,</group>
   </rule>
 
 </group>

--- a/rules/0150-cimserver_rules.xml
+++ b/rules/0150-cimserver_rules.xml
@@ -18,7 +18,7 @@
     <if_sid>9600</if_sid>
     <match>Authentication failed</match>
     <description>cimserver: Compaq Insight Manager authentication failure.</description>
-    <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.8,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.8,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,</group>
   </rule>
 
   <rule id="9611" level="12">

--- a/rules/0155-dovecot_rules.xml
+++ b/rules/0155-dovecot_rules.xml
@@ -67,14 +67,14 @@
   <if_matched_sid>9702</if_matched_sid>
   <same_source_ip />
   <description>Dovecot Multiple Authentication Failures.</description>
-  <group>authentication_failures,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,nist_800_53_IA.10,</group>
+  <group>authentication_failures,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,</group>
 </rule>
 
 <rule id="9751" level="10" frequency="8" timeframe="240">
   <if_matched_sid>9705</if_matched_sid>
   <same_source_ip />
   <description>Dovecot brute force attack (multiple auth failures).</description>
-  <group>authentication_failures,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,nist_800_53_IA.10,</group>
+  <group>authentication_failures,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,</group>
 </rule>
 
 <rule id="9770" level="0">

--- a/rules/0155-dovecot_rules.xml
+++ b/rules/0155-dovecot_rules.xml
@@ -17,14 +17,14 @@
   <if_sid>9700</if_sid>
   <match>login: Login: </match>
   <description>Dovecot Authentication Success.</description>
-  <group>authentication_success,pci_dss_10.2.5,gpg13_7.1,gpg13_7.2,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+  <group>authentication_success,pci_dss_10.2.5,gpg13_7.1,gpg13_7.2,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,</group>
 </rule>
 
 <rule id="9702" level="5">
   <if_sid>9700</if_sid>
   <match>Password mismatch$</match>
   <description>Dovecot Authentication Failed.</description>
-  <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+  <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,</group>
 </rule>
 
 <rule id="9703" level="3">
@@ -44,21 +44,21 @@
   <if_sid>9700</if_sid>
   <match>user not found|User not known|unknown user|auth failed</match>
   <description>Dovecot Invalid User Login Attempt.</description>
-  <group>invalid_login,authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+  <group>invalid_login,authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,</group>
 </rule>
 
 <rule id="9706" level="3">
   <if_sid>9700</if_sid>
   <match>: Disconnected: </match>
   <description>Dovecot Session Disconnected.</description>
-  <group>pci_dss_10.2.5,pci_dss_8.1.5,pci_dss_8.1.8,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,hipaa_164.312.a.1,hipaa_164.312.a.2.III,nist_800_53_AU.3.1,nist_800_53_IA.10,nist_800_53_AC.2,nist_800_53_AC.12,</group>
+  <group>pci_dss_10.2.5,pci_dss_8.1.5,pci_dss_8.1.8,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,hipaa_164.312.a.1,hipaa_164.312.a.2.III,nist_800_53_IA.10,nist_800_53_AC.7,nist_800_53_AC.2,nist_800_53_AC.12,</group>
 </rule>
 
 <rule id="9707" level="5">
   <if_sid>9700</if_sid>
   <match>: Aborted login</match>
   <description>Dovecot Aborted Login.</description>
-  <group>invalid_login,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+  <group>invalid_login,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,</group>
 </rule>
 
 
@@ -67,14 +67,14 @@
   <if_matched_sid>9702</if_matched_sid>
   <same_source_ip />
   <description>Dovecot Multiple Authentication Failures.</description>
-  <group>authentication_failures,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,nist_800_53_SC.7,</group>
+  <group>authentication_failures,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,nist_800_53_IA.10,</group>
 </rule>
 
 <rule id="9751" level="10" frequency="8" timeframe="240">
   <if_matched_sid>9705</if_matched_sid>
   <same_source_ip />
   <description>Dovecot brute force attack (multiple auth failures).</description>
-  <group>authentication_failures,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,nist_800_53_SC.7,</group>
+  <group>authentication_failures,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,nist_800_53_IA.10,</group>
 </rule>
 
 <rule id="9770" level="0">
@@ -86,7 +86,7 @@
   <if_sid>9770</if_sid>
   <match>user not found|User not known|unknown user|auth failed</match>
   <description>Dovecot Invalid User Login Attempt.</description>
-  <group>invalid_login,authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+  <group>invalid_login,authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,</group>
 </rule>
 
 </group>

--- a/rules/0160-vmpop3d_rules.xml
+++ b/rules/0160-vmpop3d_rules.xml
@@ -16,7 +16,7 @@
   <rule id="9801" level="5">
     <if_sid>9800</if_sid>
     <match>failed auth</match>
-    <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,</group>
     <description>vm-pop3d: Login failed accessing the pop3 server.</description>
   </rule>
 
@@ -24,7 +24,7 @@
     <if_matched_sid>9801</if_matched_sid>
     <same_source_ip />
     <description>vm-pop3d: POP3 brute force (multiple failed logins).</description>
-    <group>authentication_failures,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,nist_800_53_SC.7,</group>
+    <group>authentication_failures,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,nist_800_53_IA.10,</group>
   </rule>
 
 </group>

--- a/rules/0160-vmpop3d_rules.xml
+++ b/rules/0160-vmpop3d_rules.xml
@@ -24,7 +24,7 @@
     <if_matched_sid>9801</if_matched_sid>
     <same_source_ip />
     <description>vm-pop3d: POP3 brute force (multiple failed logins).</description>
-    <group>authentication_failures,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,nist_800_53_IA.10,</group>
+    <group>authentication_failures,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,</group>
   </rule>
 
 </group>

--- a/rules/0165-vpopmail_rules.xml
+++ b/rules/0165-vpopmail_rules.xml
@@ -17,28 +17,28 @@
   <rule id="9901" level="5">
     <if_sid>9900</if_sid>
     <match> password fail </match>
-    <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,</group>
     <description>vpopmail: Login failed.</description>
   </rule>
 
   <rule id="9902" level="5">
     <if_sid>9900</if_sid>
     <match> vpopmail user not found </match>
-    <group>invalid_login,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>invalid_login,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,</group>
     <description>vpopmail: Attempt to login to vpopmail with invalid username.</description>
   </rule>
 
   <rule id="9903" level="5">
     <if_sid>9900</if_sid>
     <match> null password given </match>
-    <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,</group>
     <description>vpopmail: Attempt to login to vpopmail with empty password.</description>
   </rule>
 
   <rule id="9904" level="3">
     <if_sid>9900</if_sid>
     <match> login success </match>
-    <group>authentication_success,pci_dss_10.2.5,gpg13_7.1,gpg13_7.2,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>authentication_success,pci_dss_10.2.5,gpg13_7.1,gpg13_7.2,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,</group>
     <description>vpopmail: successful login.</description>
   </rule>
 
@@ -46,21 +46,21 @@
     <if_matched_sid>9901</if_matched_sid>
     <same_source_ip />
     <description>vpopmail: brute force (multiple failed logins).</description>
-    <group>authentication_failures,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,nist_800_53_SC.7,</group>
+    <group>authentication_failures,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,nist_800_53_IA.10,</group>
   </rule>
 
   <rule id="9952" level="10" frequency="10" timeframe="240">
     <if_matched_sid>9902</if_matched_sid>
     <same_source_ip />
     <description>vpopmail: brute force (email harvesting).</description>
-    <group>authentication_failures,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,nist_800_53_SC.7,</group>
+    <group>authentication_failures,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,nist_800_53_IA.10,</group>
   </rule>
 
   <rule id="9953" level="10" frequency="10" timeframe="240">
     <if_matched_sid>9903</if_matched_sid>
     <same_source_ip />
     <description>vpopmail: brute force (empty password).</description>
-    <group>authentication_failures,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,nist_800_53_SC.7,</group>
+    <group>authentication_failures,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,nist_800_53_IA.10,</group>
   </rule>
 
 </group>

--- a/rules/0165-vpopmail_rules.xml
+++ b/rules/0165-vpopmail_rules.xml
@@ -46,21 +46,21 @@
     <if_matched_sid>9901</if_matched_sid>
     <same_source_ip />
     <description>vpopmail: brute force (multiple failed logins).</description>
-    <group>authentication_failures,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,nist_800_53_IA.10,</group>
+    <group>authentication_failures,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,</group>
   </rule>
 
   <rule id="9952" level="10" frequency="10" timeframe="240">
     <if_matched_sid>9902</if_matched_sid>
     <same_source_ip />
     <description>vpopmail: brute force (email harvesting).</description>
-    <group>authentication_failures,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,nist_800_53_IA.10,</group>
+    <group>authentication_failures,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,</group>
   </rule>
 
   <rule id="9953" level="10" frequency="10" timeframe="240">
     <if_matched_sid>9903</if_matched_sid>
     <same_source_ip />
     <description>vpopmail: brute force (empty password).</description>
-    <group>authentication_failures,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,nist_800_53_IA.10,</group>
+    <group>authentication_failures,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,</group>
   </rule>
 
 </group>

--- a/rules/0170-ftpd_rules.xml
+++ b/rules/0170-ftpd_rules.xml
@@ -70,7 +70,7 @@
     <if_sid>11100</if_sid>
     <match>repeated login failures</match>
     <description>FTPD: Multiple FTP failed login attempts.</description>
-    <group>authentication_failures,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,nist_800_53_IA.10,</group>
+    <group>authentication_failures,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,</group>
   </rule>
 
   <rule id="11110" level="3">

--- a/rules/0170-ftpd_rules.xml
+++ b/rules/0170-ftpd_rules.xml
@@ -18,7 +18,7 @@
     <if_sid>11100</if_sid>
     <match>FTP LOGIN REFUSED</match>
     <description>FTPD: connection refused.</description>
-    <group>authentication_failed,access_denied,pci_dss_10.2.4,pci_dss_10.2.5,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>authentication_failed,access_denied,pci_dss_10.2.4,pci_dss_10.2.5,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,</group>
   </rule>
 
   <rule id="11102" level="0">
@@ -48,14 +48,14 @@
   <rule id="11106" level="3">
     <if_sid>11100</if_sid>
     <match>FTP LOGIN FROM|connection from|connect from</match>
-    <group>connection_attempt,pci_dss_10.2.1,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>connection_attempt,pci_dss_10.2.1,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_IA.10,</group>
     <description>FTPD: Remote host connected to FTP server.,</description>
   </rule>
 
   <rule id="11107" level="5">
     <if_sid>11100</if_sid>
     <match>refused connect from</match>
-    <group>access_denied,pci_dss_10.2.4,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>access_denied,pci_dss_10.2.4,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,</group>
     <description>FTPD: Connection blocked by Tcp Wrappers.</description>
   </rule>
 
@@ -70,7 +70,7 @@
     <if_sid>11100</if_sid>
     <match>repeated login failures</match>
     <description>FTPD: Multiple FTP failed login attempts.</description>
-    <group>authentication_failures,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,nist_800_53_SC.7,</group>
+    <group>authentication_failures,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,nist_800_53_IA.10,</group>
   </rule>
 
   <rule id="11110" level="3">
@@ -84,20 +84,20 @@
     <if_sid>11100</if_sid>
     <match>PAM_ERROR_MSG: Account is disabled</match>
     <description>FTPD: Attempt to login with disabled account.</description>
-    <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_8.1.4,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,hipaa_164.312.a.1,nist_800_53_AU.3.1,nist_800_53_IA.10,nist_800_53_AC.2,</group>
+    <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_8.1.4,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,hipaa_164.312.a.1,nist_800_53_IA.10,nist_800_53_AC.7,nist_800_53_AC.2,</group>
   </rule>
 
   <rule id="11112" level="5">
     <if_sid>11100</if_sid>
     <match>^Failed authentication from</match>
     <description>FTPD: authentication failure.</description>
-    <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,</group>
   </rule>
 
   <rule id="11113" level="5">
     <if_sid>11100</if_sid>
     <regex>^login \S+ from \S+ failed</regex>
     <description>FTPD: authentication failure.</description>
-    <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,</group>
   </rule>
 </group>

--- a/rules/0175-proftpd_rules.xml
+++ b/rules/0175-proftpd_rules.xml
@@ -82,7 +82,7 @@
     <if_sid>11200</if_sid>
     <match>Maximum login attempts </match>
     <description>proftpd: Multiple failed login attempts.</description>
-    <group>authentication_failures,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,nist_800_53_IA.10,</group>
+    <group>authentication_failures,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,</group>
   </rule>
 
   <rule id="11211" level="4">
@@ -170,7 +170,7 @@
     <if_matched_sid>11204</if_matched_sid>
     <same_source_ip />
     <description>proftpd: FTP brute force (multiple failed logins).</description>
-    <group>authentication_failures,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,nist_800_53_IA.10,</group>
+    <group>authentication_failures,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,</group>
   </rule>
 
   <rule id="11252" level="10" frequency="12" timeframe="60">

--- a/rules/0175-proftpd_rules.xml
+++ b/rules/0175-proftpd_rules.xml
@@ -17,7 +17,7 @@
     <if_sid>11200</if_sid>
     <match>FTP session opened.$</match>
     <description>proftpd: FTP session opened.</description>
-    <group>connection_attempt,pci_dss_10.2.5,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>connection_attempt,pci_dss_10.2.5,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,</group>
   </rule>
 
   <rule id="11202" level="0">
@@ -30,35 +30,35 @@
     <if_sid>11200</if_sid>
     <match> no such user </match>
     <description>proftpd: Attempt to login using a non-existent user.</description>
-    <group>invalid_login,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>invalid_login,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,</group>
   </rule>
 
   <rule id="11204" level="5">
     <if_sid>11200</if_sid>
     <match>Incorrect password.$|Login failed</match>
     <description>proftpd: Login failed accessing the FTP server</description>
-    <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,</group>
   </rule>
 
   <rule id="11205" level="3">
     <if_sid>11200</if_sid>
     <match>Login successful</match>
     <description>proftpd: FTP Authentication success.</description>
-    <group>authentication_success,pci_dss_10.2.5,gpg13_7.1,gpg13_7.2,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>authentication_success,pci_dss_10.2.5,gpg13_7.1,gpg13_7.2,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,</group>
   </rule>
 
   <rule id="11206" level="5">
     <if_sid>11200</if_sid>
     <regex>Connection from \S+ [\S+] denied</regex>
     <description>proftpd: Connection denied by ProFTPD configuration.</description>
-    <group>access_denied,pci_dss_10.2.4,pci_dss_10.2.5,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>access_denied,pci_dss_10.2.4,pci_dss_10.2.5,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,</group>
   </rule>
 
   <rule id="11207" level="5">
     <if_sid>11200</if_sid>
     <match>refused connect from</match>
     <description>proftpd: Connection refused by TCP Wrappers.</description>
-    <group>access_denied,pci_dss_10.2.4,pci_dss_10.2.5,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>access_denied,pci_dss_10.2.4,pci_dss_10.2.5,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,</group>
   </rule>
 
   <rule id="11208" level="4">
@@ -75,14 +75,14 @@
     <description> keep state of FTP traffic.</description>
     <info type="link">http://www.kb.cert.org/vuls/id/328867</info>
     <info type="text">US-Cert Note VU#328867: Multiple vendors' firewalls do not adequately keep state of FTP traffic</info>
-    <group>pci_dss_10.6.1,pci_dss_11.4,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.6,nist_800_53_SC.7,</group>
+    <group>pci_dss_10.6.1,pci_dss_11.4,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.6,nist_800_53_IA.10,</group>
   </rule>
 
   <rule id="11210" level="10">
     <if_sid>11200</if_sid>
     <match>Maximum login attempts </match>
     <description>proftpd: Multiple failed login attempts.</description>
-    <group>authentication_failures,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,nist_800_53_SC.7,</group>
+    <group>authentication_failures,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,nist_800_53_IA.10,</group>
   </rule>
 
   <rule id="11211" level="4">
@@ -142,7 +142,7 @@
     <if_sid>11200</if_sid>
     <match>Reallocating sreaddir buffer</match>
     <description>proftpd: FTP server Buffer overflow attempt.</description>
-    <group>pci_dss_6.5.2,pci_dss_11.4,pci_dss_6.2,gdpr_IV_35.7.d,nist_800_53_SA.11,nist_800_53_SC.7,nist_800_53_MA.2,</group>
+    <group>pci_dss_6.5.2,pci_dss_11.4,pci_dss_6.2,gdpr_IV_35.7.d,nist_800_53_SA.11,nist_800_53_IA.10,nist_800_53_SI.2,</group>
   </rule>
 
   <rule id="11220" level="4">
@@ -170,14 +170,14 @@
     <if_matched_sid>11204</if_matched_sid>
     <same_source_ip />
     <description>proftpd: FTP brute force (multiple failed logins).</description>
-    <group>authentication_failures,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,nist_800_53_SC.7,</group>
+    <group>authentication_failures,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,nist_800_53_IA.10,</group>
   </rule>
 
   <rule id="11252" level="10" frequency="12" timeframe="60">
     <if_matched_sid>11201</if_matched_sid>
     <same_source_ip />
     <description>proftpd: Multiple connection attempts from same source.</description>
-    <group>recon,pci_dss_11.4,gdpr_IV_35.7.d,nist_800_53_SC.7,</group>
+    <group>recon,pci_dss_11.4,gdpr_IV_35.7.d,nist_800_53_IA.10,</group>
   </rule>
 
   <rule id="11253" level="10" frequency="12" timeframe="120">

--- a/rules/0180-pure-ftpd_rules.xml
+++ b/rules/0180-pure-ftpd_rules.xml
@@ -52,7 +52,7 @@
     <if_matched_sid>11302</if_matched_sid>
     <same_source_ip />
     <description>pure-ftpd: FTP brute force (multiple failed logins).</description>
-    <group>authentication_failures,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,nist_800_53_IA.10,</group>
+    <group>authentication_failures,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,</group>
   </rule>
 
   <rule id="11307" level="10" frequency="8" timeframe="60">

--- a/rules/0180-pure-ftpd_rules.xml
+++ b/rules/0180-pure-ftpd_rules.xml
@@ -25,7 +25,7 @@
     <if_sid>11300</if_sid>
     <match>[WARNING] Authentication failed for user</match>
     <description>pure-ftpd: FTP Authentication failed.</description>
-    <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,</group>
   </rule>
 
   <rule id="11303" level="0">
@@ -45,28 +45,28 @@
     <if_sid>11300</if_sid>
     <match>[INFO] Can't change directory to</match>
     <description>pure-ftpd: Attempt to access invalid directory</description>
-    <group>pci_dss_10.2.4,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>pci_dss_10.2.4,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,</group>
   </rule>
 
   <rule id="11306" level="10" frequency="8" timeframe="120">
     <if_matched_sid>11302</if_matched_sid>
     <same_source_ip />
     <description>pure-ftpd: FTP brute force (multiple failed logins).</description>
-    <group>authentication_failures,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,nist_800_53_SC.7,</group>
+    <group>authentication_failures,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,nist_800_53_IA.10,</group>
   </rule>
 
   <rule id="11307" level="10" frequency="8" timeframe="60">
     <if_matched_sid>11301</if_matched_sid>
     <same_source_ip />
     <description>pure-ftpd: Multiple connection attempts from same source.</description>
-    <group>recon,pci_dss_11.4,gdpr_IV_35.7.d,nist_800_53_SC.7,</group>
+    <group>recon,pci_dss_11.4,gdpr_IV_35.7.d,nist_800_53_IA.10,</group>
   </rule>
 
   <rule id="11309" level="3">
     <if_sid>11300</if_sid>
     <match>[INFO] \S+ is now logged in| is now logged in</match>
     <description>pure-ftpd: FTP Authentication success.</description>
-    <group>authentication_success,pci_dss_10.2.5,gpg13_7.1,gpg13_7.2,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>authentication_success,pci_dss_10.2.5,gpg13_7.1,gpg13_7.2,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,</group>
   </rule>
 
   <rule id="11310" level="0">

--- a/rules/0185-vsftpd_rules.xml
+++ b/rules/0185-vsftpd_rules.xml
@@ -46,7 +46,7 @@
     <if_matched_sid>11403</if_matched_sid>
     <same_source_ip />
     <description>vsftpd: FTP brute force (multiple failed logins).</description>
-    <group>authentication_failures,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,nist_800_53_IA.10,</group>
+    <group>authentication_failures,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,</group>
   </rule>
 
   <rule id="11452" level="10" frequency="12" timeframe="60">

--- a/rules/0185-vsftpd_rules.xml
+++ b/rules/0185-vsftpd_rules.xml
@@ -26,14 +26,14 @@
     <if_sid>11400</if_sid>
     <match>OK LOGIN: </match>
     <description>vsftpd: FTP Authentication success.</description>
-    <group>authentication_success,pci_dss_10.2.5,gpg13_7.1,gpg13_7.2,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>authentication_success,pci_dss_10.2.5,gpg13_7.1,gpg13_7.2,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,</group>
   </rule>
 
   <rule id="11403" level="5">
     <if_sid>11400</if_sid>
     <match>FAIL LOGIN: </match>
     <description>vsftpd: Login failed accessing the FTP server.</description>
-    <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,</group>
   </rule>
 
   <rule id="11404" level="0">
@@ -46,7 +46,7 @@
     <if_matched_sid>11403</if_matched_sid>
     <same_source_ip />
     <description>vsftpd: FTP brute force (multiple failed logins).</description>
-    <group>authentication_failures,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,nist_800_53_SC.7,</group>
+    <group>authentication_failures,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,nist_800_53_IA.10,</group>
   </rule>
 
   <rule id="11452" level="10" frequency="12" timeframe="60">
@@ -54,7 +54,7 @@
     <same_source_ip />
     <description>vsftpd: Multiple FTP connection attempts from </description>
     <description>same source IP.</description>
-    <group>recon,pci_dss_11.4,gdpr_IV_35.7.d,nist_800_53_SC.7,</group>
+    <group>recon,pci_dss_11.4,gdpr_IV_35.7.d,nist_800_53_IA.10,</group>
   </rule>
 
 </group>

--- a/rules/0190-ms_ftpd_rules.xml
+++ b/rules/0190-ms_ftpd_rules.xml
@@ -25,7 +25,7 @@
     <action>PASS</action>
     <id>530</id>
     <description>MS-FTP: FTP Authentication failed.</description>
-    <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,</group>
   </rule>
 
   <rule id="11503" level="3">
@@ -33,7 +33,7 @@
     <action>PASS</action>
     <id>230</id>
     <description>MS-FTP: FTP Authentication success.</description>
-    <group>authentication_success,pci_dss_10.2.5,gpg13_7.1,gpg13_7.2,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>authentication_success,pci_dss_10.2.5,gpg13_7.1,gpg13_7.2,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,</group>
   </rule>
 
   <rule id="11504" level="4">
@@ -46,14 +46,14 @@
     <if_matched_sid>11502</if_matched_sid>
     <same_source_ip />
     <description>MS-FTP: FTP brute force (multiple failed logins).</description>
-    <group>authentication_failures,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,nist_800_53_SC.7,</group>
+    <group>authentication_failures,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,nist_800_53_IA.10,</group>
   </rule>
 
   <rule id="11511" level="10" frequency="10" timeframe="30">
     <if_matched_sid>11501</if_matched_sid>
     <same_source_ip />
     <description>MS-FTP: Multiple connection attempts from same source.</description>
-    <group>recon,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,nist_800_53_SC.7,</group>
+    <group>recon,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,nist_800_53_IA.10,</group>
   </rule>
 
   <rule id="11512" level="10" frequency="8" timeframe="120">

--- a/rules/0190-ms_ftpd_rules.xml
+++ b/rules/0190-ms_ftpd_rules.xml
@@ -46,14 +46,14 @@
     <if_matched_sid>11502</if_matched_sid>
     <same_source_ip />
     <description>MS-FTP: FTP brute force (multiple failed logins).</description>
-    <group>authentication_failures,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,nist_800_53_IA.10,</group>
+    <group>authentication_failures,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,</group>
   </rule>
 
   <rule id="11511" level="10" frequency="10" timeframe="30">
     <if_matched_sid>11501</if_matched_sid>
     <same_source_ip />
     <description>MS-FTP: Multiple connection attempts from same source.</description>
-    <group>recon,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,nist_800_53_IA.10,</group>
+    <group>recon,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,</group>
   </rule>
 
   <rule id="11512" level="10" frequency="8" timeframe="120">

--- a/rules/0195-named_rules.xml
+++ b/rules/0195-named_rules.xml
@@ -17,14 +17,14 @@
     <if_sid>12100</if_sid>
     <match>dropping source port zero packet from</match>
     <description>Invalid DNS packet. Possibility of attack.</description>
-    <group>invalid_access,pci_dss_10.2.4,pci_dss_11.4,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,nist_800_53_SC.7,</group>
+    <group>invalid_access,pci_dss_10.2.4,pci_dss_11.4,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,nist_800_53_IA.10,</group>
   </rule>
 
   <rule id="12102" level="9">
     <if_sid>12100</if_sid>
     <match>denied AXFR from</match>
     <description>Failed attempt to perform a zone transfer.</description>
-    <group>access_denied,pci_dss_10.2.4,pci_dss_11.4,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,nist_800_53_SC.7,</group>
+    <group>access_denied,pci_dss_10.2.4,pci_dss_11.4,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,nist_800_53_IA.10,</group>
   </rule>
 
   <rule id="12103" level="4">
@@ -33,14 +33,14 @@
     <description>DNS update denied. </description>
     <description>Generally mis-configuration.</description>
     <info type="link">http://seclists.org/incidents/2000/May/217</info>
-    <group>client_misconfig,pci_dss_10.2.4,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>client_misconfig,pci_dss_10.2.4,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,</group>
   </rule>
 
   <rule id="12104" level="4">
     <if_sid>12100</if_sid>
     <match>unable to rename log file</match>
     <description>Log permission misconfiguration in Named.</description>
-    <group>system_error,pci_dss_10.1,hipaa_164.312.b,nist_800_53_AU.1,</group>
+    <group>system_error,pci_dss_10.1,hipaa_164.312.b,nist_800_53_AU.12,</group>
   </rule>
 
   <rule id="12105" level="4">
@@ -60,7 +60,7 @@
     <if_sid>12100</if_sid>
     <regex>update \S+ denied</regex>
     <description>DNS update using RFC2136 Dynamic protocol.</description>
-    <group>pci_dss_10.2.4,pci_dss_10.6.1,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,nist_800_53_AU.6,</group>
+    <group>pci_dss_10.2.4,pci_dss_10.6.1,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,nist_800_53_AU.6,</group>
   </rule>
 
   <rule id="12108" level="5">
@@ -68,7 +68,7 @@
     <match>query (cache) denied|: query (cache)</match>
     <description>Query cache denied (probably config error).</description>
     <info type="link">http://www.reedmedia.net/misc/dns/errors.html</info>
-	<group>system_error,pci_dss_10.2.4,pci_dss_10.6.1,gpg13_4.3,connection_attempt,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,nist_800_53_AU.6,</group>
+	<group>system_error,pci_dss_10.2.4,pci_dss_10.6.1,gpg13_4.3,connection_attempt,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,nist_800_53_AU.6,</group>
   </rule>
 
   <rule id="12109" level="12">
@@ -228,14 +228,14 @@
     <if_sid>12100</if_sid>
     <regex>open: \S+: permission denied$</regex>
     <description>Could not open configuration file, permission denied.</description>
-	<group>pci_dss_10.2.4,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+	<group>pci_dss_10.2.4,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,</group>
   </rule>
 
   <rule id="12134" level="4">
     <if_sid>12100</if_sid>
     <match>loading configuration: permission denied</match>
     <description>Could not open configuration file, permission denied.</description>
-	<group>pci_dss_10.2.4,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+	<group>pci_dss_10.2.4,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,</group>
   </rule>
 
   <rule id="12135" level="0">
@@ -304,7 +304,7 @@
     <if_sid>12100</if_sid>
     <regex>zone transfer \S+ denied</regex>
     <description>zone transfer denied</description>
-    <group>pci_dss_10.6.1,pci_dss_10.2.4,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.6,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>pci_dss_10.6.1,pci_dss_10.2.4,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.6,nist_800_53_IA.10,nist_800_53_AC.7,</group>
   </rule>
 
   <rule id="12146" level="0">

--- a/rules/0195-named_rules.xml
+++ b/rules/0195-named_rules.xml
@@ -17,14 +17,14 @@
     <if_sid>12100</if_sid>
     <match>dropping source port zero packet from</match>
     <description>Invalid DNS packet. Possibility of attack.</description>
-    <group>invalid_access,pci_dss_10.2.4,pci_dss_11.4,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,nist_800_53_IA.10,</group>
+    <group>invalid_access,pci_dss_10.2.4,pci_dss_11.4,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,</group>
   </rule>
 
   <rule id="12102" level="9">
     <if_sid>12100</if_sid>
     <match>denied AXFR from</match>
     <description>Failed attempt to perform a zone transfer.</description>
-    <group>access_denied,pci_dss_10.2.4,pci_dss_11.4,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,nist_800_53_IA.10,</group>
+    <group>access_denied,pci_dss_10.2.4,pci_dss_11.4,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,</group>
   </rule>
 
   <rule id="12103" level="4">

--- a/rules/0200-smbd_rules.xml
+++ b/rules/0200-smbd_rules.xml
@@ -23,7 +23,7 @@
     <if_sid>13100</if_sid>
     <match>Denied connection from|Connection denied from</match>
     <description>Samba connection denied.</description>
-    <group>access_denied,pci_dss_10.2.4,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>access_denied,pci_dss_10.2.4,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,</group>
   </rule>
 
   <rule id="13103" level="0">
@@ -36,7 +36,7 @@
     <if_sid>13100</if_sid>
     <match>Permission denied--</match>
     <description>Samba: User action denied by configuration.</description>
-    <group>access_denied,pci_dss_10.2.4,pci_dss_10.2.5,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>access_denied,pci_dss_10.2.4,pci_dss_10.2.5,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,</group>
   </rule>
 
   <rule id="13105" level="3">
@@ -68,7 +68,7 @@
     <if_sid>13100</if_sid>
     <match>Connection denied from</match>
     <description>Samba: Connection was denied.</description>
-    <group>pci_dss_10.2.4,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>pci_dss_10.2.4,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,</group>
   </rule>
 
   <rule id="13111" level="3">
@@ -82,7 +82,7 @@
     <match>gvfsd-smb</match>
     <regex>segfault at \S+ ip \S+ sp \S+ error \d+ in</regex>
     <description>Samba: Segfault in gvfs-smb.</description>
-    <group>pci_dss_6.5.2,pci_dss_11.4,pci_dss_6.2,gdpr_IV_35.7.d,nist_800_53_SA.11,nist_800_53_SC.7,nist_800_53_MA.2,</group>
+    <group>pci_dss_6.5.2,pci_dss_11.4,pci_dss_6.2,gdpr_IV_35.7.d,nist_800_53_SA.11,nist_800_53_IA.10,nist_800_53_SI.2,</group>
   </rule>
 
 </group>

--- a/rules/0205-racoon_rules.xml
+++ b/rules/0205-racoon_rules.xml
@@ -66,6 +66,6 @@
     <if_matched_sid>14101</if_matched_sid>
     <same_source_ip />
     <description>racoon: Multiple failed VPN logins.</description>
-    <group>pci_dss_11.4,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_IA.10,nist_800_53_AC.7,</group>
+    <group>pci_dss_11.4,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,</group>
   </rule>
 </group>

--- a/rules/0205-racoon_rules.xml
+++ b/rules/0205-racoon_rules.xml
@@ -16,7 +16,7 @@
   <rule id="14101" level="5">
     <decoded_as>racoon-failed</decoded_as>
     <description>racoon: VPN authentication failed.</description>
-    <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,</group>
   </rule>
 
   <rule id="14110" level="0">
@@ -40,7 +40,7 @@
   <rule id="14120" level="3">
     <if_sid>14110</if_sid>
     <match>ISAKMP-SA established </match>
-    <group>authentication_success,pci_dss_10.2.5,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>authentication_success,pci_dss_10.2.5,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,</group>
     <description>racoon: VPN established.</description>
   </rule>
 
@@ -66,6 +66,6 @@
     <if_matched_sid>14101</if_matched_sid>
     <same_source_ip />
     <description>racoon: Multiple failed VPN logins.</description>
-    <group>pci_dss_11.4,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_SC.7,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>pci_dss_11.4,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_IA.10,nist_800_53_AC.7,</group>
   </rule>
 </group>

--- a/rules/0210-vpn_concentrator_rules.xml
+++ b/rules/0210-vpn_concentrator_rules.xml
@@ -17,14 +17,14 @@
     <if_sid>14200</if_sid>
     <id>^IKE/52$</id>
     <description>CiscoVPN: VPN authentication successful.</description>
-    <group>authentication_success,pci_dss_10.2.5,gpg13_7.1,gpg13_7.2,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>authentication_success,pci_dss_10.2.5,gpg13_7.1,gpg13_7.2,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,</group>
   </rule>
 
   <rule id="14202" level="5">
     <if_sid>14200</if_sid>
     <id>^AUTH/5$|^AUTH/9$|^IKE/167$|^PPP/9$|^SSH/33$|^PSH/23$</id>
     <description>CiscoVPN: VPN authentication failed.</description>
-    <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,</group>
   </rule>
 
   <rule id="14203" level="4">
@@ -32,13 +32,13 @@
     <id>^HTTP/47$|^SSH/16$</id>
     <options>alert_by_email</options>
     <description>CiscoVPN: VPN Admin authentication successful.</description>
-    <group>authentication_success,pci_dss_10.2.5,gpg13_7.1,gpg13_7.2,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>authentication_success,pci_dss_10.2.5,gpg13_7.1,gpg13_7.2,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,</group>
   </rule>
 
   <rule id="14251" level="10" frequency="10" timeframe="240">
     <if_matched_sid>14202</if_matched_sid>
     <same_source_ip />
     <description>CiscoVPN: Multiple VPN authentication failures.</description>
-    <group>authentication_failures,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>authentication_failures,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,</group>
   </rule>
 </group>

--- a/rules/0215-policy_rules.xml
+++ b/rules/0215-policy_rules.xml
@@ -12,13 +12,13 @@
     <if_group>authentication_success</if_group>
     <time>6 pm - 8:30 am</time>
     <description>Successful login during non-business hours.</description>
-    <group>login_time,pci_dss_10.2.5,pci_dss_10.6.1,gpg13_7.1,gpg13_7.2,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,nist_800_53_AU.6,</group>
+    <group>login_time,pci_dss_10.2.5,pci_dss_10.6.1,gpg13_7.1,gpg13_7.2,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,nist_800_53_AU.6,</group>
   </rule>
 
   <rule id="17102" level="9">
     <if_group>authentication_success</if_group>
     <weekday>weekends</weekday>
     <description>Successful login during weekend.</description>
-    <group>login_day,pci_dss_10.2.5,pci_dss_10.6.1,gpg13_7.1,gpg13_7.2,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,nist_800_53_AU.6,</group>
+    <group>login_day,pci_dss_10.2.5,pci_dss_10.6.1,gpg13_7.1,gpg13_7.2,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,nist_800_53_AU.6,</group>
   </rule>
 </group>

--- a/rules/0220-msauth_rules.xml
+++ b/rules/0220-msauth_rules.xml
@@ -52,21 +52,21 @@
     <if_sid>18105</if_sid>
     <id>^529$|^530$|^531$|^532$|^533$|^534$|^535$|^536$|^537$|^539$|^4625$</id>
     <description>Windows Logon Failure.</description>
-    <group>win_authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>win_authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,</group>
   </rule>
 
   <rule id="18107" level="3">
     <if_sid>18104</if_sid>
     <id>^528$|^540$|^673$|^4624$|^4769$</id>
     <description>Windows Logon Success.</description>
-    <group>authentication_success,pci_dss_10.2.5,gpg13_7.1,gpg13_7.2,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>authentication_success,pci_dss_10.2.5,gpg13_7.1,gpg13_7.2,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,</group>
   </rule>
 
   <rule id="18108" level="4">
     <if_sid>18105</if_sid>
     <id>^577$|^4673$</id>
     <description>Windows: Failed attempt to perform a privileged operation.</description>
-    <group>authentication_success,pci_dss_10.2.2,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>authentication_success,pci_dss_10.2.2,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.6,</group>
   </rule>
 
   <rule id="18109" level="3">
@@ -81,7 +81,7 @@
     <id>^624$|^626$|^4720$|^4722$</id>
     <description>Windows: User account enabled or created.</description>
     <group>adduser,account_changed,</group>
-    <group>pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.a.2.I,hipaa_164.312.a.2.II,hipaa_164.312.b,nist_800_53_AC.2,nist_800_53_IA.4,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.a.2.I,hipaa_164.312.a.2.II,hipaa_164.312.b,nist_800_53_AC.2,nist_800_53_IA.4,nist_800_53_IA.10,nist_800_53_AC.7,</group>
   </rule>
 
   <rule id="18111" level="8">
@@ -89,14 +89,14 @@
     <id>^628$|^642$|^685$|^4738$|^4781$</id>
     <description>Windows: User account changed.</description>
     <group>account_changed,</group>
-    <group>pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.a.2.I,hipaa_164.312.a.2.II,hipaa_164.312.b,nist_800_53_AC.2,nist_800_53_IA.4,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.a.2.I,hipaa_164.312.a.2.II,hipaa_164.312.b,nist_800_53_AC.2,nist_800_53_IA.4,nist_800_53_IA.10,nist_800_53_AC.7,</group>
   </rule>
 
   <rule id="18112" level="8">
     <if_sid>18104</if_sid>
     <id>^630$|^629$|^4725$|^4726$</id>
     <description>Windows: User account disabled or deleted.</description>
-    <group>adduser,account_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.a.2.I,hipaa_164.312.a.2.II,hipaa_164.312.b,nist_800_53_AC.2,nist_800_53_IA.4,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>adduser,account_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.a.2.I,hipaa_164.312.a.2.II,hipaa_164.312.b,nist_800_53_AC.2,nist_800_53_IA.4,nist_800_53_IA.10,nist_800_53_AC.7,</group>
   </rule>
 
   <rule id="18113" level="8">
@@ -114,7 +114,7 @@
     <id>^656$|^4752$|^659$|^4755$|^660$|^4756$|^661$|^4757$|^664$|^4760$|</id>
     <id>^665$|^4761$|^666$|^4762$</id>
     <description>Windows: Group Account Changed</description>
-    <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.a.2.I,hipaa_164.312.a.2.II,hipaa_164.312.b,nist_800_53_AC.2,nist_800_53_IA.4,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.a.2.I,hipaa_164.312.a.2.II,hipaa_164.312.b,nist_800_53_AC.2,nist_800_53_IA.4,nist_800_53_IA.10,nist_800_53_AC.7,</group>
   </rule>
 
   <rule id="18115" level="8">
@@ -122,14 +122,14 @@
     <id>^640$</id>
     <description>Windows: General account database changed.</description>
     <info type="link">https://www.ultimatewindowssecurity.com/securitylog/encyclopedia/event.aspx?eventid=640</info>
-    <group>adduser,account_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.a.2.I,hipaa_164.312.a.2.II,hipaa_164.312.b,nist_800_53_AC.2,nist_800_53_IA.4,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>adduser,account_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.a.2.I,hipaa_164.312.a.2.II,hipaa_164.312.b,nist_800_53_AC.2,nist_800_53_IA.4,nist_800_53_IA.10,nist_800_53_AC.7,</group>
   </rule>
 
   <rule id="18116" level="9">
     <if_sid>18104</if_sid>
     <id>^644$|^4740$</id>
     <description>Windows: User account locked out (multiple login errors).</description>
-    <group>authentication_failures,pci_dss_8.1.6,pci_dss_11.4,gpg13_7.5,gdpr_IV_35.7.d,hipaa_164.312.a.1,nist_800_53_AC.7,nist_800_53_SC.7,</group>
+    <group>authentication_failures,pci_dss_8.1.6,pci_dss_11.4,gpg13_7.5,gdpr_IV_35.7.d,hipaa_164.312.a.1,nist_800_53_AC.7,nist_800_53_IA.10,</group>
   </rule>
 
   <rule id="18117" level="7">
@@ -151,7 +151,7 @@
     <options>alert_by_email</options>
     <if_fts />
     <description>Windows: First time this user logged in this system.</description>
-    <group>authentication_success,pci_dss_10.2.5,gpg13_7.1,gpg13_7.2,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>authentication_success,pci_dss_10.2.5,gpg13_7.1,gpg13_7.2,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,</group>
   </rule>
 
   <rule id="18120" level="0">
@@ -164,21 +164,21 @@
     <if_sid>18102, 18103</if_sid>
     <id>^20187$|^20014$|^20078$|^20050$|^20049$|^20189$</id>
     <description>Windows: Remote access login failure.</description>
-    <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_8.1.5,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,hipaa_164.312.a.1,nist_800_53_AU.3.1,nist_800_53_IA.10,nist_800_53_AC.2,</group>
+    <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_8.1.5,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,hipaa_164.312.a.1,nist_800_53_IA.10,nist_800_53_AC.7,nist_800_53_AC.2,</group>
   </rule>
 
   <rule id="18126" level="3">
     <if_sid>18101</if_sid>
     <id>^20158$</id>
     <description>Windows: Remote access login success.</description>
-    <group>authentication_success,pci_dss_10.2.5,pci_dss_8.1.5,gpg13_7.1,gpg13_7.2,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,hipaa_164.312.a.1,nist_800_53_AU.3.1,nist_800_53_IA.10,nist_800_53_AC.2,</group>
+    <group>authentication_success,pci_dss_10.2.5,pci_dss_8.1.5,gpg13_7.1,gpg13_7.2,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,hipaa_164.312.a.1,nist_800_53_IA.10,nist_800_53_AC.7,nist_800_53_AC.2,</group>
   </rule>
 
   <rule id="18127" level="5">
     <if_sid>18104</if_sid>
     <id>^646$|^645$|^647$|^4741$|^4742$|^4743$</id>
     <description>Windows: Computer account added/changed/deleted.</description>
-    <group>account_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.a.2.I,hipaa_164.312.a.2.II,hipaa_164.312.b,nist_800_53_AC.2,nist_800_53_IA.4,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>account_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.a.2.I,hipaa_164.312.a.2.II,hipaa_164.312.b,nist_800_53_AC.2,nist_800_53_IA.4,nist_800_53_IA.10,nist_800_53_AC.7,</group>
   </rule>
 
   <rule id="18128" level="8">
@@ -186,7 +186,7 @@
     <id>^65xxx</id>
     <description>Windows: Group account added/changed/deleted.</description>
     <info>This rule has been deprecated</info>
-    <group>account_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.a.2.I,hipaa_164.312.a.2.II,hipaa_164.312.b,nist_800_53_AC.2,nist_800_53_IA.4,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>account_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.a.2.I,hipaa_164.312.a.2.II,hipaa_164.312.b,nist_800_53_AC.2,nist_800_53_IA.4,nist_800_53_IA.10,nist_800_53_AC.7,</group>
   </rule>
 
   <rule id="18129" level="8">
@@ -203,7 +203,7 @@
     <id>^529$|^4625$</id>
     <description>Windows: Logon Failure - Unknown user or bad password.</description>
     <info type="link">https://www.ultimatewindowssecurity.com/securitylog/encyclopedia/event.aspx?eventid=4625</info>
-    <group>win_authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>win_authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,</group>
   </rule>
 
   <rule id="18131" level="5">
@@ -211,7 +211,7 @@
     <id>^530$</id>
     <description>Windows: Logon Failure - Account logon time restriction violation.</description>
     <info type="link">https://www.ultimatewindowssecurity.com/securitylog/encyclopedia/event.aspx?eventid=530</info>
-    <group>win_authentication_failed,login_denied,pci_dss_10.2.5,pci_dss_8.1.5,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,hipaa_164.312.a.1,nist_800_53_AU.3.1,nist_800_53_IA.10,nist_800_53_AC.2,</group>
+    <group>win_authentication_failed,login_denied,pci_dss_10.2.5,pci_dss_8.1.5,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,hipaa_164.312.a.1,nist_800_53_IA.10,nist_800_53_AC.7,nist_800_53_AC.2,</group>
   </rule>
 
   <rule id="18132" level="5">
@@ -219,7 +219,7 @@
     <id>^531$</id>
     <description>Windows: Logon Failure - Account currently disabled.</description>
     <info type="link">https://www.ultimatewindowssecurity.com/securitylog/encyclopedia/event.aspx?eventid=531</info>
-    <group>win_authentication_failed,login_denied,pci_dss_10.2.5,pci_dss_8.1.4,gpg13_7.5,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,hipaa_164.312.a.1,nist_800_53_AU.3.1,nist_800_53_IA.10,nist_800_53_AC.2,</group>
+    <group>win_authentication_failed,login_denied,pci_dss_10.2.5,pci_dss_8.1.4,gpg13_7.5,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,hipaa_164.312.a.1,nist_800_53_IA.10,nist_800_53_AC.7,nist_800_53_AC.2,</group>
   </rule>
 
   <rule id="18133" level="5">
@@ -227,7 +227,7 @@
     <id>^532$</id>
     <description>Windows: Logon Failure - Specified account expired.</description>
     <info type="link">https://www.ultimatewindowssecurity.com/securitylog/encyclopedia/event.aspx?eventid=532</info>
-    <group>win_authentication_failed,login_denied,pci_dss_10.2.5,pci_dss_8.1.5,gpg13_7.5,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,hipaa_164.312.a.1,nist_800_53_AU.3.1,nist_800_53_IA.10,nist_800_53_AC.2,</group>
+    <group>win_authentication_failed,login_denied,pci_dss_10.2.5,pci_dss_8.1.5,gpg13_7.5,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,hipaa_164.312.a.1,nist_800_53_IA.10,nist_800_53_AC.7,nist_800_53_AC.2,</group>
   </rule>
 
   <rule id="18134" level="7">
@@ -235,7 +235,7 @@
     <id>^533$</id>
     <description>Windows: Logon Failure - User not allowed to login at this computer.</description>
     <info type="link">https://www.ultimatewindowssecurity.com/securitylog/encyclopedia/event.aspx?eventid=533</info>
-    <group>win_authentication_failed,login_denied,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.5,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>win_authentication_failed,login_denied,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.5,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,</group>
   </rule>
 
   <rule id="18135" level="5">
@@ -243,7 +243,7 @@
     <id>^534$</id>
     <description>Windows: Logon Failure - User not granted logon type.</description>
     <info type="link">https://www.ultimatewindowssecurity.com/securitylog/encyclopedia/event.aspx?eventid=534</info>
-    <group>win_authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.5,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>win_authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.5,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,</group>
   </rule>
 
   <rule id="18136" level="5">
@@ -251,28 +251,28 @@
     <id>^535$</id>
     <description>Windows: Logon Failure - Account's password expired.</description>
     <info type="link">https://www.ultimatewindowssecurity.com/securitylog/encyclopedia/event.aspx?eventid=535</info>
-    <group>win_authentication_failed,pci_dss_10.2.5,pci_dss_8.2.4,gpg13_7.5,gdpr_IV_32.2,hipaa_164.312.b,hipaa_164.312.d,nist_800_53_AU.3.1,nist_800_53_IA.10,nist_800_53_IA.5,</group>
+    <group>win_authentication_failed,pci_dss_10.2.5,pci_dss_8.2.4,gpg13_7.5,gdpr_IV_32.2,hipaa_164.312.b,hipaa_164.312.d,nist_800_53_IA.10,nist_800_53_AC.7,nist_800_53_IA.5,</group>
   </rule>
 
   <rule id="18137" level="5">
     <if_sid>18106</if_sid>
     <id>^536$|^537$</id>
     <description>Windows: Logon Failure - Internal error.</description>
-    <group>win_authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>win_authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,</group>
   </rule>
 
   <rule id="18138" level="7">
     <if_sid>18106</if_sid>
     <id>^539$</id>
     <description>Windows: Logon Failure - Account locked out.</description>
-    <group>win_authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_8.1.6,gpg13_7.5,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,hipaa_164.312.a.1,nist_800_53_AU.3.1,nist_800_53_IA.10,nist_800_53_AC.7,</group>
+    <group>win_authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_8.1.6,gpg13_7.5,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,hipaa_164.312.a.1,nist_800_53_IA.10,nist_800_53_AC.7,nist_800_53_AC.7,</group>
   </rule>
 
   <rule id="18139" level="5">
     <if_sid>18105</if_sid>
     <id>^673$|^675$|^681$|^4769$</id>
     <description>Windows DC Logon Failure.</description>
-    <group>win_authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>win_authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,</group>
   </rule>
 
   <rule id="18140" level="5">
@@ -295,21 +295,21 @@
     <id>^671$|^4767$</id>
     <description>Windows: User account unlocked.</description>
     <info type="link">https://www.ultimatewindowssecurity.com/securitylog/encyclopedia/event.aspx?eventID=4767</info>
-    <group>account_changed,pci_dss_10.2.5,pci_dss_8.1.6,gpg13_7.10,gdpr_IV_32.2,hipaa_164.312.b,hipaa_164.312.a.1,nist_800_53_AU.3.1,nist_800_53_IA.10,nist_800_53_AC.7,</group>
+    <group>account_changed,pci_dss_10.2.5,pci_dss_8.1.6,gpg13_7.10,gdpr_IV_32.2,hipaa_164.312.b,hipaa_164.312.a.1,nist_800_53_IA.10,nist_800_53_AC.7,nist_800_53_AC.7,</group>
   </rule>
 
   <rule id="18143" level="8">
     <if_sid>18114</if_sid>
     <id>^631$|^635$|^658$</id>
     <description>Windows: Security enabled group created.</description>
-    <group>adduser,account_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.a.2.I,hipaa_164.312.a.2.II,hipaa_164.312.b,nist_800_53_AC.2,nist_800_53_IA.4,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>adduser,account_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.a.2.I,hipaa_164.312.a.2.II,hipaa_164.312.b,nist_800_53_AC.2,nist_800_53_IA.4,nist_800_53_IA.10,nist_800_53_AC.7,</group>
   </rule>
 
   <rule id="18144" level="8">
     <if_sid>18114</if_sid>
     <id>^634$|^638$|^662$</id>
     <description>Windows: Security enabled group deleted.</description>
-    <group>adduser,account_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.a.2.I,hipaa_164.312.a.2.II,hipaa_164.312.b,nist_800_53_AC.2,nist_800_53_IA.4,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>adduser,account_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.a.2.I,hipaa_164.312.a.2.II,hipaa_164.312.b,nist_800_53_AC.2,nist_800_53_IA.4,nist_800_53_IA.10,nist_800_53_AC.7,</group>
   </rule>
 
   <!-- Some services change their startup type automatically -->
@@ -345,7 +345,7 @@
     <if_sid>18104</if_sid>
     <id>^538$|^551$|^4634$|^4647$</id>
     <description>Windows User Logoff.</description>
-    <group>pci_dss_10.2.5,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>pci_dss_10.2.5,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,</group>
   </rule>
 
 <!-- Granular group rules -->
@@ -355,7 +355,7 @@
     <id>^631$|^4727$|^635$|^4731$|^658$|^4754$|^648$|^4744$|^653$|^4749$|</id>
     <id>^663$|^4759$</id>
     <description>Windows: Group Account Created</description>
-    <group>group_created,win_group_created,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.a.2.I,hipaa_164.312.a.2.II,hipaa_164.312.b,nist_800_53_AC.2,nist_800_53_IA.4,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>group_created,win_group_created,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.a.2.I,hipaa_164.312.a.2.II,hipaa_164.312.b,nist_800_53_AC.2,nist_800_53_IA.4,nist_800_53_IA.10,nist_800_53_AC.7,</group>
   </rule>
 
   <rule id="18201" level="5">
@@ -363,14 +363,14 @@
     <id>^634$|^4730$|^638$|^4734$|^662$|^4758$|^652$|^4748$|^657$|^4753$|</id>
     <id>^667$|^4763$</id>
     <description>Windows: Group Account Deleted</description>
-    <group>group_deleted,win_group_deleted,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.a.2.I,hipaa_164.312.a.2.II,hipaa_164.312.b,nist_800_53_AC.2,nist_800_53_IA.4,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>group_deleted,win_group_deleted,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.a.2.I,hipaa_164.312.a.2.II,hipaa_164.312.b,nist_800_53_AC.2,nist_800_53_IA.4,nist_800_53_IA.10,nist_800_53_AC.7,</group>
   </rule>
 
   <rule id="18202" level="5">
     <if_sid>18200</if_sid>
     <id>^631$|^4727$</id>
     <description>Windows: Security Enabled Global Group Created</description>
-    <group>group_created,win_group_created,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.a.2.I,hipaa_164.312.a.2.II,hipaa_164.312.b,nist_800_53_AC.2,nist_800_53_IA.4,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>group_created,win_group_created,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.a.2.I,hipaa_164.312.a.2.II,hipaa_164.312.b,nist_800_53_AC.2,nist_800_53_IA.4,nist_800_53_IA.10,nist_800_53_AC.7,</group>
     <info type="link">https://www.ultimatewindowssecurity.com/securitylog/encyclopedia/event.aspx?eventid=631</info>
   </rule>
 
@@ -378,7 +378,7 @@
     <if_sid>18114</if_sid>
     <id>^632$|^4728$</id>
     <description>Windows: Security Enabled Global Group Member Added</description>
-    <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.a.2.I,hipaa_164.312.a.2.II,hipaa_164.312.b,nist_800_53_AC.2,nist_800_53_IA.4,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.a.2.I,hipaa_164.312.a.2.II,hipaa_164.312.b,nist_800_53_AC.2,nist_800_53_IA.4,nist_800_53_IA.10,nist_800_53_AC.7,</group>
     <info type="link">https://www.ultimatewindowssecurity.com/securitylog/encyclopedia/event.aspx?eventid=632</info>
   </rule>
 
@@ -386,7 +386,7 @@
     <if_sid>18114</if_sid>
     <id>^633$|^4729$</id>
     <description>Windows: Security Enabled Global Group Member Removed</description>
-    <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.a.2.I,hipaa_164.312.a.2.II,hipaa_164.312.b,nist_800_53_AC.2,nist_800_53_IA.4,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.a.2.I,hipaa_164.312.a.2.II,hipaa_164.312.b,nist_800_53_AC.2,nist_800_53_IA.4,nist_800_53_IA.10,nist_800_53_AC.7,</group>
     <info type="link">https://www.ultimatewindowssecurity.com/securitylog/encyclopedia/event.aspx?eventid=633</info>
   </rule>
 
@@ -394,7 +394,7 @@
     <if_sid>18201</if_sid>
     <id>^634$|^4730$</id>
     <description>Windows: Security Enabled Global Group Deleted</description>
-    <group>group_deleted,win_group_deleted,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.a.2.I,hipaa_164.312.a.2.II,hipaa_164.312.b,nist_800_53_AC.2,nist_800_53_IA.4,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>group_deleted,win_group_deleted,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.a.2.I,hipaa_164.312.a.2.II,hipaa_164.312.b,nist_800_53_AC.2,nist_800_53_IA.4,nist_800_53_IA.10,nist_800_53_AC.7,</group>
     <info type="link">https://www.ultimatewindowssecurity.com/securitylog/encyclopedia/event.aspx?eventid=634</info>
   </rule>
 
@@ -402,7 +402,7 @@
     <if_sid>18200</if_sid>
     <id>^635$|^4731$</id>
     <description>Windows: Security Enabled Local Group Created</description>
-    <group>group_created,win_group_created,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.a.2.I,hipaa_164.312.a.2.II,hipaa_164.312.b,nist_800_53_AC.2,nist_800_53_IA.4,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>group_created,win_group_created,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.a.2.I,hipaa_164.312.a.2.II,hipaa_164.312.b,nist_800_53_AC.2,nist_800_53_IA.4,nist_800_53_IA.10,nist_800_53_AC.7,</group>
     <info type="link">https://www.ultimatewindowssecurity.com/securitylog/encyclopedia/event.aspx?eventid=635</info>
   </rule>
 
@@ -410,7 +410,7 @@
     <if_sid>18114</if_sid>
     <id>^636$|^4732$</id>
     <description>Windows: Security Enabled Local Group Member Added</description>
-   <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.a.2.I,hipaa_164.312.a.2.II,hipaa_164.312.b,nist_800_53_AC.2,nist_800_53_IA.4,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+   <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.a.2.I,hipaa_164.312.a.2.II,hipaa_164.312.b,nist_800_53_AC.2,nist_800_53_IA.4,nist_800_53_IA.10,nist_800_53_AC.7,</group>
     <info type="link">https://www.ultimatewindowssecurity.com/securitylog/encyclopedia/event.aspx?eventid=636</info>
   </rule>
 
@@ -418,7 +418,7 @@
     <if_sid>18114</if_sid>
     <id>^637$|^4733$</id>
     <description>Windows: Security Enabled Local Group Member Removed</description>
-    <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.a.2.I,hipaa_164.312.a.2.II,hipaa_164.312.b,nist_800_53_AC.2,nist_800_53_IA.4,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.a.2.I,hipaa_164.312.a.2.II,hipaa_164.312.b,nist_800_53_AC.2,nist_800_53_IA.4,nist_800_53_IA.10,nist_800_53_AC.7,</group>
     <info type="link">https://www.ultimatewindowssecurity.com/securitylog/encyclopedia/event.aspx?eventid=637</info>
   </rule>
 
@@ -426,7 +426,7 @@
     <if_sid>18201</if_sid>
     <id>^638$|^4734$</id>
     <description>Windows: Security Enabled Local Group Deleted</description>
-    <group>group_deleted,win_group_deleted,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.a.2.I,hipaa_164.312.a.2.II,hipaa_164.312.b,nist_800_53_AC.2,nist_800_53_IA.4,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>group_deleted,win_group_deleted,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.a.2.I,hipaa_164.312.a.2.II,hipaa_164.312.b,nist_800_53_AC.2,nist_800_53_IA.4,nist_800_53_IA.10,nist_800_53_AC.7,</group>
     <info type="link">https://www.ultimatewindowssecurity.com/securitylog/encyclopedia/event.aspx?eventid=638</info>
   </rule>
 
@@ -434,7 +434,7 @@
     <if_sid>18114</if_sid>
     <id>^639$|^4735$</id>
     <description>Windows: Security Enabled Local Group Changed</description>
-    <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.a.2.I,hipaa_164.312.a.2.II,hipaa_164.312.b,nist_800_53_AC.2,nist_800_53_IA.4,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.a.2.I,hipaa_164.312.a.2.II,hipaa_164.312.b,nist_800_53_AC.2,nist_800_53_IA.4,nist_800_53_IA.10,nist_800_53_AC.7,</group>
     <info type="link">https://www.ultimatewindowssecurity.com/securitylog/encyclopedia/event.aspx?eventid=639</info>
   </rule>
 
@@ -442,7 +442,7 @@
     <if_sid>18114</if_sid>
     <id>^641$|^4737$</id>
     <description>Windows: Security Enabled Global Group Changed</description>
-    <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.a.2.I,hipaa_164.312.a.2.II,hipaa_164.312.b,nist_800_53_AC.2,nist_800_53_IA.4,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.a.2.I,hipaa_164.312.a.2.II,hipaa_164.312.b,nist_800_53_AC.2,nist_800_53_IA.4,nist_800_53_IA.10,nist_800_53_AC.7,</group>
     <info type="link">https://www.ultimatewindowssecurity.com/securitylog/encyclopedia/event.aspx?eventid=641</info>
   </rule>
 
@@ -450,7 +450,7 @@
     <if_sid>18200</if_sid>
     <id>^658$|^4754$</id>
     <description>Windows: Security Enabled Universal Group Created</description>
-    <group>group_created,win_group_created,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.a.2.I,hipaa_164.312.a.2.II,hipaa_164.312.b,nist_800_53_AC.2,nist_800_53_IA.4,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>group_created,win_group_created,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.a.2.I,hipaa_164.312.a.2.II,hipaa_164.312.b,nist_800_53_AC.2,nist_800_53_IA.4,nist_800_53_IA.10,nist_800_53_AC.7,</group>
     <info type="link">https://www.ultimatewindowssecurity.com/securitylog/encyclopedia/event.aspx?eventid=658</info>
   </rule>
 
@@ -458,7 +458,7 @@
     <if_sid>18114</if_sid>
     <id>^659$|^4755$</id>
     <description>Windows: Security Enabled Universal Group Changed</description>
-    <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.a.2.I,hipaa_164.312.a.2.II,hipaa_164.312.b,nist_800_53_AC.2,nist_800_53_IA.4,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.a.2.I,hipaa_164.312.a.2.II,hipaa_164.312.b,nist_800_53_AC.2,nist_800_53_IA.4,nist_800_53_IA.10,nist_800_53_AC.7,</group>
     <info type="link">https://www.ultimatewindowssecurity.com/securitylog/encyclopedia/event.aspx?eventid=659</info>
   </rule>
 
@@ -466,7 +466,7 @@
     <if_sid>18114</if_sid>
     <id>^660$|^4756$</id>
     <description>Windows: Security Enabled Universal Group Member Added</description>
-    <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.a.2.I,hipaa_164.312.a.2.II,hipaa_164.312.b,nist_800_53_AC.2,nist_800_53_IA.4,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.a.2.I,hipaa_164.312.a.2.II,hipaa_164.312.b,nist_800_53_AC.2,nist_800_53_IA.4,nist_800_53_IA.10,nist_800_53_AC.7,</group>
     <info type="link">https://www.ultimatewindowssecurity.com/securitylog/encyclopedia/event.aspx?eventid=660</info>
   </rule>
 
@@ -474,7 +474,7 @@
     <if_sid>18114</if_sid>
     <id>^661$|^4757$</id>
     <description>Windows: Security Enabled Universal Group Member Removed</description>
-    <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.a.2.I,hipaa_164.312.a.2.II,hipaa_164.312.b,nist_800_53_AC.2,nist_800_53_IA.4,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.a.2.I,hipaa_164.312.a.2.II,hipaa_164.312.b,nist_800_53_AC.2,nist_800_53_IA.4,nist_800_53_IA.10,nist_800_53_AC.7,</group>
     <info type="link">https://www.ultimatewindowssecurity.com/securitylog/encyclopedia/event.aspx?eventid=661</info>
   </rule>
 
@@ -482,7 +482,7 @@
     <if_sid>18201</if_sid>
     <id>^662$|^4758$</id>
     <description>Windows: Security Enabled Universal Group Deleted</description>
-    <group>group_deleted,win_group_deleted,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.a.2.I,hipaa_164.312.a.2.II,hipaa_164.312.b,nist_800_53_AC.2,nist_800_53_IA.4,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>group_deleted,win_group_deleted,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.a.2.I,hipaa_164.312.a.2.II,hipaa_164.312.b,nist_800_53_AC.2,nist_800_53_IA.4,nist_800_53_IA.10,nist_800_53_AC.7,</group>
     <info type="link">https://www.ultimatewindowssecurity.com/securitylog/encyclopedia/event.aspx?eventid=662</info>
   </rule>
 
@@ -490,7 +490,7 @@
     <if_sid>18207,18208</if_sid>
     <regex> ID:\s+\p*S-1-5-32-544\s</regex>
     <description>Windows: Administrators Group Changed</description>
-    <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.a.2.I,hipaa_164.312.a.2.II,hipaa_164.312.b,nist_800_53_AC.2,nist_800_53_IA.4,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.a.2.I,hipaa_164.312.a.2.II,hipaa_164.312.b,nist_800_53_AC.2,nist_800_53_IA.4,nist_800_53_IA.10,nist_800_53_AC.7,</group>
     <info type="link">https://support.microsoft.com/kb/243330</info>
   </rule>
 
@@ -498,7 +498,7 @@
     <if_sid>18207,18208</if_sid>
     <regex> ID:\s+%{S-1-1-0}| ID:\s+S-1-1-0\s</regex>
     <description>Windows: Everyone Group Changed</description>
-    <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.a.2.I,hipaa_164.312.a.2.II,hipaa_164.312.b,nist_800_53_AC.2,nist_800_53_IA.4,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.a.2.I,hipaa_164.312.a.2.II,hipaa_164.312.b,nist_800_53_AC.2,nist_800_53_IA.4,nist_800_53_IA.10,nist_800_53_AC.7,</group>
     <info type="link">https://support.microsoft.com/kb/243330</info>
   </rule>
 
@@ -506,7 +506,7 @@
     <if_sid>18207,18208</if_sid>
     <regex> ID:\s+%{S-1-5-9}| ID:\s+S-1-5-9\s</regex>
     <description>Windows: Enterprise Domain Controllers Group Changed</description>
-    <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.a.2.I,hipaa_164.312.a.2.II,hipaa_164.312.b,nist_800_53_AC.2,nist_800_53_IA.4,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.a.2.I,hipaa_164.312.a.2.II,hipaa_164.312.b,nist_800_53_AC.2,nist_800_53_IA.4,nist_800_53_IA.10,nist_800_53_AC.7,</group>
     <info type="link">https://support.microsoft.com/kb/243330</info>
   </rule>
 
@@ -514,7 +514,7 @@
     <if_sid>18207,18208</if_sid>
     <regex> ID:\s+%{S-1-5-11}| ID:\s+S-1-5-11\s</regex>
     <description>Windows: Authenticated Users Group Changed</description>
-    <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.a.2.I,hipaa_164.312.a.2.II,hipaa_164.312.b,nist_800_53_AC.2,nist_800_53_IA.4,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.a.2.I,hipaa_164.312.a.2.II,hipaa_164.312.b,nist_800_53_AC.2,nist_800_53_IA.4,nist_800_53_IA.10,nist_800_53_AC.7,</group>
     <info type="link">https://support.microsoft.com/kb/243330</info>
   </rule>
 
@@ -522,7 +522,7 @@
     <if_sid>18207,18208</if_sid>
     <regex> ID:\s+%{S-1-5-13}| ID:\s+S-1-5-13\s</regex>
     <description>Windows: Terminal Server Users Group Changed</description>
-    <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.a.2.I,hipaa_164.312.a.2.II,hipaa_164.312.b,nist_800_53_AC.2,nist_800_53_IA.4,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.a.2.I,hipaa_164.312.a.2.II,hipaa_164.312.b,nist_800_53_AC.2,nist_800_53_IA.4,nist_800_53_IA.10,nist_800_53_AC.7,</group>
     <info type="link">https://support.microsoft.com/kb/243330</info>
   </rule>
 
@@ -530,7 +530,7 @@
     <if_sid>18203,18204</if_sid>
     <regex> ID:\s+%{S-1-5-21\S+-512}| ID:\s+S-1-5-21\S+-512\s</regex>
     <description>Windows: Domain Admins Group Changed</description>
-    <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.a.2.I,hipaa_164.312.a.2.II,hipaa_164.312.b,nist_800_53_AC.2,nist_800_53_IA.4,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.a.2.I,hipaa_164.312.a.2.II,hipaa_164.312.b,nist_800_53_AC.2,nist_800_53_IA.4,nist_800_53_IA.10,nist_800_53_AC.7,</group>
     <info type="link">https://support.microsoft.com/kb/243330</info>
   </rule>
 
@@ -538,7 +538,7 @@
     <if_sid>18203,18204</if_sid>
     <regex> ID:\s+%{S-1-5-21\S+-513}| ID:\s+S-1-5-21\S+-513\s</regex>
     <description>Windows: Domain Users Group Changed</description>
-    <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.a.2.I,hipaa_164.312.a.2.II,hipaa_164.312.b,nist_800_53_AC.2,nist_800_53_IA.4,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.a.2.I,hipaa_164.312.a.2.II,hipaa_164.312.b,nist_800_53_AC.2,nist_800_53_IA.4,nist_800_53_IA.10,nist_800_53_AC.7,</group>
     <info type="link">https://support.microsoft.com/kb/243330</info>
   </rule>
 
@@ -553,7 +553,7 @@
     <if_sid>18203,18204</if_sid>
     <regex> ID:\s+%{S-1-5-21\S+-514}| ID:\s+S-1-5-21\S+-514\s</regex>
     <description>Windows: Domain Guests Group Changed</description>
-    <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.a.2.I,hipaa_164.312.a.2.II,hipaa_164.312.b,nist_800_53_AC.2,nist_800_53_IA.4,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.a.2.I,hipaa_164.312.a.2.II,hipaa_164.312.b,nist_800_53_AC.2,nist_800_53_IA.4,nist_800_53_IA.10,nist_800_53_AC.7,</group>
     <info type="link">https://support.microsoft.com/kb/243330</info>
   </rule>
 
@@ -561,7 +561,7 @@
     <if_sid>18203,18204</if_sid>
     <regex> ID:\s+%{S-1-5-21\S+-515}| ID:\s+S-1-5-21\S+-515\s</regex>
     <description>Windows: Domain Computers Group Changed</description>
-    <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.a.2.I,hipaa_164.312.a.2.II,hipaa_164.312.b,nist_800_53_AC.2,nist_800_53_IA.4,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.a.2.I,hipaa_164.312.a.2.II,hipaa_164.312.b,nist_800_53_AC.2,nist_800_53_IA.4,nist_800_53_IA.10,nist_800_53_AC.7,</group>
     <info type="link">https://support.microsoft.com/kb/243330</info>
   </rule>
 
@@ -569,7 +569,7 @@
     <if_sid>18203,18204</if_sid>
     <regex> ID:\s+%{S-1-5-21\S+-516}| ID:\s+S-1-5-21\S+-516\s</regex>
     <description>Windows: Domain Controllers Group Changed</description>
-    <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.a.2.I,hipaa_164.312.a.2.II,hipaa_164.312.b,nist_800_53_AC.2,nist_800_53_IA.4,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.a.2.I,hipaa_164.312.a.2.II,hipaa_164.312.b,nist_800_53_AC.2,nist_800_53_IA.4,nist_800_53_IA.10,nist_800_53_AC.7,</group>
     <info type="link">https://support.microsoft.com/kb/243330</info>
   </rule>
 
@@ -577,7 +577,7 @@
     <if_sid>18207,18208</if_sid>
     <regex> ID:\s+%{S-1-5-21\S+-517}| ID:\s+S-1-5-21\S+-517\s</regex>
     <description>Windows: Cert Publishers Group Changed</description>
-    <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.a.2.I,hipaa_164.312.a.2.II,hipaa_164.312.b,nist_800_53_AC.2,nist_800_53_IA.4,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.a.2.I,hipaa_164.312.a.2.II,hipaa_164.312.b,nist_800_53_AC.2,nist_800_53_IA.4,nist_800_53_IA.10,nist_800_53_AC.7,</group>
     <info type="link">https://support.microsoft.com/kb/243330</info>
   </rule>
 
@@ -585,7 +585,7 @@
     <if_sid>18203,18204</if_sid>
     <regex> ID:\s+%{S-1-5-21\.+-518}| ID:\s+S-1-5-21\.+-518\s</regex>
     <description>Windows: Schema Admins Group Changed</description>
-    <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.a.2.I,hipaa_164.312.a.2.II,hipaa_164.312.b,nist_800_53_AC.2,nist_800_53_IA.4,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.a.2.I,hipaa_164.312.a.2.II,hipaa_164.312.b,nist_800_53_AC.2,nist_800_53_IA.4,nist_800_53_IA.10,nist_800_53_AC.7,</group>
     <info type="link">https://support.microsoft.com/kb/243330</info>
   </rule>
 
@@ -593,7 +593,7 @@
     <if_sid>18213,18214</if_sid>
     <regex> ID:\s+%{S-1-5-21\S+-519}| ID:\s+S-1-5-21\S+-519\s</regex>
     <description>Windows: Enterprise Admins Group Changed</description>
-    <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.a.2.I,hipaa_164.312.a.2.II,hipaa_164.312.b,nist_800_53_AC.2,nist_800_53_IA.4,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.a.2.I,hipaa_164.312.a.2.II,hipaa_164.312.b,nist_800_53_AC.2,nist_800_53_IA.4,nist_800_53_IA.10,nist_800_53_AC.7,</group>
     <info type="link">https://support.microsoft.com/kb/243330</info>
   </rule>
 
@@ -601,7 +601,7 @@
     <if_sid>18203,18204</if_sid>
     <regex> ID:\s+%{S-1-5-21\S+-520}| ID:\s+S-1-5-21\S+-520\s</regex>
     <description>Windows: Group Policy Creator Owners Group Changed</description>
-    <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.a.2.I,hipaa_164.312.a.2.II,hipaa_164.312.b,nist_800_53_AC.2,nist_800_53_IA.4,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.a.2.I,hipaa_164.312.a.2.II,hipaa_164.312.b,nist_800_53_AC.2,nist_800_53_IA.4,nist_800_53_IA.10,nist_800_53_AC.7,</group>
     <info type="link">https://support.microsoft.com/kb/243330</info>
   </rule>
 
@@ -609,7 +609,7 @@
     <if_sid>18207,18208</if_sid>
     <regex> ID:\s+%{S-1-5-21\S+-553}| ID:\s+S-1-5-21\S+-553\s</regex>
     <description>Windows: RAS and IAS Servers Group Changed</description>
-    <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.a.2.I,hipaa_164.312.a.2.II,hipaa_164.312.b,nist_800_53_AC.2,nist_800_53_IA.4,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.a.2.I,hipaa_164.312.a.2.II,hipaa_164.312.b,nist_800_53_AC.2,nist_800_53_IA.4,nist_800_53_IA.10,nist_800_53_AC.7,</group>
     <info type="link">https://support.microsoft.com/kb/243330</info>
   </rule>
 
@@ -617,7 +617,7 @@
     <if_sid>18207,18208</if_sid>
     <regex> ID:\s+%{S-1-5-32-545}| ID:\s+S-1-5-32-545\s</regex>
     <description>Windows: Users Group Changed</description>
-    <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.a.2.I,hipaa_164.312.a.2.II,hipaa_164.312.b,nist_800_53_AC.2,nist_800_53_IA.4,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.a.2.I,hipaa_164.312.a.2.II,hipaa_164.312.b,nist_800_53_AC.2,nist_800_53_IA.4,nist_800_53_IA.10,nist_800_53_AC.7,</group>
     <info type="link">https://support.microsoft.com/kb/243330</info>
   </rule>
 
@@ -625,7 +625,7 @@
     <if_sid>18207,18208</if_sid>
     <regex> ID:\s+%{S-1-5-32-546}| ID:\s+S-1-5-32-546\s</regex>
     <description>Windows: Guests Group Changed</description>
-    <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.a.2.I,hipaa_164.312.a.2.II,hipaa_164.312.b,nist_800_53_AC.2,nist_800_53_IA.4,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.a.2.I,hipaa_164.312.a.2.II,hipaa_164.312.b,nist_800_53_AC.2,nist_800_53_IA.4,nist_800_53_IA.10,nist_800_53_AC.7,</group>
     <info type="link">https://support.microsoft.com/kb/243330</info>
   </rule>
 
@@ -633,7 +633,7 @@
     <if_sid>18207,18208</if_sid>
     <regex> ID:\s+%{S-1-5-32-547}| ID:\s+S-1-5-32-547\s</regex>
     <description>Windows: Power Users Group Changed</description>
-    <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.a.2.I,hipaa_164.312.a.2.II,hipaa_164.312.b,nist_800_53_AC.2,nist_800_53_IA.4,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.a.2.I,hipaa_164.312.a.2.II,hipaa_164.312.b,nist_800_53_AC.2,nist_800_53_IA.4,nist_800_53_IA.10,nist_800_53_AC.7,</group>
     <info type="link">https://support.microsoft.com/kb/243330</info>
   </rule>
 
@@ -641,7 +641,7 @@
     <if_sid>18207,18208</if_sid>
     <regex> ID:\s+%{S-1-5-32-548}| ID:\s+S-1-5-32-548\s</regex>
     <description>Windows: Account Operators Group Changed</description>
-    <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.a.2.I,hipaa_164.312.a.2.II,hipaa_164.312.b,nist_800_53_AC.2,nist_800_53_IA.4,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.a.2.I,hipaa_164.312.a.2.II,hipaa_164.312.b,nist_800_53_AC.2,nist_800_53_IA.4,nist_800_53_IA.10,nist_800_53_AC.7,</group>
     <info type="link">https://support.microsoft.com/kb/243330</info>
   </rule>
 
@@ -649,7 +649,7 @@
     <if_sid>18207,18208</if_sid>
     <regex> ID:\s+%{S-1-5-32-549}| ID:\s+S-1-5-32-549\s</regex>
     <description>Windows: Server Operators Group Changed</description>
-    <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.a.2.I,hipaa_164.312.a.2.II,hipaa_164.312.b,nist_800_53_AC.2,nist_800_53_IA.4,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.a.2.I,hipaa_164.312.a.2.II,hipaa_164.312.b,nist_800_53_AC.2,nist_800_53_IA.4,nist_800_53_IA.10,nist_800_53_AC.7,</group>
     <info type="link">https://support.microsoft.com/kb/243330</info>
   </rule>
 
@@ -657,7 +657,7 @@
     <if_sid>18207,18208</if_sid>
     <regex> ID:\s+%{S-1-5-32-550}| ID:\s+S-1-5-32-550\s</regex>
     <description>Windows: Print Operators Group Changed</description>
-    <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.a.2.I,hipaa_164.312.a.2.II,hipaa_164.312.b,nist_800_53_AC.2,nist_800_53_IA.4,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.a.2.I,hipaa_164.312.a.2.II,hipaa_164.312.b,nist_800_53_AC.2,nist_800_53_IA.4,nist_800_53_IA.10,nist_800_53_AC.7,</group>
     <info type="link">https://support.microsoft.com/kb/243330</info>
   </rule>
 
@@ -665,7 +665,7 @@
     <if_sid>18207,18208</if_sid>
     <regex> ID:\s+%{S-1-5-32-551}| ID:\s+S-1-5-32-551\s</regex>
     <description>Windows: Backup Operators Group Changed</description>
-    <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.a.2.I,hipaa_164.312.a.2.II,hipaa_164.312.b,nist_800_53_AC.2,nist_800_53_IA.4,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.a.2.I,hipaa_164.312.a.2.II,hipaa_164.312.b,nist_800_53_AC.2,nist_800_53_IA.4,nist_800_53_IA.10,nist_800_53_AC.7,</group>
     <info type="link">https://support.microsoft.com/kb/243330</info>
   </rule>
 
@@ -673,7 +673,7 @@
     <if_sid>18207,18208</if_sid>
     <regex> ID:\s+%{S-1-5-32-552}| ID:\s+S-1-5-32-552\s</regex>
     <description>Windows: Replicators Group Changed</description>
-    <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.a.2.I,hipaa_164.312.a.2.II,hipaa_164.312.b,nist_800_53_AC.2,nist_800_53_IA.4,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.a.2.I,hipaa_164.312.a.2.II,hipaa_164.312.b,nist_800_53_AC.2,nist_800_53_IA.4,nist_800_53_IA.10,nist_800_53_AC.7,</group>
     <info type="link">https://support.microsoft.com/kb/243330</info>
   </rule>
 
@@ -681,7 +681,7 @@
     <if_sid>18207,18208</if_sid>
     <regex> ID:\s+%{S-1-5-32-554}| ID:\s+S-1-5-32-554\s</regex>
     <description>Pre-Windows 2000 Compatible Access Group Changed</description>
-    <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.a.2.I,hipaa_164.312.a.2.II,hipaa_164.312.b,nist_800_53_AC.2,nist_800_53_IA.4,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.a.2.I,hipaa_164.312.a.2.II,hipaa_164.312.b,nist_800_53_AC.2,nist_800_53_IA.4,nist_800_53_IA.10,nist_800_53_AC.7,</group>
     <info type="link">https://support.microsoft.com/kb/243330</info>
   </rule>
 
@@ -689,7 +689,7 @@
     <if_sid>18207,18208</if_sid>
     <regex> ID:\s+%{S-1-5-32-555}| ID:\s+S-1-5-32-555\s</regex>
     <description>Windows: Remote Desktop Users Group Changed</description>
-    <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.a.2.I,hipaa_164.312.a.2.II,hipaa_164.312.b,nist_800_53_AC.2,nist_800_53_IA.4,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.a.2.I,hipaa_164.312.a.2.II,hipaa_164.312.b,nist_800_53_AC.2,nist_800_53_IA.4,nist_800_53_IA.10,nist_800_53_AC.7,</group>
     <info type="link">https://support.microsoft.com/kb/243330</info>
   </rule>
 
@@ -697,7 +697,7 @@
     <if_sid>18207,18208</if_sid>
     <regex> ID:\s+%{S-1-5-32-556}| ID:\s+S-1-5-32-556\s</regex>
     <description>Windows: Network Configuration Operators Group Changed</description>
-    <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.a.2.I,hipaa_164.312.a.2.II,hipaa_164.312.b,nist_800_53_AC.2,nist_800_53_IA.4,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.a.2.I,hipaa_164.312.a.2.II,hipaa_164.312.b,nist_800_53_AC.2,nist_800_53_IA.4,nist_800_53_IA.10,nist_800_53_AC.7,</group>
     <info type="link">https://support.microsoft.com/kb/243330</info>
   </rule>
 
@@ -705,7 +705,7 @@
     <if_sid>18207,18208</if_sid>
     <regex> ID:\s+%{S-1-5-32-557}| ID:\s+S-1-5-32-557\s</regex>
     <description>Windows: Incoming Forest Trust Builders Group Changed</description>
-    <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.a.2.I,hipaa_164.312.a.2.II,hipaa_164.312.b,nist_800_53_AC.2,nist_800_53_IA.4,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.a.2.I,hipaa_164.312.a.2.II,hipaa_164.312.b,nist_800_53_AC.2,nist_800_53_IA.4,nist_800_53_IA.10,nist_800_53_AC.7,</group>
     <info type="link">https://support.microsoft.com/kb/243330</info>
   </rule>
 
@@ -713,7 +713,7 @@
     <if_sid>18207,18208</if_sid>
     <regex> ID:\s+%{S-1-5-32-558}| ID:\s+S-1-5-32-558\s</regex>
     <description>Windows: Performance Monitor Users Group Changed</description>
-    <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.a.2.I,hipaa_164.312.a.2.II,hipaa_164.312.b,nist_800_53_AC.2,nist_800_53_IA.4,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.a.2.I,hipaa_164.312.a.2.II,hipaa_164.312.b,nist_800_53_AC.2,nist_800_53_IA.4,nist_800_53_IA.10,nist_800_53_AC.7,</group>
     <info type="link">https://support.microsoft.com/kb/243330</info>
   </rule>
 
@@ -721,7 +721,7 @@
     <if_sid>18207,18208</if_sid>
     <regex> ID:\s+%{S-1-5-32-559}| ID:\s+S-1-5-32-559\s</regex>
     <description>Windows: Performance Log Users Group Changed</description>
-    <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.a.2.I,hipaa_164.312.a.2.II,hipaa_164.312.b,nist_800_53_AC.2,nist_800_53_IA.4,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.a.2.I,hipaa_164.312.a.2.II,hipaa_164.312.b,nist_800_53_AC.2,nist_800_53_IA.4,nist_800_53_IA.10,nist_800_53_AC.7,</group>
     <info type="link">https://support.microsoft.com/kb/243330</info>
   </rule>
 
@@ -729,7 +729,7 @@
     <if_sid>18207,18208</if_sid>
     <regex> ID:\s+%{S-1-5-32-560}| ID:\s+S-1-5-32-560\s</regex>
     <description>Windows Authorization Access Group Changed</description>
-    <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.a.2.I,hipaa_164.312.a.2.II,hipaa_164.312.b,nist_800_53_AC.2,nist_800_53_IA.4,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.a.2.I,hipaa_164.312.a.2.II,hipaa_164.312.b,nist_800_53_AC.2,nist_800_53_IA.4,nist_800_53_IA.10,nist_800_53_AC.7,</group>
     <info type="link">https://support.microsoft.com/kb/243330</info>
   </rule>
 
@@ -737,7 +737,7 @@
     <if_sid>18207,18208</if_sid>
     <regex> ID:\s+%{S-1-5-32-561}| ID:\s+S-1-5-32-561\s</regex>
     <description>Windows: Terminal Server License Servers Group Changed</description>
-    <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.a.2.I,hipaa_164.312.a.2.II,hipaa_164.312.b,nist_800_53_AC.2,nist_800_53_IA.4,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.a.2.I,hipaa_164.312.a.2.II,hipaa_164.312.b,nist_800_53_AC.2,nist_800_53_IA.4,nist_800_53_IA.10,nist_800_53_AC.7,</group>
     <info type="link">https://support.microsoft.com/kb/243330</info>
   </rule>
 
@@ -745,7 +745,7 @@
     <if_sid>18207,18208</if_sid>
     <regex> ID:\s+%{S-1-5-32-562}| ID:\s+S-1-5-32-562\s</regex>
     <description>Windows: Distributed COM Users Group Changed</description>
-    <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.a.2.I,hipaa_164.312.a.2.II,hipaa_164.312.b,nist_800_53_AC.2,nist_800_53_IA.4,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.a.2.I,hipaa_164.312.a.2.II,hipaa_164.312.b,nist_800_53_AC.2,nist_800_53_IA.4,nist_800_53_IA.10,nist_800_53_AC.7,</group>
     <info type="link">https://support.microsoft.com/kb/243330</info>
   </rule>
 
@@ -753,7 +753,7 @@
     <if_sid>18207,18208</if_sid>
     <regex> ID:\s+%{S-1-5-\s*21\.+\s*-498}| ID:\s+S-1-5-\s*21\.+\s*-498\s</regex>
     <description>Windows: Enterprise Read-only Domain Controllers Group Changed</description>
-    <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.a.2.I,hipaa_164.312.a.2.II,hipaa_164.312.b,nist_800_53_AC.2,nist_800_53_IA.4,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.a.2.I,hipaa_164.312.a.2.II,hipaa_164.312.b,nist_800_53_AC.2,nist_800_53_IA.4,nist_800_53_IA.10,nist_800_53_AC.7,</group>
     <info type="link">https://support.microsoft.com/kb/243330</info>
   </rule>
 
@@ -761,7 +761,7 @@
     <if_sid>18207,18208</if_sid>
     <regex> ID:\s+%{S-1-5-\s*21\.+\s*-529}| ID:\s+S-1-5-\s*21\.+\s*-529\s</regex>
     <description>Windows: Read-only Domain Controllers Group Changed</description>
-    <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.a.2.I,hipaa_164.312.a.2.II,hipaa_164.312.b,nist_800_53_AC.2,nist_800_53_IA.4,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.a.2.I,hipaa_164.312.a.2.II,hipaa_164.312.b,nist_800_53_AC.2,nist_800_53_IA.4,nist_800_53_IA.10,nist_800_53_AC.7,</group>
     <info type="link">https://support.microsoft.com/kb/243330</info>
   </rule>
 
@@ -769,7 +769,7 @@
     <if_sid>18207,18208</if_sid>
     <regex> ID:\s+%{S-1-5-32-569}| ID:\s+S-1-5-32-569\s</regex>
     <description>Windows: Cryptographic Operators Group Changed</description>
-    <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.a.2.I,hipaa_164.312.a.2.II,hipaa_164.312.b,nist_800_53_AC.2,nist_800_53_IA.4,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.a.2.I,hipaa_164.312.a.2.II,hipaa_164.312.b,nist_800_53_AC.2,nist_800_53_IA.4,nist_800_53_IA.10,nist_800_53_AC.7,</group>
     <info type="link">https://support.microsoft.com/kb/243330</info>
   </rule>
 
@@ -777,7 +777,7 @@
     <if_sid>18207,18208</if_sid>
     <regex> ID:\s+%{S-1-5-\s*21\.+\s*-571}| ID:\s+S-1-5-\s*21\.+\s*-571\s</regex>
     <description>Windows: Allowed RODC Password Replication Group Changed</description>
-    <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.a.2.I,hipaa_164.312.a.2.II,hipaa_164.312.b,nist_800_53_AC.2,nist_800_53_IA.4,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.a.2.I,hipaa_164.312.a.2.II,hipaa_164.312.b,nist_800_53_AC.2,nist_800_53_IA.4,nist_800_53_IA.10,nist_800_53_AC.7,</group>
     <info type="link">https://support.microsoft.com/kb/243330</info>
   </rule>
 
@@ -785,7 +785,7 @@
     <if_sid>18207,18208</if_sid>
     <regex> ID:\s+%{S-1-5-\s*21\.+\s*-572}| ID:\s+S-1-5-\s*21\.+\s*-572\s</regex>
     <description>Windows: Denied RODC Password Replication Group Changed</description>
-    <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.a.2.I,hipaa_164.312.a.2.II,hipaa_164.312.b,nist_800_53_AC.2,nist_800_53_IA.4,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.a.2.I,hipaa_164.312.a.2.II,hipaa_164.312.b,nist_800_53_AC.2,nist_800_53_IA.4,nist_800_53_IA.10,nist_800_53_AC.7,</group>
     <info type="link">https://support.microsoft.com/kb/243330</info>
   </rule>
 
@@ -793,7 +793,7 @@
     <if_sid>18207,18208</if_sid>
     <regex> ID:\s+%{S-1-5-32-573}| ID:\s+S-1-5-32-573\s</regex>
     <description>Windows: Event Log Readers Group Changed</description>
-    <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.a.2.I,hipaa_164.312.a.2.II,hipaa_164.312.b,nist_800_53_AC.2,nist_800_53_IA.4,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.a.2.I,hipaa_164.312.a.2.II,hipaa_164.312.b,nist_800_53_AC.2,nist_800_53_IA.4,nist_800_53_IA.10,nist_800_53_AC.7,</group>
     <info type="link">https://support.microsoft.com/kb/243330</info>
   </rule>
 
@@ -801,7 +801,7 @@
     <if_sid>18207,18208</if_sid>
     <regex> ID:\s+%{S-1-5-32-574}| ID:\s+S-1-5-32-574\s</regex>
     <description>Windows: Certificate Service DCOM Access Group Changed</description>
-    <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.a.2.I,hipaa_164.312.a.2.II,hipaa_164.312.b,nist_800_53_AC.2,nist_800_53_IA.4,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.a.2.I,hipaa_164.312.a.2.II,hipaa_164.312.b,nist_800_53_AC.2,nist_800_53_IA.4,nist_800_53_IA.10,nist_800_53_AC.7,</group>
     <info type="link">https://support.microsoft.com/kb/243330</info>
   </rule>
 
@@ -810,7 +810,7 @@
     <if_sid>18101</if_sid>
     <id>^200$|^300$|^302$</id>
     <description>Windows: TS Gateway login success.</description>
-    <group>authentication_success,pci_dss_10.2.5,gpg13_7.1,gpg13_7.2,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>authentication_success,pci_dss_10.2.5,gpg13_7.1,gpg13_7.2,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,</group>
     <info type="link">https://technet.microsoft.com/en-us/library/cc775181(v=ws.10).aspx</info>
   </rule>
 
@@ -829,7 +829,7 @@
     <if_sid>18102, 18103</if_sid>
     <id>^201$|^203$|^204$|^301$|^304$|^305$|^306$|^1001$</id>
     <description>Windows: TS Gateway login failure.</description>
-    <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,</group>
     <info type="link">https://technet.microsoft.com/en-us/library/cc775181(v=ws.10).aspx</info>
   </rule>
 
@@ -850,7 +850,7 @@
     <id>^528$|^538$|^540$|^4624$</id>
     <user>^LOCAL SERVICE|^NETWORK SERVICE|^ANONYMOUS LOGON</user>
     <description>Windows Logon Success (ignored).</description>
-    <group>pci_dss_10.2.5,gpg13_7.1,gpg13_7.2,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>pci_dss_10.2.5,gpg13_7.1,gpg13_7.2,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,</group>
   </rule>
 
 
@@ -861,7 +861,7 @@
     <description>Windows DC integrity check on decrypted </description>
     <description>field failed.</description>
     <info type="link">https://web.mit.edu/kerberos/</info>
-    <group>win_authentication_failed,attacks,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,nist_800_53_SC.7,</group>
+    <group>win_authentication_failed,attacks,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,nist_800_53_IA.10,</group>
   </rule>
 
   <rule id="18171" level="10">
@@ -869,7 +869,7 @@
     <match>Failure Code: 0x22</match>
     <description>Windows DC - Possible replay attack.</description>
     <info type="link">https://web.mit.edu/kerberos/</info>
-    <group>win_authentication_failed,attacks,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,nist_800_53_SC.7,</group>
+    <group>win_authentication_failed,attacks,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,nist_800_53_IA.10,</group>
   </rule>
 
   <rule id="18172" level="7">
@@ -877,7 +877,7 @@
     <match>Failure Code: 0x25</match>
     <description>Windows DC - Clock skew too great.</description>
     <info type="link">https://web.mit.edu/kerberos/</info>
-    <group>win_authentication_failed,attacks,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,nist_800_53_SC.7,</group>
+    <group>win_authentication_failed,attacks,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,nist_800_53_IA.10,</group>
   </rule>
 
 
@@ -885,7 +885,7 @@
   <rule id="18180" level="5">
     <if_sid>18105</if_sid>
     <id>^18456$</id>
-    <group>win_authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>win_authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,</group>
     <description>MS SQL Server Logon Failure.</description>
   </rule>
 
@@ -893,7 +893,7 @@
     <if_sid>18104</if_sid>
     <id>^18454$|^18453$</id>
     <description>MS SQL Server Logon Success.</description>
-    <group>authentication_success,pci_dss_10.2.5,gpg13_7.1,gpg13_7.2,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>authentication_success,pci_dss_10.2.5,gpg13_7.1,gpg13_7.2,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,</group>
   </rule>
 
 <!-- Detail logon rules -->
@@ -902,7 +902,7 @@
     <id>^4624$</id>
     <match>Logon Type:   8</match>
     <description>MS Exchange Logon Success.</description>
-    <group>pci_dss_10.2.5,gpg13_7.1,gpg13_7.2,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>pci_dss_10.2.5,gpg13_7.1,gpg13_7.2,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,</group>
   </rule>
 
   <rule id="18261" level="0">
@@ -910,7 +910,7 @@
     <id>^4634$</id>
     <match>Logon Type:   8</match>
     <description>MS Exchange User Logoff.</description>
-    <group>pci_dss_10.2.5,gpg13_7.1,gpg13_7.2,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>pci_dss_10.2.5,gpg13_7.1,gpg13_7.2,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,</group>
   </rule>
 
 
@@ -919,14 +919,14 @@
     <if_matched_sid>18108</if_matched_sid>
     <same_user />
     <description>Windows: Multiple failed attempts to perform a privileged operation by the same user.</description>
-    <group>pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,nist_800_53_SC.7,</group>
+    <group>pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,nist_800_53_IA.10,</group>
   </rule>
 
   <rule id="18152" level="10" frequency="$MS_FREQ" timeframe="240">
     <if_matched_group>win_authentication_failed</if_matched_group>
     <same_source_ip />
     <description>Multiple Windows Logon Failures.</description>
-    <group>authentication_failures,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,nist_800_53_SC.7,</group>
+    <group>authentication_failures,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,nist_800_53_IA.10,</group>
   </rule>
 
   <rule id="18153" level="10" frequency="$MS_FREQ" timeframe="240">
@@ -949,13 +949,13 @@
   <rule id="18156" level="10" frequency="$MS_FREQ" timeframe="240">
     <if_matched_sid>18125</if_matched_sid>
     <description>Windows: Multiple remote access login failures.</description>
-    <group>authentication_failures,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,pci_dss_8.1.5,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,hipaa_164.312.a.1,nist_800_53_AU.3.1,nist_800_53_IA.10,nist_800_53_SC.7,nist_800_53_AC.2,</group>
+    <group>authentication_failures,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,pci_dss_8.1.5,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,hipaa_164.312.a.1,nist_800_53_IA.10,nist_800_53_AC.7,nist_800_53_IA.10,nist_800_53_AC.2,</group>
   </rule>
 
   <rule id="18157" level="10" frequency="$MS_FREQ" timeframe="240">
       <if_matched_sid>18258</if_matched_sid>
       <description>Windows: Multiple TS Gateway login failures.</description>
-      <group>authentication_failures,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,nist_800_53_SC.7,</group>
+      <group>authentication_failures,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,nist_800_53_IA.10,</group>
   </rule>
 
   <!--

--- a/rules/0220-msauth_rules.xml
+++ b/rules/0220-msauth_rules.xml
@@ -265,7 +265,7 @@
     <if_sid>18106</if_sid>
     <id>^539$</id>
     <description>Windows: Logon Failure - Account locked out.</description>
-    <group>win_authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_8.1.6,gpg13_7.5,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,hipaa_164.312.a.1,nist_800_53_IA.10,nist_800_53_AC.7,nist_800_53_AC.7,</group>
+    <group>win_authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_8.1.6,gpg13_7.5,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,hipaa_164.312.a.1,nist_800_53_IA.10,nist_800_53_AC.7,</group>
   </rule>
 
   <rule id="18139" level="5">
@@ -295,7 +295,7 @@
     <id>^671$|^4767$</id>
     <description>Windows: User account unlocked.</description>
     <info type="link">https://www.ultimatewindowssecurity.com/securitylog/encyclopedia/event.aspx?eventID=4767</info>
-    <group>account_changed,pci_dss_10.2.5,pci_dss_8.1.6,gpg13_7.10,gdpr_IV_32.2,hipaa_164.312.b,hipaa_164.312.a.1,nist_800_53_IA.10,nist_800_53_AC.7,nist_800_53_AC.7,</group>
+    <group>account_changed,pci_dss_10.2.5,pci_dss_8.1.6,gpg13_7.10,gdpr_IV_32.2,hipaa_164.312.b,hipaa_164.312.a.1,nist_800_53_IA.10,nist_800_53_AC.7,</group>
   </rule>
 
   <rule id="18143" level="8">
@@ -861,7 +861,7 @@
     <description>Windows DC integrity check on decrypted </description>
     <description>field failed.</description>
     <info type="link">https://web.mit.edu/kerberos/</info>
-    <group>win_authentication_failed,attacks,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,nist_800_53_IA.10,</group>
+    <group>win_authentication_failed,attacks,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,</group>
   </rule>
 
   <rule id="18171" level="10">
@@ -869,7 +869,7 @@
     <match>Failure Code: 0x22</match>
     <description>Windows DC - Possible replay attack.</description>
     <info type="link">https://web.mit.edu/kerberos/</info>
-    <group>win_authentication_failed,attacks,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,nist_800_53_IA.10,</group>
+    <group>win_authentication_failed,attacks,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,</group>
   </rule>
 
   <rule id="18172" level="7">
@@ -877,7 +877,7 @@
     <match>Failure Code: 0x25</match>
     <description>Windows DC - Clock skew too great.</description>
     <info type="link">https://web.mit.edu/kerberos/</info>
-    <group>win_authentication_failed,attacks,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,nist_800_53_IA.10,</group>
+    <group>win_authentication_failed,attacks,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,</group>
   </rule>
 
 
@@ -919,14 +919,14 @@
     <if_matched_sid>18108</if_matched_sid>
     <same_user />
     <description>Windows: Multiple failed attempts to perform a privileged operation by the same user.</description>
-    <group>pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,nist_800_53_IA.10,</group>
+    <group>pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,</group>
   </rule>
 
   <rule id="18152" level="10" frequency="$MS_FREQ" timeframe="240">
     <if_matched_group>win_authentication_failed</if_matched_group>
     <same_source_ip />
     <description>Multiple Windows Logon Failures.</description>
-    <group>authentication_failures,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,nist_800_53_IA.10,</group>
+    <group>authentication_failures,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,</group>
   </rule>
 
   <rule id="18153" level="10" frequency="$MS_FREQ" timeframe="240">
@@ -949,13 +949,13 @@
   <rule id="18156" level="10" frequency="$MS_FREQ" timeframe="240">
     <if_matched_sid>18125</if_matched_sid>
     <description>Windows: Multiple remote access login failures.</description>
-    <group>authentication_failures,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,pci_dss_8.1.5,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,hipaa_164.312.a.1,nist_800_53_IA.10,nist_800_53_AC.7,nist_800_53_IA.10,nist_800_53_AC.2,</group>
+    <group>authentication_failures,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,pci_dss_8.1.5,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,hipaa_164.312.a.1,nist_800_53_IA.10,nist_800_53_AC.7,nist_800_53_AC.2,</group>
   </rule>
 
   <rule id="18157" level="10" frequency="$MS_FREQ" timeframe="240">
       <if_matched_sid>18258</if_matched_sid>
       <description>Windows: Multiple TS Gateway login failures.</description>
-      <group>authentication_failures,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,nist_800_53_IA.10,</group>
+      <group>authentication_failures,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,</group>
   </rule>
 
   <!--

--- a/rules/0225-mcafee_av_rules.xml
+++ b/rules/0225-mcafee_av_rules.xml
@@ -45,21 +45,21 @@
   <rule id="7504" level="12">
     <if_sid>7500</if_sid>
     <regex>$MCAFEE_VIRUS</regex>
-    <group>virus,pci_dss_5.1,pci_dss_5.2,pci_dss_10.6.1,pci_dss_11.4,gpg13_4.2,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_SI.5,nist_800_53_AU.6,nist_800_53_SC.7,</group>
+    <group>virus,pci_dss_5.1,pci_dss_5.2,pci_dss_10.6.1,pci_dss_11.4,gpg13_4.2,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_SI.3,nist_800_53_AU.6,nist_800_53_IA.10,</group>
     <description>McAfee Windows AV - Virus detected and not removed.</description>
   </rule>
 
   <rule id="7505" level="7">
     <if_sid>7504</if_sid>
     <match>$MCAFEE_VIRUS_OK</match>
-    <group>virus,pci_dss_5.1,pci_dss_5.2,pci_dss_10.6.1,pci_dss_11.4,gpg13_4.2,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_SI.5,nist_800_53_AU.6,nist_800_53_SC.7,</group>
+    <group>virus,pci_dss_5.1,pci_dss_5.2,pci_dss_10.6.1,pci_dss_11.4,gpg13_4.2,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_SI.3,nist_800_53_AU.6,nist_800_53_IA.10,</group>
     <description>McAfee Windows AV - Virus detected and properly removed.</description>
   </rule>
 
   <rule id="7506" level="7">
     <if_sid>7504</if_sid>
     <match>Will be deleted</match>
-    <group>virus,pci_dss_5.1,pci_dss_5.2,pci_dss_10.6.1,pci_dss_11.4,gpg13_4.2,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_SI.5,nist_800_53_AU.6,nist_800_53_SC.7,</group>
+    <group>virus,pci_dss_5.1,pci_dss_5.2,pci_dss_10.6.1,pci_dss_11.4,gpg13_4.2,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_SI.3,nist_800_53_AU.6,nist_800_53_IA.10,</group>
     <description>McAfee Windows AV - Virus detected and file will be deleted.</description>
   </rule>
 
@@ -67,7 +67,7 @@
     <if_sid>7500</if_sid>
     <match>scan started|scan stopped</match>
     <description>McAfee Windows AV - Scan started or stopped.</description>
-    <group>pci_dss_5.1,pci_dss_10.2.6,pci_dss_10.6.1,gpg13_4.14,gpg13_10.1,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_SI.5,nist_800_53_AU.3.1,nist_800_53_IA.10,nist_800_53_AU.6,</group>
+    <group>pci_dss_5.1,pci_dss_10.2.6,pci_dss_10.6.1,gpg13_4.14,gpg13_10.1,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_SI.3,nist_800_53_IA.10,nist_800_53_AU.5,nist_800_53_AU.6,</group>
   </rule>
 
   <rule id="7508" level="3">
@@ -75,42 +75,42 @@
     <id>^257</id>
     <match>completed.  No detections</match>
     <description>McAfee Windows AV - Scan completed with no viruses found.</description>
-    <group>pci_dss_5.1,pci_dss_10.2.6,pci_dss_10.6.1,gpg13_4.14,gpg13_10.1,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_SI.5,nist_800_53_AU.3.1,nist_800_53_IA.10,nist_800_53_AU.6,</group>
+    <group>pci_dss_5.1,pci_dss_10.2.6,pci_dss_10.6.1,gpg13_4.14,gpg13_10.1,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_SI.3,nist_800_53_IA.10,nist_800_53_AU.5,nist_800_53_AU.6,</group>
   </rule>
 
   <rule id="7509" level="5">
     <if_sid>7500</if_sid>
     <match>scan was cancelled |has taken too long</match>
     <description>McAfee Windows AV - Virus scan cancelled.</description>
-    <group>pci_dss_5.1,pci_dss_10.2.6,pci_dss_10.6.1,gpg13_4.14,gpg13_10.1,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_SI.5,nist_800_53_AU.3.1,nist_800_53_IA.10,nist_800_53_AU.6,</group>
+    <group>pci_dss_5.1,pci_dss_10.2.6,pci_dss_10.6.1,gpg13_4.14,gpg13_10.1,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_SI.3,nist_800_53_IA.10,nist_800_53_AU.5,nist_800_53_AU.6,</group>
   </rule>
 
   <rule id="7510" level="5">
     <if_sid>7500</if_sid>
     <match>scan was canceled because</match>
     <description>McAfee Windows AV - Virus scan cancelled due to shutdown.</description>
-    <group>pci_dss_5.1,pci_dss_10.2.6,pci_dss_10.6.1,gpg13_4.14,gpg13_10.1,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_SI.5,nist_800_53_AU.3.1,nist_800_53_IA.10,nist_800_53_AU.6,</group>
+    <group>pci_dss_5.1,pci_dss_10.2.6,pci_dss_10.6.1,gpg13_4.14,gpg13_10.1,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_SI.3,nist_800_53_IA.10,nist_800_53_AU.5,nist_800_53_AU.6,</group>
   </rule>
 
   <rule id="7511" level="3">
     <if_sid>7500</if_sid>
     <match>update was successful</match>
     <description>McAfee Windows AV - Virus program or DAT update succeeded.</description>
-    <group>pci_dss_5.1,pci_dss_10.6.1,pci_dss_5.2,gpg13_4.4,gpg13_4.14,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_SI.5,nist_800_53_AU.6,</group>
+    <group>pci_dss_5.1,pci_dss_10.6.1,pci_dss_5.2,gpg13_4.4,gpg13_4.14,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_SI.3,nist_800_53_AU.6,</group>
   </rule>
 
   <rule id="07512" level="7">
     <if_sid>7500</if_sid>
     <match>update failed</match>
     <description>McAfee Windows AV - Virus program or DAT update failed.</description>
-    <group>pci_dss_5.1,pci_dss_10.6.1,pci_dss_5.2,gpg13_4.14,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_SI.5,nist_800_53_AU.6,</group>
+    <group>pci_dss_5.1,pci_dss_10.6.1,pci_dss_5.2,gpg13_4.14,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_SI.3,nist_800_53_AU.6,</group>
   </rule>
 
   <rule id="7513" level="7">
     <if_sid>7500</if_sid>
     <match>update was cancelled</match>
     <description>McAfee Windows AV - Virus program or DAT update cancelled.</description>
-    <group>pci_dss_5.1,pci_dss_10.6.1,pci_dss_5.2,gpg13_4.14,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_SI.5,nist_800_53_AU.6,</group>
+    <group>pci_dss_5.1,pci_dss_10.6.1,pci_dss_5.2,gpg13_4.14,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_SI.3,nist_800_53_AU.6,</group>
   </rule>
 
   <rule id="7514" level="5">
@@ -125,7 +125,7 @@
   <rule id="7550" level="10" frequency="$MCAFEE_FREQ" timeframe="240">
     <if_matched_sid>7502</if_matched_sid>
     <description>Multiple McAfee AV warning events.</description>
-    <group>pci_dss_5.1,pci_dss_10.6.1,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_SI.5,nist_800_53_AU.6,</group>
+    <group>pci_dss_5.1,pci_dss_10.6.1,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_SI.3,nist_800_53_AU.6,</group>
   </rule>
 
 </group>

--- a/rules/0230-ms-se_rules.xml
+++ b/rules/0230-ms-se_rules.xml
@@ -42,28 +42,28 @@
   <rule id="7705" level="12">
     <if_sid>7704</if_sid>
     <id>^1118$|^1119$</id>
-    <group>virus,pci_dss_5.1,pci_dss_5.2,pci_dss_10.6.1,pci_dss_11.4,gpg13_4.2,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_SI.5,nist_800_53_AU.6,nist_800_53_SC.7,</group>
+    <group>virus,pci_dss_5.1,pci_dss_5.2,pci_dss_10.6.1,pci_dss_11.4,gpg13_4.2,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_SI.3,nist_800_53_AU.6,nist_800_53_IA.10,</group>
     <description>Microsoft Security Essentials - Virus detected, but unable to remove.</description>
   </rule>
 
   <rule id="7706" level="7">
     <if_sid>7704</if_sid>
     <id>^1107$</id>
-    <group>virus,pci_dss_5.1,pci_dss_5.2,pci_dss_10.6.1,pci_dss_11.4,gpg13_4.2,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_SI.5,nist_800_53_AU.6,nist_800_53_SC.7,</group>
+    <group>virus,pci_dss_5.1,pci_dss_5.2,pci_dss_10.6.1,pci_dss_11.4,gpg13_4.2,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_SI.3,nist_800_53_AU.6,nist_800_53_IA.10,</group>
     <description>Microsoft Security Essentials - Virus detected and properly removed.</description>
   </rule>
 
   <rule id="7707" level="7">
     <if_sid>7704</if_sid>
     <id>^1119$|^1118$|^1117$|^1116$</id>
-    <group>virus,pci_dss_5.1,pci_dss_5.2,pci_dss_10.6.1,pci_dss_11.4,gpg13_4.2,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_SI.5,nist_800_53_AU.6,nist_800_53_SC.7,</group>
+    <group>virus,pci_dss_5.1,pci_dss_5.2,pci_dss_10.6.1,pci_dss_11.4,gpg13_4.2,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_SI.3,nist_800_53_AU.6,nist_800_53_IA.10,</group>
     <description>Microsoft Security Essentials - Virus detected.</description>
   </rule>
 
    <rule id="7708" level="7">
     <if_sid>7704</if_sid>
     <id>^1015$</id>
-    <group>virus,pci_dss_5.1,pci_dss_5.2,pci_dss_10.6.1,pci_dss_11.4,gpg13_4.2,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_SI.5,nist_800_53_AU.6,nist_800_53_SC.7,</group>
+    <group>virus,pci_dss_5.1,pci_dss_5.2,pci_dss_10.6.1,pci_dss_11.4,gpg13_4.2,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_SI.3,nist_800_53_AU.6,nist_800_53_IA.10,</group>
     <description>Microsoft Security Essentials - Suspicious activity detected.</description>
   </rule>
 
@@ -71,7 +71,7 @@
     <if_sid>7704</if_sid>
     <id>^5007$</id>
     <description>Microsoft Security Essentials - Configuration changed.</description>
-    <group>policy_changed,pci_dss_10.2.7,pci_dss_10.6.1,gpg13_4.4,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,nist_800_53_AU.6,</group>
+    <group>policy_changed,pci_dss_10.2.7,pci_dss_10.6.1,gpg13_4.4,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AU.6,</group>
   </rule>
 
   <rule id="7710" level="9">

--- a/rules/0235-vmware_rules.xml
+++ b/rules/0235-vmware_rules.xml
@@ -64,14 +64,14 @@
     <if_sid>19106</if_sid>
     <match>logged in$</match>
     <description>VMWare ESX authentication success.</description>
-    <group>authentication_success,pci_dss_10.2.5,gpg13_7.1,gpg13_7.2,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>authentication_success,pci_dss_10.2.5,gpg13_7.1,gpg13_7.2,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,</group>
   </rule>
 
   <rule id="19111" level="5">
     <if_sid>19106</if_sid>
     <match>Failed login attempt for</match>
     <description>VMWare ESX authentication failure.</description>
-    <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,</group>
   </rule>
 
   <rule id="19112" level="3">
@@ -79,7 +79,7 @@
     <program_name>vmware-hostd|vmware-authd</program_name>
     <match>Accepted password for|login from</match>
     <description>VMWare ESX user login.</description>
-    <group>authentication_success,pci_dss_10.2.5,gpg13_7.1,gpg13_7.2,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>authentication_success,pci_dss_10.2.5,gpg13_7.1,gpg13_7.2,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,</group>
   </rule>
 
   <rule id="19113" level="3">
@@ -87,7 +87,7 @@
     <program_name>vmware-hostd|vmware-authd</program_name>
     <match>Rejected password for</match>
     <description>VMWare ESX user authentication failure.</description>
-    <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,</group>
   </rule>
 
 
@@ -118,7 +118,7 @@
     <if_sid>19106</if_sid>
     <match>-> VM_STATE_RECONFIGURING</match>
     <description>Virtual machine being reconfigured.</description>
-    <group>config_changed,pci_dss_10.2.7,gpg13_4.13,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>config_changed,pci_dss_10.2.7,gpg13_4.13,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_IA.10,</group>
     <options>alert_by_email</options>
   </rule>
 
@@ -141,14 +141,14 @@
     <if_matched_sid>19111</if_matched_sid>
     <same_source_ip />
     <description>Multiple VMWare ESX authentication failures.</description>
-    <group>authentication_failures,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,nist_800_53_SC.7,</group>
+    <group>authentication_failures,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,nist_800_53_IA.10,</group>
   </rule>
 
   <rule id="19153" level="10" frequency="8" timeframe="120">
     <if_matched_sid>19113</if_matched_sid>
     <same_source_ip />
     <description>Multiple VMWare ESX user authentication failures.</description>
-    <group>authentication_failures,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,nist_800_53_SC.7,</group>
+    <group>authentication_failures,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,nist_800_53_IA.10,</group>
   </rule>
 
 </group>

--- a/rules/0235-vmware_rules.xml
+++ b/rules/0235-vmware_rules.xml
@@ -141,14 +141,14 @@
     <if_matched_sid>19111</if_matched_sid>
     <same_source_ip />
     <description>Multiple VMWare ESX authentication failures.</description>
-    <group>authentication_failures,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,nist_800_53_IA.10,</group>
+    <group>authentication_failures,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,</group>
   </rule>
 
   <rule id="19153" level="10" frequency="8" timeframe="120">
     <if_matched_sid>19113</if_matched_sid>
     <same_source_ip />
     <description>Multiple VMWare ESX user authentication failures.</description>
-    <group>authentication_failures,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,nist_800_53_IA.10,</group>
+    <group>authentication_failures,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,</group>
   </rule>
 
 </group>

--- a/rules/0240-ids_rules.xml
+++ b/rules/0240-ids_rules.xml
@@ -64,7 +64,7 @@
     <same_id />
     <check_if_ignored>id</check_if_ignored>
     <description>Multiple IDS alerts for same id.</description>
-    <group>pci_dss_10.6.1,pci_dss_11.4,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.6,nist_800_53_SC.7,</group>
+    <group>pci_dss_10.6.1,pci_dss_11.4,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.6,nist_800_53_IA.10,</group>
   </rule>
 
   <rule id="20151" level="10" frequency="$IDS_FREQ" timeframe="120" ignore="90">
@@ -72,7 +72,7 @@
     <same_source_ip />
     <check_if_ignored>srcip, id</check_if_ignored>
     <description>Multiple IDS events from same source ip.</description>
-    <group>pci_dss_10.6.1,pci_dss_11.4,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.6,nist_800_53_SC.7,</group>
+    <group>pci_dss_10.6.1,pci_dss_11.4,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.6,nist_800_53_IA.10,</group>
   </rule>
 
 

--- a/rules/0245-web_rules.xml
+++ b/rules/0245-web_rules.xml
@@ -99,7 +99,7 @@
     <if_sid>31100</if_sid>
     <description>URL too long. Higher than allowed on most </description>
     <description>browsers. Possible attack.</description>
-    <group>invalid_access,pci_dss_6.5,pci_dss_11.4,pci_dss_6.5.8,pci_dss_10.2.4,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_SA.11,nist_800_53_IA.10,nist_800_53_IA.10,nist_800_53_AC.7,</group>
+    <group>invalid_access,pci_dss_6.5,pci_dss_11.4,pci_dss_6.5.8,pci_dss_10.2.4,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_SA.11,nist_800_53_IA.10,nist_800_53_AC.7,</group>
   </rule>
 
 

--- a/rules/0245-web_rules.xml
+++ b/rules/0245-web_rules.xml
@@ -24,7 +24,7 @@
     <if_sid>31100</if_sid>
     <id>^4</id>
     <description>Web server 400 error code.</description>
-	<group>attack,pci_dss_6.5,pci_dss_11.4,gdpr_IV_35.7.d,nist_800_53_SA.11,nist_800_53_SC.7,</group>
+	<group>attack,pci_dss_6.5,pci_dss_11.4,gdpr_IV_35.7.d,nist_800_53_SA.11,nist_800_53_IA.10,</group>
   </rule>
 
   <rule id="31102" level="0">
@@ -39,7 +39,7 @@
     <url>=select%20|select+|insert%20|%20from%20|%20where%20|union%20|</url>
     <url>union+|where+|null,null|xp_cmdshell</url>
     <description>SQL injection attempt.</description>
-    <group>attack,sql_injection,pci_dss_6.5,pci_dss_11.4,pci_dss_6.5.1,gdpr_IV_35.7.d,nist_800_53_SA.11,nist_800_53_SC.7,</group>
+    <group>attack,sql_injection,pci_dss_6.5,pci_dss_11.4,pci_dss_6.5.1,gdpr_IV_35.7.d,nist_800_53_SA.11,nist_800_53_IA.10,</group>
   </rule>
 
   <rule id="31104" level="6">
@@ -52,7 +52,7 @@
     <url>/x90/|default.ida|/sumthin|nsiislog.dll|chmod%|wget%|cd%20|</url>
     <url>exec%20|../..//|%5C../%5C|././././|2e%2e%5c%2e|\x5C\x5C</url>
     <description>Common web attack.</description>
-    <group>attack,pci_dss_6.5,pci_dss_11.4,pci_dss_6.5.1,gdpr_IV_35.7.d,nist_800_53_SA.11,nist_800_53_SC.7,</group>
+    <group>attack,pci_dss_6.5,pci_dss_11.4,pci_dss_6.5.1,gdpr_IV_35.7.d,nist_800_53_SA.11,nist_800_53_IA.10,</group>
   </rule>
 
   <rule id="31105" level="6">
@@ -60,21 +60,21 @@
     <url>%3Cscript|%3C%2Fscript|script>|script%3E|SRC=javascript|IMG%20|</url>
     <url>%20ONLOAD=|INPUT%20|iframe%20</url>
     <description>XSS (Cross Site Scripting) attempt.</description>
-    <group>attack,pci_dss_6.5,pci_dss_11.4,pci_dss_6.5.7,gdpr_IV_35.7.d,nist_800_53_SA.11,nist_800_53_SC.7,</group>
+    <group>attack,pci_dss_6.5,pci_dss_11.4,pci_dss_6.5.7,gdpr_IV_35.7.d,nist_800_53_SA.11,nist_800_53_IA.10,</group>
   </rule>
 
   <rule id="31106" level="6">
     <if_sid>31103, 31104, 31105</if_sid>
     <id>^200</id>
     <description>A web attack returned code 200 (success).</description>
-    <group>attack,pci_dss_6.5,pci_dss_11.4,gdpr_IV_35.7.d,nist_800_53_SA.11,nist_800_53_SC.7,</group>
+    <group>attack,pci_dss_6.5,pci_dss_11.4,gdpr_IV_35.7.d,nist_800_53_SA.11,nist_800_53_IA.10,</group>
   </rule>
 
   <rule id="31110" level="6">
     <if_sid>31100</if_sid>
     <url>?-d|?-s|?-a|?-b|?-w</url>
     <description>PHP CGI-bin vulnerability attempt.</description>
-    <group>attack,pci_dss_6.5,pci_dss_11.4,gdpr_IV_35.7.d,nist_800_53_SA.11,nist_800_53_SC.7,</group>
+    <group>attack,pci_dss_6.5,pci_dss_11.4,gdpr_IV_35.7.d,nist_800_53_SA.11,nist_800_53_IA.10,</group>
   </rule>
 
   <rule id="31109" level="6">
@@ -82,7 +82,7 @@
     <url>+as+varchar</url>
     <regex>%2Bchar\(\d+\)%2Bchar\(\d+\)%2Bchar\(\d+\)%2Bchar\(\d+\)%2Bchar\(\d+\)%2Bchar\(\d+\)</regex>
     <description>MSSQL Injection attempt (/ur.php, urchin.js)</description>
-    <group>attack,pci_dss_6.5,pci_dss_11.4,pci_dss_6.5.1,gdpr_IV_35.7.d,nist_800_53_SA.11,nist_800_53_SC.7,</group>
+    <group>attack,pci_dss_6.5,pci_dss_11.4,pci_dss_6.5.1,gdpr_IV_35.7.d,nist_800_53_SA.11,nist_800_53_IA.10,</group>
   </rule>
 
 
@@ -99,7 +99,7 @@
     <if_sid>31100</if_sid>
     <description>URL too long. Higher than allowed on most </description>
     <description>browsers. Possible attack.</description>
-    <group>invalid_access,pci_dss_6.5,pci_dss_11.4,pci_dss_6.5.8,pci_dss_10.2.4,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_SA.11,nist_800_53_SC.7,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>invalid_access,pci_dss_6.5,pci_dss_11.4,pci_dss_6.5.8,pci_dss_10.2.4,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_SA.11,nist_800_53_IA.10,nist_800_53_IA.10,nist_800_53_AC.7,</group>
   </rule>
 
 
@@ -154,7 +154,7 @@
     <same_source_ip />
     <description>Multiple web server 400 error codes </description>
     <description>from same source ip.</description>
-    <group>web_scan,recon,pci_dss_6.5,pci_dss_11.4,gdpr_IV_35.7.d,nist_800_53_SA.11,nist_800_53_SC.7,</group>
+    <group>web_scan,recon,pci_dss_6.5,pci_dss_11.4,gdpr_IV_35.7.d,nist_800_53_SA.11,nist_800_53_IA.10,</group>
   </rule>
 
   <rule id="31152" level="10" frequency="8" timeframe="120">
@@ -162,14 +162,14 @@
     <same_source_ip />
     <description>Multiple SQL injection attempts from same </description>
     <description>source ip.</description>
-    <group>attack,sql_injection,pci_dss_6.5,pci_dss_11.4,pci_dss_6.5.1,gdpr_IV_35.7.d,nist_800_53_SA.11,nist_800_53_SC.7,</group>
+    <group>attack,sql_injection,pci_dss_6.5,pci_dss_11.4,pci_dss_6.5.1,gdpr_IV_35.7.d,nist_800_53_SA.11,nist_800_53_IA.10,</group>
   </rule>
 
   <rule id="31153" level="10" frequency="10" timeframe="120">
     <if_matched_sid>31104</if_matched_sid>
     <same_source_ip />
     <description>Multiple common web attacks from same source ip.</description>
-    <group>attack,pci_dss_6.5,pci_dss_11.4,gdpr_IV_35.7.d,nist_800_53_SA.11,nist_800_53_SC.7,</group>
+    <group>attack,pci_dss_6.5,pci_dss_11.4,gdpr_IV_35.7.d,nist_800_53_SA.11,nist_800_53_IA.10,</group>
   </rule>
 
   <rule id="31154" level="10" frequency="10" timeframe="120">
@@ -177,14 +177,14 @@
     <same_source_ip />
     <description>Multiple XSS (Cross Site Scripting) attempts </description>
     <description>from same source ip.</description>
-    <group>attack,pci_dss_6.5,pci_dss_11.4,pci_dss_6.5.7,gdpr_IV_35.7.d,nist_800_53_SA.11,nist_800_53_SC.7,</group>
+    <group>attack,pci_dss_6.5,pci_dss_11.4,pci_dss_6.5.7,gdpr_IV_35.7.d,nist_800_53_SA.11,nist_800_53_IA.10,</group>
   </rule>
 
   <rule id="31161" level="10" frequency="14" timeframe="120">
     <if_matched_sid>31121</if_matched_sid>
     <same_source_ip />
     <description>Multiple web server 501 error code (Not Implemented).</description>
-    <group>web_scan,recon,pci_dss_6.5,pci_dss_11.4,gdpr_IV_35.7.d,nist_800_53_SA.11,nist_800_53_SC.7,</group>
+    <group>web_scan,recon,pci_dss_6.5,pci_dss_11.4,gdpr_IV_35.7.d,nist_800_53_SA.11,nist_800_53_IA.10,</group>
   </rule>
 
   <rule id="31162" level="10" frequency="14" timeframe="120">
@@ -198,21 +198,21 @@
     <if_matched_sid>31123</if_matched_sid>
     <same_source_ip />
     <description>Multiple web server 503 error code (Service unavailable).</description>
-    <group>web_scan,recon,pci_dss_6.5,pci_dss_11.4,pci_dss_10.6.1,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_SA.11,nist_800_53_SC.7,nist_800_53_AU.6,</group>
+    <group>web_scan,recon,pci_dss_6.5,pci_dss_11.4,pci_dss_10.6.1,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_SA.11,nist_800_53_IA.10,nist_800_53_AU.6,</group>
   </rule>
 
   <rule id="31164" level="6">
     <if_sid>31100</if_sid>
     <url>=%27|select%2B|insert%2B|%2Bfrom%2B|%2Bwhere%2B|%2Bunion%2B</url>
     <description>SQL injection attempt.</description>
-    <group>attack,sqlinjection,attack,pci_dss_6.5,pci_dss_11.4,pci_dss_6.5.1,gdpr_IV_35.7.d,nist_800_53_SA.11,nist_800_53_SC.7,</group>
+    <group>attack,sqlinjection,attack,pci_dss_6.5,pci_dss_11.4,pci_dss_6.5.1,gdpr_IV_35.7.d,nist_800_53_SA.11,nist_800_53_IA.10,</group>
   </rule>
 
   <rule id="31165" level="6">
     <if_sid>31100</if_sid>
     <url>%EF%BC%87|%EF%BC%87|%EF%BC%87|%2531|%u0053%u0045</url>
     <description>SQL injection attempt.</description>
-    <group>attack,sqlinjection,pci_dss_6.5,pci_dss_11.4,pci_dss_6.5.1,gdpr_IV_35.7.d,nist_800_53_SA.11,nist_800_53_SC.7,</group>
+    <group>attack,sqlinjection,pci_dss_6.5,pci_dss_11.4,pci_dss_6.5.1,gdpr_IV_35.7.d,nist_800_53_SA.11,nist_800_53_IA.10,</group>
   </rule>
 
 <!--
@@ -236,7 +236,7 @@
         <description>Shellshock attack detected</description>
 	<info type="cve">CVE-2014-6271</info>
 	<info type="link">https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2014-6271</info>
-        <group>attack,pci_dss_11.4,gdpr_IV_35.7.d,nist_800_53_SC.7,</group>
+        <group>attack,pci_dss_11.4,gdpr_IV_35.7.d,nist_800_53_IA.10,</group>
     </rule>
 
 
@@ -246,7 +246,7 @@
         <description>Shellshock attack detected</description>
 	<info type="cve">CVE-2014-6278</info>
 	<info type="link">https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2014-6278</info>
-        <group>attack,pci_dss_11.4,nist_800_53_SC.7,</group>
+        <group>attack,pci_dss_11.4,nist_800_53_IA.10,</group>
     </rule>
 
 

--- a/rules/0250-apache_rules.xml
+++ b/rules/0250-apache_rules.xml
@@ -91,7 +91,7 @@
     <match>failed to open stream: No such file or directory|</match>
     <match>Failed opening </match>
     <description>Apache: Attempt to access an non-existent file (those are reported on the access.log).</description>
-    <group>unknown_resource,pci_dss_10.2.1,pci_dss_10.2.4,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_IA.10,nist_800_53_AC.7,</group>
+    <group>unknown_resource,pci_dss_10.2.1,pci_dss_10.2.4,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,</group>
   </rule>
 
   <!-- [Tue Mar 07 12:05:15 2006] [error] [client 200.206.165.91] Invalid URI in request %3Bi%3A3%3Bi%3A0%3B%7D; usercookie[password]=d6ed9e1750d0b2aba6b3311cbec087d8; 45befd35f8a0f47b89ed8831f892b8dc=167c4e46a940cd2570b952eea527b27a; PHPSESSID=616hjdg7kj9bln37efsv7vt7g3
@@ -108,7 +108,7 @@
     <if_matched_sid>30115</if_matched_sid>
     <same_source_ip />
     <description>Apache: Multiple Invalid URI requests from same source.</description>
-    <group>invalid_request,pci_dss_10.2.4,pci_dss_11.4,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,nist_800_53_IA.10,</group>
+    <group>invalid_request,pci_dss_10.2.4,pci_dss_11.4,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,</group>
   </rule>
 
   <rule id="30117" level="10">
@@ -130,7 +130,7 @@
     <if_matched_sid>30118</if_matched_sid>
     <same_source_ip />
     <description>ModSecurity: Multiple attempts blocked.</description>
-    <group>modsecurity,access_denied,pci_dss_10.2.4,pci_dss_11.4,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,nist_800_53_IA.10,</group>
+    <group>modsecurity,access_denied,pci_dss_10.2.4,pci_dss_11.4,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,</group>
   </rule>
 
   <rule id="30120" level="12">
@@ -156,7 +156,7 @@
   <rule id="30202" level="10" frequency="10" timeframe="120">
     <if_matched_sid>30201</if_matched_sid>
     <description>ModSecurity: Multiple attempts blocked.</description>
-    <group>modsecurity,access_denied,pci_dss_10.2.4,pci_dss_11.4,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,nist_800_53_IA.10,</group>
+    <group>modsecurity,access_denied,pci_dss_10.2.4,pci_dss_11.4,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,</group>
   </rule>
 
   <!-- Apache 2.4 Rules -->
@@ -220,14 +220,14 @@
     <if_sid>30301</if_sid>
     <id>AH01618|AH01808|AH01790</id>
     <description>Apache: Attempt to login using a non-existent user.</description>
-    <group>invalid_login,pci_dss_11.4,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_IA.10,nist_800_53_AC.7,</group>
+    <group>invalid_login,pci_dss_11.4,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,</group>
   </rule>
 
   <rule id="30310" level="10" frequency="12" timeframe="160">
     <if_matched_sid>30309</if_matched_sid>
     <same_source_ip/>
     <description>Apache: Multiple authentication failures with invalid user.</description>
-    <group>authentication_failures,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,nist_800_53_IA.10,</group>
+    <group>authentication_failures,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,</group>
   </rule>
 
   <rule id="30312" level="0">
@@ -250,7 +250,7 @@
     <if_matched_sid>30315</if_matched_sid>
     <same_source_ip />
     <description>Apache: Multiple Invalid URI requests from same source.</description>
-    <group>invalid_request,pci_dss_10.2.4,pci_dss_11.4,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,nist_800_53_IA.10,</group>
+    <group>invalid_request,pci_dss_10.2.4,pci_dss_11.4,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,</group>
   </rule>
 
   <rule id="30317" level="10">

--- a/rules/0250-apache_rules.xml
+++ b/rules/0250-apache_rules.xml
@@ -38,21 +38,21 @@
     <match>exit signal Segmentation Fault</match>
     <description>Apache: segmentation fault.</description>
     <info type="link">http://www.securityfocus.com/infocus/1633</info>
-    <group>service_availability,pci_dss_6.5.2,pci_dss_6.6,gpg13_4.14,gdpr_IV_35.7.d,nist_800_53_SA.11,nist_800_53_SI.10,nist_800_53_SI.11,nist_800_53_SI.15,nist_800_53_SI.16,</group>
+    <group>service_availability,pci_dss_6.5.2,pci_dss_6.6,gpg13_4.14,gdpr_IV_35.7.d,nist_800_53_SA.11,</group>
   </rule>
 
   <rule id="30105" level="5">
     <if_sid>30101</if_sid>
     <match>denied by server configuration</match>
     <description>Apache: Attempt to access forbidden file or directory.</description>
-    <group>access_denied,pci_dss_6.5.8,pci_dss_10.2.4,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_SA.11,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>access_denied,pci_dss_6.5.8,pci_dss_10.2.4,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_SA.11,nist_800_53_IA.10,nist_800_53_AC.7,</group>
   </rule>
 
   <rule id="30106" level="5">
     <if_sid>30101</if_sid>
     <match>Directory index forbidden by rule</match>
     <description>Apache: Attempt to access forbidden directory index.</description>
-    <group>access_denied,pci_dss_6.5.8,pci_dss_10.2.4,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_SA.11,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>access_denied,pci_dss_6.5.8,pci_dss_10.2.4,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_SA.11,nist_800_53_IA.10,nist_800_53_AC.7,</group>
   </rule>
 
   <rule id="30107" level="6">
@@ -61,28 +61,28 @@
     <description>Apache: Code Red attack.</description>
     <info type="link">http://www.cert.org/advisories/CA-2001-19.html</info>
     <info type="text">CERT: Advisory CA-2001-19 "Code Red" Worm Exploiting Buffer Overflow In IIS Indexing Service DLL</info>
-    <group>automatic_attack,pci_dss_6.2,pci_dss_6.5.2,pci_dss_11.4,gdpr_IV_35.7.d,nist_800_53_MA.2,nist_800_53_SA.11,nist_800_53_SC.7,</group>
+    <group>automatic_attack,pci_dss_6.2,pci_dss_6.5.2,pci_dss_11.4,gdpr_IV_35.7.d,nist_800_53_SI.2,nist_800_53_SA.11,nist_800_53_IA.10,</group>
   </rule>
 
   <rule id="30108" level="5">
     <if_sid>30102</if_sid>
     <match>authentication failed</match>
     <description>Apache: User authentication failed.</description>
-    <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,</group>
   </rule>
 
   <rule id="30109" level="9">
     <if_sid>30101</if_sid>
     <regex>user \S+ not found|user \S+ in realm \.* not found</regex>
     <description>Apache: Attempt to login using a non-existent user.</description>
-    <group>invalid_login,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>invalid_login,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,</group>
   </rule>
 
   <rule id="30110" level="5">
     <if_sid>30101</if_sid>
     <match>authentication failure</match>
     <description>Apache: User authentication failed.</description>
-    <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,</group>
   </rule>
 
   <rule id="30112" level="0">
@@ -91,7 +91,7 @@
     <match>failed to open stream: No such file or directory|</match>
     <match>Failed opening </match>
     <description>Apache: Attempt to access an non-existent file (those are reported on the access.log).</description>
-    <group>unknown_resource,pci_dss_10.2.1,pci_dss_10.2.4,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>unknown_resource,pci_dss_10.2.1,pci_dss_10.2.4,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_IA.10,nist_800_53_AC.7,</group>
   </rule>
 
   <!-- [Tue Mar 07 12:05:15 2006] [error] [client 200.206.165.91] Invalid URI in request %3Bi%3A3%3Bi%3A0%3B%7D; usercookie[password]=d6ed9e1750d0b2aba6b3311cbec087d8; 45befd35f8a0f47b89ed8831f892b8dc=167c4e46a940cd2570b952eea527b27a; PHPSESSID=616hjdg7kj9bln37efsv7vt7g3
@@ -108,14 +108,14 @@
     <if_matched_sid>30115</if_matched_sid>
     <same_source_ip />
     <description>Apache: Multiple Invalid URI requests from same source.</description>
-    <group>invalid_request,pci_dss_10.2.4,pci_dss_11.4,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,nist_800_53_SC.7,</group>
+    <group>invalid_request,pci_dss_10.2.4,pci_dss_11.4,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,nist_800_53_IA.10,</group>
   </rule>
 
   <rule id="30117" level="10">
     <if_sid>30101</if_sid>
     <match>File name too long|request failed: URI too long</match>
     <description>Apache: Invalid URI, file name too long.</description>
-    <group>invalid_request,pci_dss_10.2.4,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>invalid_request,pci_dss_10.2.4,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,</group>
   </rule>
 
   <!-- Mod security rules by <ossec ( at ) sioban.net -->
@@ -123,14 +123,14 @@
     <if_sid>30101</if_sid>
     <match>mod_security: Access denied|ModSecurity: Access denied</match>
     <description>ModSecurity: Access attempt blocked.</description>
-    <group>modsecurity,access_denied,pci_dss_10.2.4,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>modsecurity,access_denied,pci_dss_10.2.4,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,</group>
   </rule>
 
   <rule id="30119" level="12" frequency="8" timeframe="120">
     <if_matched_sid>30118</if_matched_sid>
     <same_source_ip />
     <description>ModSecurity: Multiple attempts blocked.</description>
-    <group>modsecurity,access_denied,pci_dss_10.2.4,pci_dss_11.4,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,nist_800_53_SC.7,</group>
+    <group>modsecurity,access_denied,pci_dss_10.2.4,pci_dss_11.4,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,nist_800_53_IA.10,</group>
   </rule>
 
   <rule id="30120" level="12">
@@ -150,13 +150,13 @@
     <if_sid>30200</if_sid>
     <match>^mod_security-message: Access denied </match>
     <description>ModSecurity: access denied.</description>
-    <group>modsecurity,access_denied,pci_dss_10.2.4,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>modsecurity,access_denied,pci_dss_10.2.4,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,</group>
   </rule>
 
   <rule id="30202" level="10" frequency="10" timeframe="120">
     <if_matched_sid>30201</if_matched_sid>
     <description>ModSecurity: Multiple attempts blocked.</description>
-    <group>modsecurity,access_denied,pci_dss_10.2.4,pci_dss_11.4,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,nist_800_53_SC.7,</group>
+    <group>modsecurity,access_denied,pci_dss_10.2.4,pci_dss_11.4,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,nist_800_53_IA.10,</group>
   </rule>
 
   <!-- Apache 2.4 Rules -->
@@ -183,21 +183,21 @@
     <match>exit signal Segmentation Fault</match>
     <description>Apache: segmentation fault.</description>
     <info type="link">http://www.securityfocus.com/infocus/1633</info>
-    <group>service_availability,pci_dss_6.5.2,pci_dss_6.6,gpg13_4.14,gdpr_IV_35.7.d,nist_800_53_SA.11,nist_800_53_SI.10,nist_800_53_SI.11,nist_800_53_SI.15,nist_800_53_SI.16,</group>
+    <group>service_availability,pci_dss_6.5.2,pci_dss_6.6,gpg13_4.14,gdpr_IV_35.7.d,nist_800_53_SA.11,</group>
   </rule>
 
   <rule id="30305" level="5">
     <if_sid>30301</if_sid>
     <id>AH01630</id>
     <description>Apache: Attempt to access forbidden file or directory.</description>
-    <group>access_denied,pci_dss_6.5.8,pci_dss_10.2.4,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_SA.11,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>access_denied,pci_dss_6.5.8,pci_dss_10.2.4,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_SA.11,nist_800_53_IA.10,nist_800_53_AC.7,</group>
   </rule>
 
   <rule id="30306" level="5">
     <if_sid>30301</if_sid>
     <id>AH01276</id>
     <description>Apache: Attempt to access forbidden directory index.</description>
-    <group>access_denied,pci_dss_6.5.8,pci_dss_10.2.4,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_SA.11,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>access_denied,pci_dss_6.5.8,pci_dss_10.2.4,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_SA.11,nist_800_53_IA.10,nist_800_53_AC.7,</group>
   </rule>
 
   <rule id="30307" level="6">
@@ -206,28 +206,28 @@
     <description>Apache: Client sent malformed Host header. Possible Code Red attack.</description>
     <info type="link">http://www.cert.org/advisories/CA-2001-19.html</info>
     <info type="text">CERT: Advisory CA-2001-19 "Code Red" Worm Exploiting Buffer Overflow In IIS Indexing Service DLL</info>
-    <group>automatic_attack,pci_dss_6.2,pci_dss_6.5.2,pci_dss_11.4,gdpr_IV_35.7.d,nist_800_53_MA.2,nist_800_53_SA.11,nist_800_53_SC.7,</group>
+    <group>automatic_attack,pci_dss_6.2,pci_dss_6.5.2,pci_dss_11.4,gdpr_IV_35.7.d,nist_800_53_SI.2,nist_800_53_SA.11,nist_800_53_IA.10,</group>
   </rule>
 
   <rule id="30308" level="5">
     <if_sid>30302</if_sid>
     <id>AH01617|AH01807|AH01694|AH01695|AH02009|AH02010</id>
     <description>Apache: User authentication failed.</description>
-    <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,</group>
   </rule>
 
   <rule id="30309" level="5">
     <if_sid>30301</if_sid>
     <id>AH01618|AH01808|AH01790</id>
     <description>Apache: Attempt to login using a non-existent user.</description>
-    <group>invalid_login,pci_dss_11.4,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_SC.7,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>invalid_login,pci_dss_11.4,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_IA.10,nist_800_53_AC.7,</group>
   </rule>
 
   <rule id="30310" level="10" frequency="12" timeframe="160">
     <if_matched_sid>30309</if_matched_sid>
     <same_source_ip/>
     <description>Apache: Multiple authentication failures with invalid user.</description>
-    <group>authentication_failures,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,nist_800_53_SC.7,</group>
+    <group>authentication_failures,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,nist_800_53_IA.10,</group>
   </rule>
 
   <rule id="30312" level="0">
@@ -236,28 +236,28 @@
     <match>failed to open stream: No such file or directory|</match>
     <match>Failed opening </match>
     <description>Apache: Attempt to access an non-existent file (those are reported on the access.log).</description>
-    <group>unknown_resource,pci_dss_10.2.4,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>unknown_resource,pci_dss_10.2.4,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,</group>
   </rule>
 
   <rule id="30315" level="5">
     <if_sid>30301</if_sid>
     <id>AH00126</id>
     <description>Apache: Invalid URI (bad client request).</description>
-    <group>invalid_request,pci_dss_10.2.4,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>invalid_request,pci_dss_10.2.4,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,</group>
   </rule>
 
   <rule id="30316" level="10" frequency="10" timeframe="120">
     <if_matched_sid>30315</if_matched_sid>
     <same_source_ip />
     <description>Apache: Multiple Invalid URI requests from same source.</description>
-    <group>invalid_request,pci_dss_10.2.4,pci_dss_11.4,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,nist_800_53_SC.7,</group>
+    <group>invalid_request,pci_dss_10.2.4,pci_dss_11.4,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,nist_800_53_IA.10,</group>
   </rule>
 
   <rule id="30317" level="10">
     <if_sid>30301</if_sid>
     <id>AH00565</id>
     <description>Apache: Invalid URI, file name too long.</description>
-    <group>invalid_request,pci_dss_10.2.4,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>invalid_request,pci_dss_10.2.4,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,</group>
   </rule>
 
   <rule id="30318" level="5">
@@ -278,7 +278,7 @@
     <if_sid>30301</if_sid>
     <match>ModSecurity: Access denied</match>
     <description>ModSecurity Access denied messages grouped</description>
-    <group>modsecurity,pci_dss_10.2.4,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>modsecurity,pci_dss_10.2.4,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,</group>
   </rule>
 
   <rule id="30403" level="0">
@@ -316,7 +316,7 @@
         <description>Apache: Shellshock attack attempt</description>
 	<info type="cve">CVE-2014-6271</info>
 	<info type="link">https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2014-6271</info>
-        <group>attack,pci_dss_11.4,gdpr_IV_35.7.d,nist_800_53_SC.7,</group>
+        <group>attack,pci_dss_11.4,gdpr_IV_35.7.d,nist_800_53_IA.10,</group>
     </rule>
 
     <rule id="30413" level="6">
@@ -325,7 +325,7 @@
         <description>Apache: Shellshock attack attempt</description>
 	<info type="cve">CVE-2014-6278</info>
 	<info type="link">https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2014-6278</info>
-        <group>attack,pci_dss_11.4,nist_800_53_SC.7,</group>
+        <group>attack,pci_dss_11.4,nist_800_53_IA.10,</group>
     </rule>
 
 </group>

--- a/rules/0255-zeus_rules.xml
+++ b/rules/0255-zeus_rules.xml
@@ -45,7 +45,7 @@
     <if_sid>31202</if_sid>
     <match>admin:Authentication failure</match>
     <description>Zeus: Admin authentication failed.</description>
-    <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,</group>
   </rule>
 
   <rule id="31206" level="0">

--- a/rules/0260-nginx_rules.xml
+++ b/rules/0260-nginx_rules.xml
@@ -48,7 +48,7 @@
     <if_sid>31301</if_sid>
     <match>no user/password was provided for basic authentication</match>
     <description>Nginx: Initial 401 authentication request.</description>
-    <group>pci_dss_10.6.1,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.6,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>pci_dss_10.6.1,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.6,nist_800_53_IA.10,nist_800_53_AC.7,</group>
   </rule>
 
   <rule id="31315" level="5">
@@ -56,14 +56,14 @@
     <match> password mismatch, client| was not found in </match>
     <description>Nginx: Web authentication failed.</description>
     <group>authentication_failed,</group>
-    <group>pci_dss_10.6.1,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.6,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>pci_dss_10.6.1,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.6,nist_800_53_IA.10,nist_800_53_AC.7,</group>
   </rule>
 
   <rule id="31316" level="10" frequency="8" timeframe="240">
     <if_matched_sid>31315</if_matched_sid>
     <same_source_ip />
     <description>Nginx: Multiple web authentication failures.</description>
-    <group>authentication_failures,pci_dss_10.6.1,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.6,nist_800_53_AU.3.1,nist_800_53_IA.10,nist_800_53_SC.7,</group>
+    <group>authentication_failures,pci_dss_10.6.1,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.6,nist_800_53_IA.10,nist_800_53_AC.7,nist_800_53_IA.10,</group>
   </rule>
 
   <rule id="31317" level="0">
@@ -76,7 +76,7 @@
     <if_sid>31301</if_sid>
     <match>failed (36: File name too long)</match>
     <description>Nginx: Invalid URI, file name too long.</description>
-    <group>invalid_request,pci_dss_10.2.4,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>invalid_request,pci_dss_10.2.4,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,</group>
   </rule>
 
   <!-- ModSecurity Rules -->
@@ -91,7 +91,7 @@
     <if_sid>31301</if_sid>
     <match>ModSecurity: Access denied</match>
     <description>ModSecurity Access denied messages grouped</description>
-    <group>modsecurity,pci_dss_10.2.4,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>modsecurity,pci_dss_10.2.4,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,</group>
   </rule>
 
   <rule id="31332" level="0">

--- a/rules/0260-nginx_rules.xml
+++ b/rules/0260-nginx_rules.xml
@@ -63,7 +63,7 @@
     <if_matched_sid>31315</if_matched_sid>
     <same_source_ip />
     <description>Nginx: Multiple web authentication failures.</description>
-    <group>authentication_failures,pci_dss_10.6.1,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.6,nist_800_53_IA.10,nist_800_53_AC.7,nist_800_53_IA.10,</group>
+    <group>authentication_failures,pci_dss_10.6.1,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.6,nist_800_53_IA.10,nist_800_53_AC.7,</group>
   </rule>
 
   <rule id="31317" level="0">

--- a/rules/0265-php_rules.xml
+++ b/rules/0265-php_rules.xml
@@ -57,7 +57,7 @@
   <rule id="31411" level="6">
     <if_sid>31410</if_sid>
     <match> expects parameter 1 to be string, array given in</match>
-    <group>attack,pci_dss_6.5,pci_dss_11.4,gdpr_IV_35.7.d,nist_800_53_SA.11,nist_800_53_SC.7,</group>
+    <group>attack,pci_dss_6.5,pci_dss_11.4,gdpr_IV_35.7.d,nist_800_53_SA.11,nist_800_53_IA.10,</group>
     <description>PHP web attack.</description>
   </rule>
 
@@ -75,7 +75,7 @@
     <description>PHP internal error (server out of space).</description>
     <options>alert_by_email</options>
     <group>low_diskspace,</group>
-    <group>attack,pci_dss_6.5,pci_dss_10.2.7,gpg13_4.3,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_SA.11,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>attack,pci_dss_6.5,pci_dss_10.2.7,gpg13_4.3,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_SA.11,nist_800_53_IA.10,</group>
   </rule>
 
 

--- a/rules/0270-web_appsec_rules.xml
+++ b/rules/0270-web_appsec_rules.xml
@@ -21,7 +21,7 @@
     <url>/wp-comments-post.php</url>
     <regex>Googlebot|MSNBot|BingBot</regex>
     <description>WordPress Comment Spam (coming from a fake search engine UA).</description>
-    <group>pci_dss_6.5,pci_dss_11.4,gdpr_IV_35.7.d,nist_800_53_SA.11,nist_800_53_SC.7,</group>
+    <group>pci_dss_6.5,pci_dss_11.4,gdpr_IV_35.7.d,nist_800_53_SA.11,nist_800_53_IA.10,</group>
    </rule>
 
 
@@ -32,7 +32,7 @@
     <url>thumb.php|timthumb.php</url>
     <regex> "GET \S+thumb.php?src=\S+.php</regex>
     <description>TimThumb vulnerability exploit attempt.</description>
-    <group>pci_dss_6.5,pci_dss_11.4,gdpr_IV_35.7.d,nist_800_53_SA.11,nist_800_53_SC.7,</group>
+    <group>pci_dss_6.5,pci_dss_11.4,gdpr_IV_35.7.d,nist_800_53_SA.11,nist_800_53_IA.10,</group>
    </rule>
 
   <!-- osCommerce login.php bypass
@@ -42,7 +42,7 @@
     <url>login.php</url>
     <regex> "POST /\S+.php/login.php?cPath=</regex>
     <description>osCommerce login.php bypass attempt.</description>
-    <group>pci_dss_6.5,pci_dss_11.4,pci_dss_10.2.4,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_SA.11,nist_800_53_SC.7,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>pci_dss_6.5,pci_dss_11.4,pci_dss_10.2.4,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_SA.11,nist_800_53_IA.10,nist_800_53_IA.10,nist_800_53_AC.7,</group>
    </rule>
 
   <!-- osCommerce file manager login.php bypass
@@ -52,7 +52,7 @@
     <url>login.php</url>
     <regex>/admin/\w+.php/login.php</regex>
     <description>osCommerce file manager login.php bypass attempt.</description>
-    <group>pci_dss_6.5,pci_dss_11.4,pci_dss_10.2.4,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_SA.11,nist_800_53_SC.7,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>pci_dss_6.5,pci_dss_11.4,pci_dss_10.2.4,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_SA.11,nist_800_53_IA.10,nist_800_53_IA.10,nist_800_53_AC.7,</group>
    </rule>
 
   <!-- Timthumb backdoor access.
@@ -62,7 +62,7 @@
     <url>/cache/external</url>
     <regex> "GET /\S+/cache/external\S+.php</regex>
     <description>TimThumb backdoor access attempt.</description>
-    <group>pci_dss_6.5,pci_dss_11.4,pci_dss_10.2.4,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_SA.11,nist_800_53_SC.7,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>pci_dss_6.5,pci_dss_11.4,pci_dss_10.2.4,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_SA.11,nist_800_53_IA.10,nist_800_53_IA.10,nist_800_53_AC.7,</group>
    </rule>
 
   <!-- Timthumb backdoor access.
@@ -72,7 +72,7 @@
     <url>cart.php</url>
     <regex> "GET /\S+cart.php?\S+templatefile=../</regex>
     <description>Cart.php directory transversal attempt.</description>
-    <group>pci_dss_6.5,pci_dss_11.4,pci_dss_10.2.4,pci_dss_6.5.1,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_SA.11,nist_800_53_SC.7,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>pci_dss_6.5,pci_dss_11.4,pci_dss_10.2.4,pci_dss_6.5.1,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_SA.11,nist_800_53_IA.10,nist_800_53_IA.10,nist_800_53_AC.7,</group>
    </rule>
 
   <!-- MSSQL IIS inject rules -->
@@ -80,7 +80,7 @@
     <if_sid>31100</if_sid>
     <url>DECLARE%20@S%20CHAR|%20AS%20CHAR</url>
     <description>MSSQL Injection attempt (ur.php, urchin.js).</description>
-   <group>pci_dss_6.5,pci_dss_11.4,pci_dss_6.5.1,gdpr_IV_35.7.d,nist_800_53_SA.11,nist_800_53_SC.7,</group>
+   <group>pci_dss_6.5,pci_dss_11.4,pci_dss_6.5.1,gdpr_IV_35.7.d,nist_800_53_SA.11,nist_800_53_IA.10,</group>
   </rule>
 
   <!-- BAD/Annoying user agents -->
@@ -88,7 +88,7 @@
     <if_sid>31100</if_sid>
     <match> "ZmEu"| "libwww-perl/|"the beast"|"Morfeus|"ZmEu|"Nikto|"w3af.sourceforge.net| Jorgee"|"Proxy Gear Pro|"DataCha0s</match>
     <description>Blacklisted user agent (known malicious user agent).</description>
-   <group>pci_dss_6.5,pci_dss_11.4,gdpr_IV_35.7.d,nist_800_53_SA.11,nist_800_53_SC.7,</group>
+   <group>pci_dss_6.5,pci_dss_11.4,gdpr_IV_35.7.d,nist_800_53_SA.11,nist_800_53_IA.10,</group>
   </rule>
 
   <!-- WordPress wp-login.php brute force -->
@@ -97,7 +97,7 @@
     <url>wp-login.php|/administrator</url>
     <regex>] "POST \S+wp-login.php| "POST /administrator</regex>
     <description>CMS (WordPress or Joomla) login attempt.</description>
-   <group>pci_dss_6.5,pci_dss_11.4,pci_dss_6.5.10,pci_dss_10.2.4,pci_dss_10.2.5,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_SA.11,nist_800_53_SC.7,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+   <group>pci_dss_6.5,pci_dss_11.4,pci_dss_6.5.10,pci_dss_10.2.4,pci_dss_10.2.5,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_SA.11,nist_800_53_IA.10,nist_800_53_IA.10,nist_800_53_AC.7,</group>
   </rule>
 
   <!-- If we see frequent wp-login POST's, it is likely a bot. -->
@@ -105,7 +105,7 @@
     <if_matched_sid>31509</if_matched_sid>
     <same_source_ip />
     <description>CMS (WordPress or Joomla) brute force attempt.</description>
-   <group>pci_dss_6.5,pci_dss_11.4,pci_dss_6.5.10,pci_dss_10.2.4,pci_dss_10.2.5,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_SA.11,nist_800_53_SC.7,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+   <group>pci_dss_6.5,pci_dss_11.4,pci_dss_6.5.10,pci_dss_10.2.4,pci_dss_10.2.5,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_SA.11,nist_800_53_IA.10,nist_800_53_IA.10,nist_800_53_AC.7,</group>
   </rule>
 
   <!-- Nothing wrong with wget per se, but it misses a lot of links
@@ -115,7 +115,7 @@
     <if_sid>31100</if_sid>
     <match>" "Wget/</match>
     <description>Blacklisted user agent (wget).</description>
-   <group>pci_dss_6.5,pci_dss_11.4,gdpr_IV_35.7.d,nist_800_53_SA.11,nist_800_53_SC.7,</group>
+   <group>pci_dss_6.5,pci_dss_11.4,gdpr_IV_35.7.d,nist_800_53_SA.11,nist_800_53_IA.10,</group>
   </rule>
 
   <!-- Uploadify scans.
@@ -125,7 +125,7 @@
     <url>uploadify.php</url>
     <regex> "GET /\S+/uploadify.php?src=http://\S+.php</regex>
     <description>Uploadify vulnerability exploit attempt.</description>
-   <group>pci_dss_6.5,pci_dss_11.4,gdpr_IV_35.7.d,nist_800_53_SA.11,nist_800_53_SC.7,</group>
+   <group>pci_dss_6.5,pci_dss_11.4,gdpr_IV_35.7.d,nist_800_53_SA.11,nist_800_53_IA.10,</group>
    </rule>
 
   <!-- BBS delete.php skin_path.
@@ -135,7 +135,7 @@
     <url>delete.php</url>
     <regex> "GET \S+/delete.php?board_skin_path=http://\S+.php</regex>
     <description>BBS delete.php exploit attempt.</description>
-   <group>pci_dss_6.5,pci_dss_11.4,gdpr_IV_35.7.d,nist_800_53_SA.11,nist_800_53_SC.7,</group>
+   <group>pci_dss_6.5,pci_dss_11.4,gdpr_IV_35.7.d,nist_800_53_SA.11,nist_800_53_IA.10,</group>
    </rule>
 
   <!-- Simple shell.php command execution
@@ -145,7 +145,7 @@
     <url>shell.php</url>
     <regex> "GET \S+/shell.php?cmd=</regex>
     <description>Simple shell.php command execution.</description>
-   <group>pci_dss_6.5,pci_dss_11.4,gdpr_IV_35.7.d,nist_800_53_SA.11,nist_800_53_SC.7,</group>
+   <group>pci_dss_6.5,pci_dss_11.4,gdpr_IV_35.7.d,nist_800_53_SA.11,nist_800_53_IA.10,</group>
    </rule>
 
   <!-- PHPMyAdmin scans
@@ -154,7 +154,7 @@
     <if_sid>31100</if_sid>
     <url>phpMyAdmin/scripts/setup.php</url>
     <description>PHPMyAdmin scans (looking for setup.php).</description>
-   <group>pci_dss_6.5,pci_dss_11.4,gdpr_IV_35.7.d,nist_800_53_SA.11,nist_800_53_SC.7,</group>
+   <group>pci_dss_6.5,pci_dss_11.4,gdpr_IV_35.7.d,nist_800_53_SA.11,nist_800_53_IA.10,</group>
    </rule>
 
   <!-- Suspicious URL's access
@@ -163,7 +163,7 @@
     <if_sid>31100</if_sid>
     <url>.swp$|.bak$|/.htaccess|/server-status|/.ssh|/.history|/wallet.dat</url>
     <description>Suspicious URL access.</description>
-   <group>pci_dss_6.5,pci_dss_11.4,gdpr_IV_35.7.d,nist_800_53_SA.11,nist_800_53_SC.7,</group>
+   <group>pci_dss_6.5,pci_dss_11.4,gdpr_IV_35.7.d,nist_800_53_SA.11,nist_800_53_IA.10,</group>
    </rule>
 
   <!-- Checking POST requests - Too many in a small type = likely a bot -->
@@ -185,7 +185,7 @@
     <if_matched_sid>31530</if_matched_sid>
     <same_source_ip />
     <description>High amount of POST requests in a small period of time (likely bot).</description>
-   <group>pci_dss_6.5,pci_dss_11.4,gdpr_IV_35.7.d,nist_800_53_SA.11,nist_800_53_SC.7,</group>
+   <group>pci_dss_6.5,pci_dss_11.4,gdpr_IV_35.7.d,nist_800_53_SA.11,nist_800_53_IA.10,</group>
    </rule>
 
   <!-- Anomaly rules - Used on common web attacks -->
@@ -194,7 +194,7 @@
     <url>%00</url>
     <regex> "GET /\S+.php?\S+%00</regex>
     <description>Anomaly URL query (attempting to pass null termination).</description>
-   <group>pci_dss_6.5,pci_dss_11.4,gdpr_IV_35.7.d,nist_800_53_SA.11,nist_800_53_SC.7,</group>
+   <group>pci_dss_6.5,pci_dss_11.4,gdpr_IV_35.7.d,nist_800_53_SA.11,nist_800_53_IA.10,</group>
    </rule>
 
 </group>

--- a/rules/0270-web_appsec_rules.xml
+++ b/rules/0270-web_appsec_rules.xml
@@ -42,7 +42,7 @@
     <url>login.php</url>
     <regex> "POST /\S+.php/login.php?cPath=</regex>
     <description>osCommerce login.php bypass attempt.</description>
-    <group>pci_dss_6.5,pci_dss_11.4,pci_dss_10.2.4,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_SA.11,nist_800_53_IA.10,nist_800_53_IA.10,nist_800_53_AC.7,</group>
+    <group>pci_dss_6.5,pci_dss_11.4,pci_dss_10.2.4,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_SA.11,nist_800_53_IA.10,nist_800_53_AC.7,</group>
    </rule>
 
   <!-- osCommerce file manager login.php bypass
@@ -52,7 +52,7 @@
     <url>login.php</url>
     <regex>/admin/\w+.php/login.php</regex>
     <description>osCommerce file manager login.php bypass attempt.</description>
-    <group>pci_dss_6.5,pci_dss_11.4,pci_dss_10.2.4,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_SA.11,nist_800_53_IA.10,nist_800_53_IA.10,nist_800_53_AC.7,</group>
+    <group>pci_dss_6.5,pci_dss_11.4,pci_dss_10.2.4,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_SA.11,nist_800_53_IA.10,nist_800_53_AC.7,</group>
    </rule>
 
   <!-- Timthumb backdoor access.
@@ -62,7 +62,7 @@
     <url>/cache/external</url>
     <regex> "GET /\S+/cache/external\S+.php</regex>
     <description>TimThumb backdoor access attempt.</description>
-    <group>pci_dss_6.5,pci_dss_11.4,pci_dss_10.2.4,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_SA.11,nist_800_53_IA.10,nist_800_53_IA.10,nist_800_53_AC.7,</group>
+    <group>pci_dss_6.5,pci_dss_11.4,pci_dss_10.2.4,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_SA.11,nist_800_53_IA.10,nist_800_53_AC.7,</group>
    </rule>
 
   <!-- Timthumb backdoor access.
@@ -72,7 +72,7 @@
     <url>cart.php</url>
     <regex> "GET /\S+cart.php?\S+templatefile=../</regex>
     <description>Cart.php directory transversal attempt.</description>
-    <group>pci_dss_6.5,pci_dss_11.4,pci_dss_10.2.4,pci_dss_6.5.1,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_SA.11,nist_800_53_IA.10,nist_800_53_IA.10,nist_800_53_AC.7,</group>
+    <group>pci_dss_6.5,pci_dss_11.4,pci_dss_10.2.4,pci_dss_6.5.1,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_SA.11,nist_800_53_IA.10,nist_800_53_AC.7,</group>
    </rule>
 
   <!-- MSSQL IIS inject rules -->
@@ -97,7 +97,7 @@
     <url>wp-login.php|/administrator</url>
     <regex>] "POST \S+wp-login.php| "POST /administrator</regex>
     <description>CMS (WordPress or Joomla) login attempt.</description>
-   <group>pci_dss_6.5,pci_dss_11.4,pci_dss_6.5.10,pci_dss_10.2.4,pci_dss_10.2.5,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_SA.11,nist_800_53_IA.10,nist_800_53_IA.10,nist_800_53_AC.7,</group>
+   <group>pci_dss_6.5,pci_dss_11.4,pci_dss_6.5.10,pci_dss_10.2.4,pci_dss_10.2.5,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_SA.11,nist_800_53_IA.10,nist_800_53_AC.7,</group>
   </rule>
 
   <!-- If we see frequent wp-login POST's, it is likely a bot. -->
@@ -105,7 +105,7 @@
     <if_matched_sid>31509</if_matched_sid>
     <same_source_ip />
     <description>CMS (WordPress or Joomla) brute force attempt.</description>
-   <group>pci_dss_6.5,pci_dss_11.4,pci_dss_6.5.10,pci_dss_10.2.4,pci_dss_10.2.5,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_SA.11,nist_800_53_IA.10,nist_800_53_IA.10,nist_800_53_AC.7,</group>
+   <group>pci_dss_6.5,pci_dss_11.4,pci_dss_6.5.10,pci_dss_10.2.4,pci_dss_10.2.5,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_SA.11,nist_800_53_IA.10,nist_800_53_AC.7,</group>
   </rule>
 
   <!-- Nothing wrong with wget per se, but it misses a lot of links

--- a/rules/0275-squid_rules.xml
+++ b/rules/0275-squid_rules.xml
@@ -38,7 +38,7 @@
     <id>^401</id>
     <description>Squid: Unauthorized: Failed attempt to access </description>
     <description>authorization-required file or directory.</description>
-    <group>pci_dss_10.2.4,pci_dss_10.2.5,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>pci_dss_10.2.4,pci_dss_10.2.5,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,</group>
   </rule>
 
   <rule id="35005" level="5">
@@ -46,7 +46,7 @@
     <id>^403</id>
     <description>Squid: Forbidden: Attempt to access forbidden file </description>
     <description>or directory.</description>
-    <group>pci_dss_10.2.4,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>pci_dss_10.2.4,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,</group>
   </rule>
 
   <rule id="35006" level="5">
@@ -54,7 +54,7 @@
     <id>^404</id>
     <description>Squid: Not Found: Attempt to access non-existent </description>
     <description>file or directory.</description>
-    <group>pci_dss_10.2.4,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>pci_dss_10.2.4,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,</group>
   </rule>
 
   <rule id="35007" level="5">
@@ -62,7 +62,7 @@
     <id>^407</id>
     <description>Squid: Proxy Authentication Required: User is not </description>
     <description>authorized to use proxy.</description>
-    <group>pci_dss_10.2.4,pci_dss_10.2.5,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>pci_dss_10.2.4,pci_dss_10.2.5,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,</group>
   </rule>
 
   <rule id="35008" level="5">
@@ -93,7 +93,7 @@
     <description>file.</description>
     <info type="link">http://www.symantec.com/avcenter/venc/data/w32.beagle.dp.html</info>
     <info type="text">W32.Beagle.DP is a Worm that drops Trojan.Lodear and opens a back door on the compromised computer.</info>
-    <group>automatic_attack,pci_dss_11.4,pci_dss_6.2,gdpr_IV_35.7.d,nist_800_53_SC.7,nist_800_53_MA.2,</group>
+    <group>automatic_attack,pci_dss_11.4,pci_dss_6.2,gdpr_IV_35.7.d,nist_800_53_IA.10,nist_800_53_SI.2,</group>
   </rule>
 
   <!-- Other worms -->
@@ -101,7 +101,7 @@
     <if_sid>35006</if_sid>
     <url>/jk/exp.wmf$|/PopupSh.ocx$</url>
     <description>Squid: Attempt to access a worm/trojan related site.</description>
-    <group>automatic_attack,pci_dss_11.4,pci_dss_6.2,gdpr_IV_35.7.d,nist_800_53_SC.7,nist_800_53_MA.2,</group>
+    <group>automatic_attack,pci_dss_11.4,pci_dss_6.2,gdpr_IV_35.7.d,nist_800_53_IA.10,nist_800_53_SI.2,</group>
   </rule>
 
   <!-- Ignoring google earth, ms web site access and some other
@@ -139,14 +139,14 @@
     <different_url />
     <description>Squid: Multiple attempts to access forbidden file </description>
     <description>or directory from same source ip.</description>
-    <group>pci_dss_10.2.4,pci_dss_11.4,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,nist_800_53_SC.7,</group>
+    <group>pci_dss_10.2.4,pci_dss_11.4,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,nist_800_53_IA.10,</group>
   </rule>
 
   <rule id="35052" level="10" frequency="$SQUID_FREQ" timeframe="120">
     <if_matched_sid>35007</if_matched_sid>
     <same_source_ip />
     <description>Squid: Multiple unauthorized attempts to use proxy.</description>
-    <group>pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,nist_800_53_SC.7,</group>
+    <group>pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,nist_800_53_IA.10,</group>
   </rule>
 
   <rule id="35053" level="10" frequency="$SQUID_FREQ" timeframe="120">
@@ -163,7 +163,7 @@
     <description>Squid: Infected machine with W32.Beagle.DP.</description>
     <info type="link">http://www.symantec.com/avcenter/venc/data/w32.beagle.dp.html</info>
     <info type="text">W32.Beagle.DP is a Worm that drops Trojan.Lodear and opens a back door on the compromised computer.</info>
-    <group>pci_dss_11.4,pci_dss_6.2,gdpr_IV_35.7.d,nist_800_53_SC.7,nist_800_53_MA.2,</group>
+    <group>pci_dss_11.4,pci_dss_6.2,gdpr_IV_35.7.d,nist_800_53_IA.10,nist_800_53_SI.2,</group>
   </rule>
 
   <rule id="35055" level="10" frequency="$SQUID_FREQ" timeframe="90">
@@ -171,7 +171,7 @@
     <same_source_ip />
     <different_url />
     <description>Squid: Multiple attempts to access a non-existent file.</description>
-    <group>pci_dss_10.2.4,pci_dss_11.4,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,nist_800_53_SC.7,</group>
+    <group>pci_dss_10.2.4,pci_dss_11.4,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,nist_800_53_IA.10,</group>
   </rule>
 
   <rule id="35056" level="12" frequency="$SQUID_FREQ" timeframe="240">
@@ -179,7 +179,7 @@
     <same_source_ip />
     <description>Squid: Multiple attempts to access a worm/trojan/virus </description>
     <description>related web site. System probably infected.</description>
-    <group>pci_dss_10.2.4,pci_dss_11.4,gpg13_4.2,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,nist_800_53_SC.7,</group>
+    <group>pci_dss_10.2.4,pci_dss_11.4,gpg13_4.2,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,nist_800_53_IA.10,</group>
   </rule>
 
   <rule id="35057" level="10" frequency="$SQUID_FREQ" timeframe="240">

--- a/rules/0275-squid_rules.xml
+++ b/rules/0275-squid_rules.xml
@@ -139,14 +139,14 @@
     <different_url />
     <description>Squid: Multiple attempts to access forbidden file </description>
     <description>or directory from same source ip.</description>
-    <group>pci_dss_10.2.4,pci_dss_11.4,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,nist_800_53_IA.10,</group>
+    <group>pci_dss_10.2.4,pci_dss_11.4,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,</group>
   </rule>
 
   <rule id="35052" level="10" frequency="$SQUID_FREQ" timeframe="120">
     <if_matched_sid>35007</if_matched_sid>
     <same_source_ip />
     <description>Squid: Multiple unauthorized attempts to use proxy.</description>
-    <group>pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,nist_800_53_IA.10,</group>
+    <group>pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,</group>
   </rule>
 
   <rule id="35053" level="10" frequency="$SQUID_FREQ" timeframe="120">
@@ -171,7 +171,7 @@
     <same_source_ip />
     <different_url />
     <description>Squid: Multiple attempts to access a non-existent file.</description>
-    <group>pci_dss_10.2.4,pci_dss_11.4,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,nist_800_53_IA.10,</group>
+    <group>pci_dss_10.2.4,pci_dss_11.4,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,</group>
   </rule>
 
   <rule id="35056" level="12" frequency="$SQUID_FREQ" timeframe="240">
@@ -179,7 +179,7 @@
     <same_source_ip />
     <description>Squid: Multiple attempts to access a worm/trojan/virus </description>
     <description>related web site. System probably infected.</description>
-    <group>pci_dss_10.2.4,pci_dss_11.4,gpg13_4.2,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,nist_800_53_IA.10,</group>
+    <group>pci_dss_10.2.4,pci_dss_11.4,gpg13_4.2,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,</group>
   </rule>
 
   <rule id="35057" level="10" frequency="$SQUID_FREQ" timeframe="240">

--- a/rules/0280-attack_rules.xml
+++ b/rules/0280-attack_rules.xml
@@ -16,44 +16,44 @@
     <if_group>authentication_success</if_group>
     <user>$SYS_USERS</user>
     <description>System user successfully logged to the system.</description>
-    <group>invalid_login,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.8,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>invalid_login,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.8,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,</group>
   </rule>
 
   <rule id="40102" level="14">
     <regex>^rpc.statd[\d+]: gethostbyname error for \W+</regex>
     <description>Buffer overflow attack on rpc.statd</description>
-    <group>exploit_attempt,pci_dss_6.2,pci_dss_6.5.2,pci_dss_11.4,gdpr_IV_35.7.d,nist_800_53_MA.2,nist_800_53_SA.11,nist_800_53_SC.7,</group>
+    <group>exploit_attempt,pci_dss_6.2,pci_dss_6.5.2,pci_dss_11.4,gdpr_IV_35.7.d,nist_800_53_SI.2,nist_800_53_SA.11,nist_800_53_IA.10,</group>
   </rule>
 
   <rule id="40103" level="14">
     <regex>ftpd[\d+]: \S+ FTP LOGIN FROM \.+ 0bin0sh</regex>
     <description>Buffer overflow on WU-FTPD versions prior to 2.6</description>
-    <group>exploit_attempt,pci_dss_6.2,pci_dss_6.5.2,pci_dss_11.4,gdpr_IV_35.7.d,nist_800_53_MA.2,nist_800_53_SA.11,nist_800_53_SC.7,</group>
+    <group>exploit_attempt,pci_dss_6.2,pci_dss_6.5.2,pci_dss_11.4,gdpr_IV_35.7.d,nist_800_53_SI.2,nist_800_53_SA.11,nist_800_53_IA.10,</group>
   </rule>
 
   <rule id="40104" level="13">
     <match>?????????????????????</match>
     <description>Possible buffer overflow attempt.</description>
-    <group>exploit_attempt,pci_dss_6.2,pci_dss_6.5.2,pci_dss_11.4,gdpr_IV_35.7.d,nist_800_53_MA.2,nist_800_53_SA.11,nist_800_53_SC.7,</group>
+    <group>exploit_attempt,pci_dss_6.2,pci_dss_6.5.2,pci_dss_11.4,gdpr_IV_35.7.d,nist_800_53_SI.2,nist_800_53_SA.11,nist_800_53_IA.10,</group>
   </rule>
 
   <rule id="40105" level="12">
     <match>changed by \(\(null\)</match>
     <description>"Null" user changed some information.</description>
-    <group>exploit_attempt,pci_dss_10.2.7,pci_dss_10.6.1,pci_dss_11.4,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,nist_800_53_AU.6,nist_800_53_SC.7,</group>
+    <group>exploit_attempt,pci_dss_10.2.7,pci_dss_10.6.1,pci_dss_11.4,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AU.6,</group>
   </rule>
 
   <rule id="40106" level="12">
     <match>@@@@@@@@@@@@@@@@@@@@@@@@@</match>
     <description>Buffer overflow attempt (probably on yppasswd).</description>
-    <group>exploit_attempt,pci_dss_6.2,pci_dss_6.5.2,pci_dss_11.4,gdpr_IV_35.7.d,nist_800_53_MA.2,nist_800_53_SA.11,nist_800_53_SC.7,</group>
+    <group>exploit_attempt,pci_dss_6.2,pci_dss_6.5.2,pci_dss_11.4,gdpr_IV_35.7.d,nist_800_53_SI.2,nist_800_53_SA.11,nist_800_53_IA.10,</group>
   </rule>
 
   <rule id="40107" level="14">
     <regex>cachefsd: Segmentation Fault - core dumped</regex>
     <description>Heap overflow in the Solaris cachefsd service.</description>
     <info type='cve'>2002-0033</info>
-    <group>exploit_attempt,pci_dss_6.2,pci_dss_6.5.2,pci_dss_11.4,gdpr_IV_35.7.d,nist_800_53_MA.2,nist_800_53_SA.11,nist_800_53_SC.7,</group>
+    <group>exploit_attempt,pci_dss_6.2,pci_dss_6.5.2,pci_dss_11.4,gdpr_IV_35.7.d,nist_800_53_SI.2,nist_800_53_SA.11,nist_800_53_IA.10,</group>
   </rule>
 
   <rule id="40109" level="12">
@@ -61,14 +61,14 @@
     <description>Stack overflow attempt or program exiting </description>
     <description>with SEGV (Solaris).</description>
     <info type="link">http://snap.nlc.dcccd.edu/reference/sysadmin/julian/ch18/389-392.html</info>
-    <group>exploit_attempt,pci_dss_6.2,pci_dss_6.5.2,pci_dss_11.4,gdpr_IV_35.7.d,nist_800_53_MA.2,nist_800_53_SA.11,nist_800_53_SC.7,</group>
+    <group>exploit_attempt,pci_dss_6.2,pci_dss_6.5.2,pci_dss_11.4,gdpr_IV_35.7.d,nist_800_53_SI.2,nist_800_53_SA.11,nist_800_53_IA.10,</group>
   </rule>
 
   <rule id="40111" level="10" frequency="12" timeframe="160">
     <if_matched_group>authentication_failed</if_matched_group>
     <same_source_ip />
     <description>Multiple authentication failures.</description>
-    <group>authentication_failures,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,gpg13_7.8,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>authentication_failures,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,gpg13_7.8,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,</group>
   </rule>
 
   <rule id="40112" level="12" timeframe="240">
@@ -77,13 +77,13 @@
     <same_source_ip />
     <description>Multiple authentication failures followed </description>
     <description>by a success.</description>
-    <group>pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gpg13_7.1,gpg13_7.8,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,nist_800_53_SC.7,</group>
+    <group>pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gpg13_7.1,gpg13_7.8,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,nist_800_53_IA.10,</group>
   </rule>
 
   <rule id="40113" level="12" frequency="8" timeframe="360">
     <if_matched_group>virus</if_matched_group>
     <description>Multiple viruses detected - Possible outbreak.</description>
-    <group>virus,pci_dss_5.1,pci_dss_5.2,pci_dss_11.4,gpg13_4.2,gdpr_IV_35.7.d,nist_800_53_SI.5,nist_800_53_SC.7,</group>
+    <group>virus,pci_dss_5.1,pci_dss_5.2,pci_dss_11.4,gpg13_4.2,gdpr_IV_35.7.d,nist_800_53_SI.3,nist_800_53_IA.10,</group>
   </rule>
 
 </group>
@@ -96,7 +96,7 @@
     <same_location/>
     <description>Attacks followed by the addition </description>
     <description>of an user.</description>
-    <group>pci_dss_10.2.7,pci_dss_10.6.1,pci_dss_11.4,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,nist_800_53_AU.6,nist_800_53_SC.7,</group>
+    <group>pci_dss_10.2.7,pci_dss_10.6.1,pci_dss_11.4,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AU.6,</group>
   </rule>
 </group>
 
@@ -107,6 +107,6 @@
     <description>Network scan from same source ip.</description>
     <same_source_ip />
     <info type="link">http://project.honeynet.org/papers/enemy2/</info>
-    <group>pci_dss_11.4,gdpr_IV_35.7.d,nist_800_53_SC.7,</group>
+    <group>pci_dss_11.4,gdpr_IV_35.7.d,nist_800_53_IA.10,</group>
   </rule>
 </group>

--- a/rules/0280-attack_rules.xml
+++ b/rules/0280-attack_rules.xml
@@ -77,7 +77,7 @@
     <same_source_ip />
     <description>Multiple authentication failures followed </description>
     <description>by a success.</description>
-    <group>pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gpg13_7.1,gpg13_7.8,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,nist_800_53_IA.10,</group>
+    <group>pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gpg13_7.1,gpg13_7.8,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,</group>
   </rule>
 
   <rule id="40113" level="12" frequency="8" timeframe="360">

--- a/rules/0295-mysql_rules.xml
+++ b/rules/0295-mysql_rules.xml
@@ -17,14 +17,14 @@
     <if_sid>50100</if_sid>
     <regex>^MySQL log: \d+ \S+ \d+ Connect</regex>
     <description>MySQL: authentication success.</description>
-    <group>authentication_success,pci_dss_10.2.5,pci_dss_8.7,gpg13_7.1,gpg13_7.2,gdpr_IV_32.2,hipaa_164.312.b,hipaa_164.312.d,hipaa_164.312.e.1,hipaa_164.312.e.2.I,hipaa_164.312.e.2.II,nist_800_53_AU.3.1,nist_800_53_IA.10,nist_800_53_SC.2,</group>
+    <group>authentication_success,pci_dss_10.2.5,pci_dss_8.7,gpg13_7.1,gpg13_7.2,gdpr_IV_32.2,hipaa_164.312.b,hipaa_164.312.d,hipaa_164.312.e.1,hipaa_164.312.e.2.I,hipaa_164.312.e.2.II,nist_800_53_IA.10,nist_800_53_AC.7,nist_800_53_SC.2,</group>
   </rule>
 
   <rule id="50106" level="9">
     <if_sid>50105</if_sid>
     <match>Access denied for user</match>
     <description>MySQL: authentication failure.</description>
-    <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_8.7,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,hipaa_164.312.d,hipaa_164.312.e.1,hipaa_164.312.e.2.I,hipaa_164.312.e.2.II,nist_800_53_AU.3.1,nist_800_53_IA.10,nist_800_53_SC.2,</group>
+    <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_8.7,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,hipaa_164.312.d,hipaa_164.312.e.1,hipaa_164.312.e.2.I,hipaa_164.312.e.2.II,nist_800_53_IA.10,nist_800_53_AC.7,nist_800_53_SC.2,</group>
   </rule>
 
   <rule id="50107" level="0">
@@ -37,7 +37,7 @@
     <if_sid>50100</if_sid>
     <regex>^MySQL log: \d+ \S+ \d+ Quit</regex>
     <description>MySQL: User disconnected from database.</description>
-    <group>pci_dss_10.2.5,pci_dss_8.7,gpg13_7.1,gpg13_7.2,gdpr_IV_32.2,hipaa_164.312.b,hipaa_164.312.d,hipaa_164.312.e.1,hipaa_164.312.e.2.I,hipaa_164.312.e.2.II,nist_800_53_AU.3.1,nist_800_53_IA.10,nist_800_53_SC.2,</group>
+    <group>pci_dss_10.2.5,pci_dss_8.7,gpg13_7.1,gpg13_7.2,gdpr_IV_32.2,hipaa_164.312.b,hipaa_164.312.d,hipaa_164.312.e.1,hipaa_164.312.e.2.I,hipaa_164.312.e.2.II,nist_800_53_IA.10,nist_800_53_AC.7,nist_800_53_SC.2,</group>
   </rule>
 
   <rule id="50120" level="12">

--- a/rules/0300-postgresql_rules.xml
+++ b/rules/0300-postgresql_rules.xml
@@ -54,14 +54,14 @@
     <if_sid>50501</if_sid>
     <match>connection authorized</match>
     <description>PostgreSQL: Database authentication success.</description>
-    <group>authentication_success,pci_dss_10.2.5,gpg13_7.1,gpg13_7.2,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>authentication_success,pci_dss_10.2.5,gpg13_7.1,gpg13_7.2,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,</group>
   </rule>
 
   <rule id="50512" level="9">
     <if_sid>50504</if_sid>
     <match>authentication failed</match>
     <description>PostgreSQL: Database authentication failure.</description>
-    <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,</group>
   </rule>
 
   <rule id="50520" level="12">
@@ -81,13 +81,13 @@
   <rule id="50580" level="10" frequency="8" timeframe="120" ignore="60">
     <if_matched_sid>50504</if_matched_sid>
     <description>PostgreSQL: Multiple database errors.</description>
-    <group>service_availability,pci_dss_10.6.1,pci_dss_11.4,gpg13_4.3,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.6,nist_800_53_SC.7,</group>
+    <group>service_availability,pci_dss_10.6.1,pci_dss_11.4,gpg13_4.3,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.6,nist_800_53_IA.10,</group>
   </rule>
 
   <rule id="50581" level="10" frequency="8" timeframe="120" ignore="60">
     <if_matched_sid>50503</if_matched_sid>
     <description>PostgreSQL: Multiple database errors.</description>
-    <group>service_availability,pci_dss_10.6.1,pci_dss_11.4,gpg13_4.3,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.6,nist_800_53_SC.7,</group>
+    <group>service_availability,pci_dss_10.6.1,pci_dss_11.4,gpg13_4.3,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.6,nist_800_53_IA.10,</group>
   </rule>
 
 </group>

--- a/rules/0305-dropbear_rules.xml
+++ b/rules/0305-dropbear_rules.xml
@@ -30,42 +30,42 @@
     <if_sid>51000</if_sid>
     <match>bad password attempt for</match>
     <description>Dropbear: Bad password attempt.</description>
-    <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_8.1.5,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,hipaa_164.312.a.1,nist_800_53_AU.3.1,nist_800_53_IA.10,nist_800_53_AC.2,</group>
+    <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_8.1.5,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,hipaa_164.312.a.1,nist_800_53_IA.10,nist_800_53_AC.7,nist_800_53_AC.2,</group>
   </rule>
 
   <rule id="51093" level="5">
     <if_sid>51000</if_sid>
     <match>attempt for nonexistent user</match>
     <description>Dropbear: Bad password attempt for non existent user.</description>
-    <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_8.1.5,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,hipaa_164.312.a.1,nist_800_53_AU.3.1,nist_800_53_IA.10,nist_800_53_AC.2,</group>
+    <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_8.1.5,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,hipaa_164.312.a.1,nist_800_53_IA.10,nist_800_53_AC.7,nist_800_53_AC.2,</group>
   </rule>
 
   <rule id="51004" level="10" frequency="8" timeframe="120" ignore="60">
     <if_matched_group>authentication_failed</if_matched_group>
     <same_source_ip />
     <description>Dropbear: dropbear brute force attempt.</description>
-    <group>authentication_failures,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,pci_dss_8.1.5,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,hipaa_164.312.a.1,nist_800_53_AU.3.1,nist_800_53_IA.10,nist_800_53_SC.7,nist_800_53_AC.2,</group>
+    <group>authentication_failures,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,pci_dss_8.1.5,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,hipaa_164.312.a.1,nist_800_53_IA.10,nist_800_53_AC.7,nist_800_53_IA.10,nist_800_53_AC.2,</group>
   </rule>
 
   <rule id="51005" level="0">
     <if_sid>51000</if_sid>
     <regex>exit after auth \(\S+\): Disconnect received</regex>
     <description>Dropbear: User disconnected.</description>
-    <group>pci_dss_10.2.5,pci_dss_8.1.5,gpg13_7.1,gpg13_7.2,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,hipaa_164.312.a.1,nist_800_53_AU.3.1,nist_800_53_IA.10,nist_800_53_AC.2,</group>
+    <group>pci_dss_10.2.5,pci_dss_8.1.5,gpg13_7.1,gpg13_7.2,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,hipaa_164.312.a.1,nist_800_53_IA.10,nist_800_53_AC.7,nist_800_53_AC.2,</group>
   </rule>
 
   <rule id="51006" level="2">
     <if_sid>51000</if_sid>
     <match>exit before auth</match>
     <description>Dropbear: Client exited before authentication.</description>
-    <group>recon,pci_dss_10.6.1,pci_dss_11.4,pci_dss_8.1.5,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,hipaa_164.312.a.1,nist_800_53_AU.6,nist_800_53_SC.7,nist_800_53_AC.2,</group>
+    <group>recon,pci_dss_10.6.1,pci_dss_11.4,pci_dss_8.1.5,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,hipaa_164.312.a.1,nist_800_53_AU.6,nist_800_53_IA.10,nist_800_53_AC.2,</group>
   </rule>
 
   <rule id="51007" level="10" frequency="8" timeframe="120" ignore="60">
     <if_matched_sid>51000</if_matched_sid>
     <same_source_ip />
     <description>Dropbear: brute force attempt.</description>
-    <group>authentication_failures,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,pci_dss_8.1.5,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,hipaa_164.312.a.1,nist_800_53_AU.3.1,nist_800_53_IA.10,nist_800_53_SC.7,nist_800_53_AC.2,</group>
+    <group>authentication_failures,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,pci_dss_8.1.5,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,hipaa_164.312.a.1,nist_800_53_IA.10,nist_800_53_AC.7,nist_800_53_IA.10,nist_800_53_AC.2,</group>
   </rule>
 
 
@@ -73,21 +73,21 @@
     <if_sid>51000</if_sid>
     <match>Incompatible remote version</match>
     <description>Dropbear: Incompatible remote version.</description>
-    <group>recon,pci_dss_10.6.1,pci_dss_11.4,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.6,nist_800_53_SC.7,</group>
+    <group>recon,pci_dss_10.6.1,pci_dss_11.4,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.6,nist_800_53_IA.10,</group>
   </rule>
 
   <rule id="51009" level="0">
     <if_sid>51000</if_sid>
     <match>password auth succeeded for</match>
     <description>Dropbear: User successfully logged in using a password.</description>
-    <group>authentication_success,pci_dss_10.2.5,pci_dss_8.1.5,gpg13_7.1,gpg13_7.2,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,hipaa_164.312.a.1,nist_800_53_AU.3.1,nist_800_53_IA.10,nist_800_53_AC.2,</group>
+    <group>authentication_success,pci_dss_10.2.5,pci_dss_8.1.5,gpg13_7.1,gpg13_7.2,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,hipaa_164.312.a.1,nist_800_53_IA.10,nist_800_53_AC.7,nist_800_53_AC.2,</group>
   </rule>
 
   <rule id="51010" level="0">
     <if_sid>51000</if_sid>
     <match>Pubkey auth succeeded</match>
     <description>Dropbear: User successfully logged in using a public key.</description>
-    <group>authentication_success,pci_dss_10.2.5,pci_dss_8.1.5,gpg13_7.1,gpg13_7.2,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,hipaa_164.312.a.1,nist_800_53_AU.3.1,nist_800_53_IA.10,nist_800_53_AC.2,</group>
+    <group>authentication_success,pci_dss_10.2.5,pci_dss_8.1.5,gpg13_7.1,gpg13_7.2,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,hipaa_164.312.a.1,nist_800_53_IA.10,nist_800_53_AC.7,nist_800_53_AC.2,</group>
   </rule>
 
 </group>

--- a/rules/0305-dropbear_rules.xml
+++ b/rules/0305-dropbear_rules.xml
@@ -44,7 +44,7 @@
     <if_matched_group>authentication_failed</if_matched_group>
     <same_source_ip />
     <description>Dropbear: dropbear brute force attempt.</description>
-    <group>authentication_failures,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,pci_dss_8.1.5,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,hipaa_164.312.a.1,nist_800_53_IA.10,nist_800_53_AC.7,nist_800_53_IA.10,nist_800_53_AC.2,</group>
+    <group>authentication_failures,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,pci_dss_8.1.5,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,hipaa_164.312.a.1,nist_800_53_IA.10,nist_800_53_AC.7,nist_800_53_AC.2,</group>
   </rule>
 
   <rule id="51005" level="0">
@@ -65,7 +65,7 @@
     <if_matched_sid>51000</if_matched_sid>
     <same_source_ip />
     <description>Dropbear: brute force attempt.</description>
-    <group>authentication_failures,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,pci_dss_8.1.5,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,hipaa_164.312.a.1,nist_800_53_IA.10,nist_800_53_AC.7,nist_800_53_IA.10,nist_800_53_AC.2,</group>
+    <group>authentication_failures,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,pci_dss_8.1.5,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,hipaa_164.312.a.1,nist_800_53_IA.10,nist_800_53_AC.7,nist_800_53_AC.2,</group>
   </rule>
 
 

--- a/rules/0310-openbsd_rules.xml
+++ b/rules/0310-openbsd_rules.xml
@@ -42,14 +42,14 @@
     <if_sid>51500</if_sid>
     <match>was not properly unmounted</match>
     <description>A filesystem was not properly unmounted, likely system crash</description>
-    <group>pci_dss_10.2.7,gpg13_4.3,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>pci_dss_10.2.7,gpg13_4.3,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_IA.10,</group>
   </rule>
 
   <rule id="51506" level="1">
     <if_sid>51500</if_sid>
     <match>UKC> quit</match>
     <description>UKC was used, possibly modifying a kernel at boot time.</description>
-    <group>pci_dss_10.2.7,gpg13_4.12,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>pci_dss_10.2.7,gpg13_4.12,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_IA.10,</group>
   </rule>
 
   <rule id="51507" level="1">
@@ -76,14 +76,14 @@
     <if_sid>51500</if_sid>
     <match>Critical temperature, shutting down</match>
     <description>System shutdown due to temperature</description>
-    <group>pci_dss_10.2.7,gpg13_4.1,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>pci_dss_10.2.7,gpg13_4.1,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_IA.10,</group>
   </rule>
 
   <rule id="51511" level="1">
     <if_sid>51500</if_sid>
     <match>_AL0[0] _PR0 failed</match>
     <description>Unknown ACPI event (bug 6299 in OpenBSD bug tracking system).</description>
-    <group>pci_dss_10.2.7,pci_dss_6.2,gpg13_4.3,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,nist_800_53_MA.2,</group>
+    <group>pci_dss_10.2.7,pci_dss_6.2,gpg13_4.3,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_SI.2,</group>
   </rule>
 
   <rule id="51512" level="1">
@@ -142,14 +142,14 @@
   <rule id="51521" level="0" noalert="1">
     <decoded_as>groupdel</decoded_as>
     <description>Grouping for groupdel rules.</description>
-    <group>groupdel,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_32.2,hipaa_164.312.a.2.I,hipaa_164.312.a.2.II,hipaa_164.312.b,nist_800_53_AC.2,nist_800_53_IA.4,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>groupdel,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_32.2,hipaa_164.312.a.2.I,hipaa_164.312.a.2.II,hipaa_164.312.b,nist_800_53_AC.2,nist_800_53_IA.4,nist_800_53_IA.10,nist_800_53_AC.7,</group>
   </rule>
 
   <rule id="51522" level="2">
     <if_sid>51521</if_sid>
     <match>group deleted</match>
     <description>Group deleted.</description>
-    <group>groupdel,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.a.2.I,hipaa_164.312.a.2.II,hipaa_164.312.b,nist_800_53_AC.2,nist_800_53_IA.4,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>groupdel,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.a.2.I,hipaa_164.312.a.2.II,hipaa_164.312.b,nist_800_53_AC.2,nist_800_53_IA.4,nist_800_53_IA.10,nist_800_53_AC.7,</group>
   </rule>
 
   <rule id="51523" level="0">
@@ -174,7 +174,7 @@
     <decoded_as>bsd_kernel</decoded_as>
     <match>uncorrectable data error reading fsbn</match>
     <description>Hard drive is dying.</description>
-    <group>pci_dss_10.2.7,gpg13_4.3,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>pci_dss_10.2.7,gpg13_4.3,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_IA.10,</group>
   </rule>
 
   <rule id="51527" level="0">
@@ -203,14 +203,14 @@
     <program_name>^hotplugd</program_name>
     <match>Permission denied$</match>
     <description>hotplugd could not open a file.</description>
-    <group>pci_dss_10.2.4,gpg13_4.6,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>pci_dss_10.2.4,gpg13_4.6,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,</group>
   </rule>
 
   <rule id="51531" level="3">
     <decoded_as>open-userdel</decoded_as>
     <match>user removed: name=</match>
     <description>User account deleted.</description>
-    <group>account_changed,pci_dss_10.2.5,pci_dss_8.1.2,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,hipaa_164.312.a.2.I,hipaa_164.312.a.2.II,nist_800_53_AU.3.1,nist_800_53_IA.10,nist_800_53_AC.2,nist_800_53_IA.4,</group>
+    <group>account_changed,pci_dss_10.2.5,pci_dss_8.1.2,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,hipaa_164.312.a.2.I,hipaa_164.312.a.2.II,nist_800_53_IA.10,nist_800_53_AC.7,nist_800_53_AC.2,nist_800_53_IA.4,</group>
   </rule>
 
   <rule id="51532" level="0">

--- a/rules/0315-apparmor_rules.xml
+++ b/rules/0315-apparmor_rules.xml
@@ -32,14 +32,14 @@
     <if_sid>52002</if_sid>
     <extra_data>exec</extra_data>
     <description>Apparmor DENIED exec operation.</description>
-    <group>pci_dss_10.2.7,pci_dss_10.6.1,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,nist_800_53_AU.6,</group>
+    <group>pci_dss_10.2.7,pci_dss_10.6.1,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AU.6,</group>
   </rule>
 
   <rule id="52004" level="4">
     <if_sid>52002</if_sid>
     <extra_data>mknod</extra_data>
     <description>Apparmor DENIED mknod operation.</description>
-    <group>pci_dss_10.2.7,pci_dss_10.6.1,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,nist_800_53_AU.6,</group>
+    <group>pci_dss_10.2.7,pci_dss_10.6.1,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AU.6,</group>
   </rule>
 
 </group>

--- a/rules/0320-clam_av_rules.xml
+++ b/rules/0320-clam_av_rules.xml
@@ -23,7 +23,7 @@
     <if_sid>52500</if_sid>
     <match>FOUND</match>
     <description>ClamAV: Virus detected</description>
-    <group>virus,pci_dss_5.1,pci_dss_5.2,pci_dss_11.4,gpg13_4.2,gdpr_IV_35.7.d,nist_800_53_SI.5,nist_800_53_SC.7,</group>
+    <group>virus,pci_dss_5.1,pci_dss_5.2,pci_dss_11.4,gpg13_4.2,gdpr_IV_35.7.d,nist_800_53_SI.3,nist_800_53_IA.10,</group>
   </rule>
 
   <rule id="52503" level="10">
@@ -51,42 +51,42 @@
     <if_sid>52500</if_sid>
     <match>Database modification detected</match>
     <description>Clamd database updated</description>
-    <group>virus,pci_dss_5.2,gpg13_4.4,gdpr_IV_35.7.d,nist_800_53_SI.5,</group>
+    <group>virus,pci_dss_5.2,gpg13_4.4,gdpr_IV_35.7.d,nist_800_53_SI.3,</group>
   </rule>
 
   <rule id="52507" level="3">
     <if_sid>52501</if_sid>
     <match>ClamAV update process started </match>
     <description>ClamAV database update</description>
-    <group>virus,pci_dss_5.2,gpg13_4.4,gdpr_IV_35.7.d,nist_800_53_SI.5,</group>
+    <group>virus,pci_dss_5.2,gpg13_4.4,gdpr_IV_35.7.d,nist_800_53_SI.3,</group>
   </rule>
 
   <rule id="52508" level="3">
     <if_sid>52501</if_sid>
     <match>Database updated </match>
     <description>ClamAV database updated</description>
-    <group>virus,pci_dss_5.2,gpg13_4.4,gdpr_IV_35.7.d,nist_800_53_SI.5,</group>
+    <group>virus,pci_dss_5.2,gpg13_4.4,gdpr_IV_35.7.d,nist_800_53_SI.3,</group>
   </rule>
 
   <rule id="52509" level="0">
     <if_sid>52501</if_sid>
     <match>Incremental update failed|Error while reading database from|Update failed.</match>
     <description>ClamAV: Could not download the incremental virus definition updates.</description>
-    <group>pci_dss_5.2,pci_dss_11.4,gdpr_IV_35.7.d,nist_800_53_SI.5,nist_800_53_SC.7,</group>
+    <group>pci_dss_5.2,pci_dss_11.4,gdpr_IV_35.7.d,nist_800_53_SI.3,nist_800_53_IA.10,</group>
   </rule>
 
   <rule id="52510" level="6">
     <if_sid>52500</if_sid>
     <match>stop|Stop</match>
     <description>Clamd stopped</description>
-    <group>virus,pci_dss_5.1,gpg13_4.14,nist_800_53_SI.5,</group>
+    <group>virus,pci_dss_5.1,gpg13_4.14,nist_800_53_SI.3,</group>
   </rule>
 
   <rule id="52511" level="10" frequency="8">
     <if_matched_sid>52502</if_matched_sid>
     <same_id />
     <description>ClamAV: Virus detected multiple times</description>
-    <group>virus,pci_dss_5.1,pci_dss_5.2,pci_dss_11.4,gpg13_4.2,gdpr_IV_35.7.d,nist_800_53_SI.5,nist_800_53_SC.7,</group>
+    <group>virus,pci_dss_5.1,pci_dss_5.2,pci_dss_11.4,gpg13_4.2,gdpr_IV_35.7.d,nist_800_53_SI.3,nist_800_53_IA.10,</group>
   </rule>
 
 </group>

--- a/rules/0330-sysmon_rules.xml
+++ b/rules/0330-sysmon_rules.xml
@@ -128,7 +128,7 @@
         <if_group>sysmon_event1</if_group>
         <field name="sysmon.image">svchost.exe</field>
         <description>Sysmon - Suspicious Process - svchost.exe</description>
-        <group>pci_dss_10.6.1,pci_dss_11.4,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.6,nist_800_53_SC.7,</group>
+        <group>pci_dss_10.6.1,pci_dss_11.4,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.6,nist_800_53_IA.10,</group>
     </rule>
 
     <rule id="184667" level="0">
@@ -142,7 +142,7 @@
         <if_group>sysmon_event1</if_group>
         <field name="sysmon.image">lsm.exe</field>
         <description>Sysmon - Suspicious Process - lsm.exe</description>
-        <group>pci_dss_10.6.1,pci_dss_11.4,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.6,nist_800_53_SC.7,</group>
+        <group>pci_dss_10.6.1,pci_dss_11.4,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.6,nist_800_53_IA.10,</group>
     </rule>
 
     <rule id="184677" level="0">
@@ -155,7 +155,7 @@
         <if_group>sysmon_event1</if_group>
         <field name="sysmon.parentImage">lsm.exe</field>
         <description>Sysmon - Suspicious Process - lsm.exe is a Parent Image</description>
-        <group>pci_dss_10.6.1,pci_dss_11.4,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.6,nist_800_53_SC.7,</group>
+        <group>pci_dss_10.6.1,pci_dss_11.4,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.6,nist_800_53_IA.10,</group>
     </rule>
 
 
@@ -163,7 +163,7 @@
         <if_group>sysmon_event1</if_group>
         <field name="sysmon.image">csrss.exe</field>
         <description>Sysmon - Suspicious Process - csrss.exe</description>
-        <group>pci_dss_10.6.1,pci_dss_11.4,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.6,nist_800_53_SC.7,</group>
+        <group>pci_dss_10.6.1,pci_dss_11.4,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.6,nist_800_53_IA.10,</group>
     </rule>
 
     <rule id="184687" level="0">
@@ -177,7 +177,7 @@
         <if_group>sysmon_event1</if_group>
         <field name="sysmon.image">lsass.exe</field>
         <description>Sysmon - Suspicious Process - lsass</description>
-        <group>pci_dss_10.6.1,pci_dss_11.4,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.6,nist_800_53_SC.7,</group>
+        <group>pci_dss_10.6.1,pci_dss_11.4,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.6,nist_800_53_IA.10,</group>
     </rule>
 
     <rule id="184697" level="0">
@@ -190,7 +190,7 @@
         <if_group>sysmon_event1</if_group>
         <field name="sysmon.parentImage">lsass.exe</field>
         <description>Sysmon - Suspicious Process - lsass.exe is a Parent Image</description>
-        <group>pci_dss_10.6.1,pci_dss_11.4,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.6,nist_800_53_SC.7,</group>
+        <group>pci_dss_10.6.1,pci_dss_11.4,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.6,nist_800_53_IA.10,</group>
     </rule>
 
 
@@ -198,7 +198,7 @@
         <if_group>sysmon_event1</if_group>
         <field name="sysmon.image">winlogon.exe</field>
         <description>Sysmon - Suspicious Process - winlogon.exe</description>
-        <group>pci_dss_10.6.1,pci_dss_11.4,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.6,nist_800_53_SC.7,</group>
+        <group>pci_dss_10.6.1,pci_dss_11.4,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.6,nist_800_53_IA.10,</group>
     </rule>
 
     <rule id="184707" level="0">
@@ -212,7 +212,7 @@
         <if_group>sysmon_event1</if_group>
         <field name="sysmon.image">wininit.exe</field>
         <description>Sysmon - Suspicious Process - wininit</description>
-        <group>pci_dss_10.6.1,pci_dss_11.4,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.6,nist_800_53_SC.7,</group>
+        <group>pci_dss_10.6.1,pci_dss_11.4,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.6,nist_800_53_IA.10,</group>
     </rule>
 
     <rule id="184717" level="0">
@@ -226,7 +226,7 @@
         <if_group>sysmon_event1</if_group>
         <field name="sysmon.image">smss.exe</field>
         <description>Sysmon - Suspicious Process - smss.exe</description>
-        <group>pci_dss_10.6.1,pci_dss_11.4,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.6,nist_800_53_SC.7,</group>
+        <group>pci_dss_10.6.1,pci_dss_11.4,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.6,nist_800_53_IA.10,</group>
     </rule>
 
     <rule id="184727" level="0">
@@ -240,7 +240,7 @@
         <if_group>sysmon_event1</if_group>
         <field name="sysmon.image">taskhost.exe</field>
         <description>Sysmon - Suspicious Process - taskhost.exe</description>
-        <group>pci_dss_10.6.1,pci_dss_11.4,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.6,nist_800_53_SC.7,</group>
+        <group>pci_dss_10.6.1,pci_dss_11.4,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.6,nist_800_53_IA.10,</group>
     </rule>
 
     <rule id="184737" level="0">
@@ -254,7 +254,7 @@
         <if_group>sysmon_event1</if_group>
         <field name="sysmon.image">/services.exe</field>
         <description>Sysmon - Suspicious Process - services.exe</description>
-        <group>pci_dss_10.6.1,pci_dss_11.4,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.6,nist_800_53_SC.7,</group>
+        <group>pci_dss_10.6.1,pci_dss_11.4,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.6,nist_800_53_IA.10,</group>
     </rule>
 
     <rule id="184747" level="0">
@@ -268,7 +268,7 @@
         <if_group>sysmon_event1</if_group>
         <field name="sysmon.image">dllhost.exe</field>
         <description>Sysmon - Suspicious Process - dllhost.exe</description>
-        <group>pci_dss_10.6.1,pci_dss_11.4,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.6,nist_800_53_SC.7,</group>
+        <group>pci_dss_10.6.1,pci_dss_11.4,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.6,nist_800_53_IA.10,</group>
     </rule>
 
     <rule id="184767" level="0">
@@ -282,7 +282,7 @@
         <if_group>sysmon_event1</if_group>
         <field name="sysmon.image">\\explorer.exe</field>
         <description>Sysmon - Suspicious Process - explorer.exe</description>
-        <group>pci_dss_10.6.1,pci_dss_11.4,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.6,nist_800_53_SC.7,</group>
+        <group>pci_dss_10.6.1,pci_dss_11.4,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.6,nist_800_53_IA.10,</group>
     </rule>
 
     <rule id="184777" level="0">

--- a/rules/0345-netscaler_rules.xml
+++ b/rules/0345-netscaler_rules.xml
@@ -24,14 +24,14 @@ id (Decoder): AAA, UI, API, SSLVPN, EVENT, SSLLOG, APPFW, TCP, ROUTING, SNMP, AC
         <if_sid>80100</if_sid>
         <match>AAA LOGIN_FAILED</match>
         <description>Netscaler: AAA module failed to login the user</description>
-        <group>authentication_failed,netscaler-aaa,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,gpg13_3.3,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+        <group>authentication_failed,netscaler-aaa,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,gpg13_3.3,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,</group>
     </rule>
 
     <rule id="80102" level="10" frequency="8">
         <if_matched_sid>80101</if_matched_sid>
         <same_source_ip />
         <description>Netscaler: Multiple AAA failed to login the user</description>
-        <group>authentication_failures,netscaler-aaa,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gpg13_7.1,gpg13_3.3,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,nist_800_53_SC.7,</group>
+        <group>authentication_failures,netscaler-aaa,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gpg13_7.1,gpg13_3.3,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,nist_800_53_IA.10,</group>
     </rule>
 
     <!--
@@ -61,7 +61,7 @@ id (Decoder): AAA, UI, API, SSLVPN, EVENT, SSLLOG, APPFW, TCP, ROUTING, SNMP, AC
         <if_matched_sid>80104</if_matched_sid>
         <same_source_ip />
         <description>Netscaler: Multiple commands failed</description>
-        <group>netscaler-cmd,pci_dss_10.2.2,pci_dss_10.6.1,gpg13_3.5,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,nist_800_53_AU.6,</group>
+        <group>netscaler-cmd,pci_dss_10.2.2,pci_dss_10.6.1,gpg13_3.5,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.6,nist_800_53_AU.6,</group>
     </rule>
 
     <!-- 02/14/2012: 14:32:35 GMT CUA30070LBN6202 PPE-1 : UI CMD_EXECUTED 427 :  User ******** - Remote_ip 10.31.66.1 - Command "delete TEST" - Status "Success" -->
@@ -80,7 +80,7 @@ id (Decoder): AAA, UI, API, SSLVPN, EVENT, SSLLOG, APPFW, TCP, ROUTING, SNMP, AC
         <if_sid>80100</if_sid>
         <match>SSLVPN LOGIN</match>
         <description>Netscaler: SSLVPN login succeeds</description>
-        <group>netscaler-sslvpn,authentication_success,pci_dss_10.2.5,gpg13_7.1,gpg13_7.2,gpg13_3.6,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+        <group>netscaler-sslvpn,authentication_success,pci_dss_10.2.5,gpg13_7.1,gpg13_7.2,gpg13_3.6,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,</group>
     </rule>
 
     <!--SSLVPN LOGOUT
@@ -90,7 +90,7 @@ id (Decoder): AAA, UI, API, SSLVPN, EVENT, SSLLOG, APPFW, TCP, ROUTING, SNMP, AC
         <if_sid>80100</if_sid>
         <match>SSLVPN LOGOUT</match>
         <description>Netscaler: SSLVPN session logs out</description>
-        <group>netscaler-sslvpn,pci_dss_10.2.5,gpg13_7.1,gpg13_3.6,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+        <group>netscaler-sslvpn,pci_dss_10.2.5,gpg13_7.1,gpg13_3.6,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,</group>
     </rule>
 
     <!--SSLVPN ICASTART
@@ -122,14 +122,14 @@ id (Decoder): AAA, UI, API, SSLVPN, EVENT, SSLLOG, APPFW, TCP, ROUTING, SNMP, AC
         <if_sid>80100</if_sid>
         <match>SSLVPN NONHTTP_RESOURCEACCESS_DENIED</match>
         <description>Netscaler: A non-http resource access is denied by policy engine.</description>
-        <group>netscaler-sslvpn,access_denied,pci_dss_10.2.4,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+        <group>netscaler-sslvpn,access_denied,pci_dss_10.2.4,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,</group>
     </rule>
 
     <rule id="80112" level="10" frequency="10" timeframe="120">
         <if_matched_sid>80111</if_matched_sid>
         <same_source_ip />
         <description>Netscaler: Multiple non-http resource access denied</description>
-        <group>netscaler-sslvpn,access_denied,pci_dss_10.2.4,pci_dss_11.4,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,nist_800_53_SC.7,</group>
+        <group>netscaler-sslvpn,access_denied,pci_dss_10.2.4,pci_dss_11.4,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,nist_800_53_IA.10,</group>
     </rule>
 
     <!--
@@ -140,13 +140,13 @@ id (Decoder): AAA, UI, API, SSLVPN, EVENT, SSLLOG, APPFW, TCP, ROUTING, SNMP, AC
         <if_sid>80100</if_sid>
         <match>SSLVPN HTTP_RESOURCEACCESS_DENIED</match>
         <description>Netscaler: A http resource access is denied by policy engine</description>
-        <group>netscaler-sslvpn,access_denied,pci_dss_10.2.4,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+        <group>netscaler-sslvpn,access_denied,pci_dss_10.2.4,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,</group>
     </rule>
 
     <rule id="80114" level="10" frequency="10" timeframe="120">
         <if_matched_sid>80113</if_matched_sid>
         <description>Netscaler: Multiple http resource access denied</description>
-        <group>netscaler-sslvpn,access_denied,pci_dss_10.2.4,pci_dss_11.4,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,nist_800_53_SC.7,</group>
+        <group>netscaler-sslvpn,access_denied,pci_dss_10.2.4,pci_dss_11.4,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,nist_800_53_IA.10,</group>
     </rule>
 
     <!--
@@ -299,7 +299,7 @@ id (Decoder): AAA, UI, API, SSLVPN, EVENT, SSLLOG, APPFW, TCP, ROUTING, SNMP, AC
         <if_sid>80100</if_sid>
         <match>APPFW APPFW_STARTURL|APPFW APPFW_DENYURL|APPFW APPFW_CONTENT_TYPE|APPFW APPFW_REFERER_HEADER|APPFW APPFW_CSRF_TAG|APPFW APPFW_XSS|APPFW APPFW_XML_XSS|APPFW APPFW_SQL|APPFW APPFW_XML_SQL|APPFW APPFW_COOKIE|APPFW APPFW_FIELDCONSISTENCY|APPFWAPPFW_BUFFEROVERFLOW_URL|APPFW APPFW_BUFFEROVER FLOW_COOKIE|APPFW APPFW_BUFFEROVERFLOW_HDR|APPFW APPFW_FIELDFORMAT|APPFW APPFW_SAFECOMMERCE|APPFW APPFW_SAFECOMMERCE_XFORM|APPFW APPFW_SAFEOBJECT|APPFW APPFW_SIGNATURE_MATCH|APPFW_RESP APPFW_XML_XSS|APPFW_RESP APPFW_XML_SQL</match>
         <description>Netscaler: Firewall violation</description>
-        <group>netscaler-appfw,pci_dss_1.4,pci_dss_6.5,pci_dss_6.6,gpg13_3.5,gdpr_IV_35.7.d,hipaa_164.312.a.1,nist_800_53_SC.7,nist_800_53_SA.11,nist_800_53_SI.10,nist_800_53_SI.11,nist_800_53_SI.15,nist_800_53_SI.16,</group>
+        <group>netscaler-appfw,pci_dss_1.4,pci_dss_6.5,pci_dss_6.6,gpg13_3.5,gdpr_IV_35.7.d,hipaa_164.312.a.1,nist_800_53_SC.7,nist_800_53_SA.11,</group>
     </rule>
 
 
@@ -324,7 +324,7 @@ id (Decoder): AAA, UI, API, SSLVPN, EVENT, SSLLOG, APPFW, TCP, ROUTING, SNMP, AC
         <if_sid>80100</if_sid>
         <match>APPFW APPFW_XML_ERR_DOS|APPFW APPFW_XML_DDOS_ERR|APPFW_RESP APPFW_XML_DDOS_ERR_MSG_SEND_FAI|APPFW_RESP APPFW_XML_DOS_ERR_CHAR_DATA_LENGTH</match>
         <description>Netscaler: Firewall: DOS\DDOS error</description>
-        <group>netscaler-appfw,pci_dss_1.4,pci_dss_11.4,gpg13_3.5,gdpr_IV_35.7.d,hipaa_164.312.a.1,nist_800_53_SC.7,</group>
+        <group>netscaler-appfw,pci_dss_1.4,pci_dss_11.4,gpg13_3.5,gdpr_IV_35.7.d,hipaa_164.312.a.1,nist_800_53_SC.7,nist_800_53_IA.10,</group>
     </rule>
 
     <!--
@@ -378,7 +378,7 @@ id (Decoder): AAA, UI, API, SSLVPN, EVENT, SSLLOG, APPFW, TCP, ROUTING, SNMP, AC
         <if_sid>80100</if_sid>
         <match>AAATM LOGIN</match>
         <description>Netscaler: Login to AAA TM vserver succeeds</description>
-        <group>netscaler-aaatm,authentication_success,pci_dss_10.2.5,gpg13_3.6,gpg13_7.1,gpg13_7.2,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+        <group>netscaler-aaatm,authentication_success,pci_dss_10.2.5,gpg13_3.6,gpg13_7.1,gpg13_7.2,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,</group>
     </rule>
 
     <!--
@@ -389,7 +389,7 @@ id (Decoder): AAA, UI, API, SSLVPN, EVENT, SSLLOG, APPFW, TCP, ROUTING, SNMP, AC
         <if_sid>80100</if_sid>
         <match>AAATM LOGOUT</match>
         <description>Netscaler: AAA TM session logged out</description>
-        <group>netscaler-aaatm,pci_dss_10.2.5,gpg13_3.6,gpg13_7.1,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+        <group>netscaler-aaatm,pci_dss_10.2.5,gpg13_3.6,gpg13_7.1,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,</group>
     </rule>
 
     <!--
@@ -399,13 +399,13 @@ id (Decoder): AAA, UI, API, SSLVPN, EVENT, SSLLOG, APPFW, TCP, ROUTING, SNMP, AC
         <if_sid>80100</if_sid>
         <match>AAATM HTTP_RESOURCEACCESS_DENIED</match>
         <description>Netscaler: A AAATM http resource access is denied by policy engine</description>
-        <group>netscaler-aaatm,access_denied,pci_dss_10.2.4,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+        <group>netscaler-aaatm,access_denied,pci_dss_10.2.4,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,</group>
     </rule>
 
     <rule id="80137" level="10" frequency="10" timeframe="120">
         <if_matched_sid>80136</if_matched_sid>
         <description>Netscaler: Multiple AAATM http resource access denied</description>
-        <group>netscaler-aaatm,access_denied,pci_dss_10.2.4,pci_dss_11.4,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,nist_800_53_SC.7,</group>
+        <group>netscaler-aaatm,access_denied,pci_dss_10.2.4,pci_dss_11.4,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,nist_800_53_IA.10,</group>
     </rule>
 
     <!--
@@ -421,7 +421,7 @@ id (Decoder): AAA, UI, API, SSLVPN, EVENT, SSLLOG, APPFW, TCP, ROUTING, SNMP, AC
         <regex>Command "login</regex>
         <status>Success</status>
         <description>Netscaler: UI/API login succeeds</description>
-        <group>netscaler-cmd,authentication_success,pci_dss_10.2.5,gpg13_3.5,gpg13_7.1,gpg13_7.2,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+        <group>netscaler-cmd,authentication_success,pci_dss_10.2.5,gpg13_3.5,gpg13_7.1,gpg13_7.2,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,</group>
     </rule>
 
     <rule id="80139" level="6">
@@ -430,14 +430,14 @@ id (Decoder): AAA, UI, API, SSLVPN, EVENT, SSLLOG, APPFW, TCP, ROUTING, SNMP, AC
         <regex>Command "login</regex>
         <status>Error</status>
         <description>Netscaler: UI/API login failed</description>
-        <group>authentication_failed,netscaler-cmd,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_3.3,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+        <group>authentication_failed,netscaler-cmd,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_3.3,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,</group>
     </rule>
 
     <rule id="80140" level="10" frequency="8">
         <if_matched_sid>80139</if_matched_sid>
         <same_source_ip />
         <description>Netscaler: Multiple UI/API login failed</description>
-        <group>authentication_failures,netscaler-cmd,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gpg13_3.3,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,nist_800_53_SC.7,</group>
+        <group>authentication_failures,netscaler-cmd,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gpg13_3.3,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,nist_800_53_IA.10,</group>
     </rule>
 
 </group>

--- a/rules/0345-netscaler_rules.xml
+++ b/rules/0345-netscaler_rules.xml
@@ -31,7 +31,7 @@ id (Decoder): AAA, UI, API, SSLVPN, EVENT, SSLLOG, APPFW, TCP, ROUTING, SNMP, AC
         <if_matched_sid>80101</if_matched_sid>
         <same_source_ip />
         <description>Netscaler: Multiple AAA failed to login the user</description>
-        <group>authentication_failures,netscaler-aaa,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gpg13_7.1,gpg13_3.3,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,nist_800_53_IA.10,</group>
+        <group>authentication_failures,netscaler-aaa,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gpg13_7.1,gpg13_3.3,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,</group>
     </rule>
 
     <!--
@@ -129,7 +129,7 @@ id (Decoder): AAA, UI, API, SSLVPN, EVENT, SSLLOG, APPFW, TCP, ROUTING, SNMP, AC
         <if_matched_sid>80111</if_matched_sid>
         <same_source_ip />
         <description>Netscaler: Multiple non-http resource access denied</description>
-        <group>netscaler-sslvpn,access_denied,pci_dss_10.2.4,pci_dss_11.4,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,nist_800_53_IA.10,</group>
+        <group>netscaler-sslvpn,access_denied,pci_dss_10.2.4,pci_dss_11.4,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,</group>
     </rule>
 
     <!--
@@ -146,7 +146,7 @@ id (Decoder): AAA, UI, API, SSLVPN, EVENT, SSLLOG, APPFW, TCP, ROUTING, SNMP, AC
     <rule id="80114" level="10" frequency="10" timeframe="120">
         <if_matched_sid>80113</if_matched_sid>
         <description>Netscaler: Multiple http resource access denied</description>
-        <group>netscaler-sslvpn,access_denied,pci_dss_10.2.4,pci_dss_11.4,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,nist_800_53_IA.10,</group>
+        <group>netscaler-sslvpn,access_denied,pci_dss_10.2.4,pci_dss_11.4,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,</group>
     </rule>
 
     <!--
@@ -405,7 +405,7 @@ id (Decoder): AAA, UI, API, SSLVPN, EVENT, SSLLOG, APPFW, TCP, ROUTING, SNMP, AC
     <rule id="80137" level="10" frequency="10" timeframe="120">
         <if_matched_sid>80136</if_matched_sid>
         <description>Netscaler: Multiple AAATM http resource access denied</description>
-        <group>netscaler-aaatm,access_denied,pci_dss_10.2.4,pci_dss_11.4,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,nist_800_53_IA.10,</group>
+        <group>netscaler-aaatm,access_denied,pci_dss_10.2.4,pci_dss_11.4,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,</group>
     </rule>
 
     <!--
@@ -437,7 +437,7 @@ id (Decoder): AAA, UI, API, SSLVPN, EVENT, SSLLOG, APPFW, TCP, ROUTING, SNMP, AC
         <if_matched_sid>80139</if_matched_sid>
         <same_source_ip />
         <description>Netscaler: Multiple UI/API login failed</description>
-        <group>authentication_failures,netscaler-cmd,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gpg13_3.3,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,nist_800_53_IA.10,</group>
+        <group>authentication_failures,netscaler-cmd,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gpg13_3.3,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,</group>
     </rule>
 
 </group>

--- a/rules/0350-amazon_rules.xml
+++ b/rules/0350-amazon_rules.xml
@@ -46,7 +46,7 @@ ID: 80200 - 80499
         <if_sid>80203</if_sid>
         <field name="aws.errorCode">AccessDenied</field>
         <description>AWS Cloudtrail: $(aws.eventSource) - $(aws.eventName). Error: $(aws.errorCode).</description>
-        <group>aws_cloudtrail,pci_dss_10.6.1,pci_dss_10.2.4,pci_dss_10.2.5,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.6,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+        <group>aws_cloudtrail,pci_dss_10.6.1,pci_dss_10.2.4,pci_dss_10.2.5,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.6,nist_800_53_IA.10,nist_800_53_AC.7,</group>
     </rule>
 
     <!-- Events with no errors -->
@@ -68,20 +68,20 @@ ID: 80200 - 80499
         <if_sid>80202</if_sid>
         <field name="aws.eventName">ConsoleLogin</field>
         <description>AWS Cloudtrail: $(aws.eventSource) - $(aws.eventName) - User Login Success.</description>
-        <group>aws_cloudtrail,authentication_success,pci_dss_10.2.5,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+        <group>aws_cloudtrail,authentication_success,pci_dss_10.2.5,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,</group>
     </rule>
 
     <rule id="80254" level="5">
         <if_sid>80253</if_sid>
         <field name="aws.responseElements.ConsoleLogin">Failure</field>
         <description>AWS Cloudtrail: $(aws.eventSource) - $(aws.eventName) - User Login failed.</description>
-        <group>aws_cloudtrail,authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+        <group>aws_cloudtrail,authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,</group>
     </rule>
 
     <rule id="80255" level="10" frequency="6" timeframe="360">
         <if_matched_sid>80254</if_matched_sid>
         <description>AWS Cloudtrail: $(aws.eventSource) - $(aws.eventName) - Possible breaking attempt (high number of login attempts).</description>
-        <group>aws_cloudtrail,authentication_failures,pci_dss_11.4,pci_dss_10.2.4,pci_dss_10.2.5,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_SC.7,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+        <group>aws_cloudtrail,authentication_failures,pci_dss_11.4,pci_dss_10.2.4,pci_dss_10.2.5,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_IA.10,nist_800_53_AC.7,</group>
     </rule>
 
 

--- a/rules/0350-amazon_rules.xml
+++ b/rules/0350-amazon_rules.xml
@@ -81,7 +81,7 @@ ID: 80200 - 80499
     <rule id="80255" level="10" frequency="6" timeframe="360">
         <if_matched_sid>80254</if_matched_sid>
         <description>AWS Cloudtrail: $(aws.eventSource) - $(aws.eventName) - Possible breaking attempt (high number of login attempts).</description>
-        <group>aws_cloudtrail,authentication_failures,pci_dss_11.4,pci_dss_10.2.4,pci_dss_10.2.5,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_IA.10,nist_800_53_AC.7,</group>
+        <group>aws_cloudtrail,authentication_failures,pci_dss_11.4,pci_dss_10.2.4,pci_dss_10.2.5,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,</group>
     </rule>
 
 

--- a/rules/0360-serv-u_rules.xml
+++ b/rules/0360-serv-u_rules.xml
@@ -68,7 +68,7 @@ TypeMessage:
         <action>02</action>
         <match>logged in</match>
         <description>Serv-U: User logged in</description>
-        <group>authentication_success,pci_dss_10.2.5,gpg13_7.1,gpg13_7.2,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+        <group>authentication_success,pci_dss_10.2.5,gpg13_7.1,gpg13_7.2,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,</group>
     </rule>
 
     <!--
@@ -93,14 +93,14 @@ TypeMessage:
         <action>02</action>
         <match>Invalid login credentials|Password wrong too many times</match>
         <description>Serv-U: Invalid credentials</description>
-        <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+        <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,</group>
     </rule>
 
     <rule id="80506" level="10" frequency="8">
         <if_matched_sid>80505</if_matched_sid>
         <same_user />
         <description>Serv-U: Multiple authentication failures.</description>
-        <group>authentication_failures,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,nist_800_53_SC.7,</group>
+        <group>authentication_failures,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,nist_800_53_IA.10,</group>
     </rule>
 
     <!--
@@ -136,7 +136,7 @@ TypeMessage:
         <action>02</action>
         <match>Connected to</match>
         <description>Serv-U: Remote host connected</description>
-        <group>pci_dss_10.2.1,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+        <group>pci_dss_10.2.1,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_IA.10,</group>
     </rule>
 
     <!--
@@ -272,7 +272,7 @@ TypeMessage:
         <action>21</action>
         <match>530 Sorry, no ANONYMOUS access allowed</match>
         <description>Serv-U: Attempt to login using anonymous user</description>
-        <group>authentication_failures,pci_dss_10.2.4,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+        <group>authentication_failures,pci_dss_10.2.4,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,</group>
         <group>gpg13_7.1,</group>
     </rule>
 
@@ -287,7 +287,7 @@ TypeMessage:
         <action>21</action>
         <match>Permission denied</match>
         <description>Serv-U: FTP/FTPS Permission denied</description>
-        <group>pci_dss_10.2.4,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+        <group>pci_dss_10.2.4,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,</group>
     </rule>
 
     <rule id="80523" level="4">
@@ -295,7 +295,7 @@ TypeMessage:
         <action>31</action>
         <match>Permission denied</match>
         <description>Serv-U: SFTP (SSH) Permission denied</description>
-        <group>pci_dss_10.2.4,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+        <group>pci_dss_10.2.4,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,</group>
     </rule>
 
     <rule id="80524" level="4">
@@ -303,7 +303,7 @@ TypeMessage:
         <action>41</action>
         <match>SESS_PERMISSION_DENIED</match>
         <description>Serv-U: HTTP/HTTPS Permission denied</description>
-        <group>pci_dss_10.2.4,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+        <group>pci_dss_10.2.4,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,</group>
     </rule>
 
 </group>

--- a/rules/0360-serv-u_rules.xml
+++ b/rules/0360-serv-u_rules.xml
@@ -100,7 +100,7 @@ TypeMessage:
         <if_matched_sid>80505</if_matched_sid>
         <same_user />
         <description>Serv-U: Multiple authentication failures.</description>
-        <group>authentication_failures,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,nist_800_53_IA.10,</group>
+        <group>authentication_failures,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,</group>
     </rule>
 
     <!--

--- a/rules/0365-auditd_rules.xml
+++ b/rules/0365-auditd_rules.xml
@@ -198,7 +198,7 @@
         <if_sid>80700</if_sid>
         <field name="audit.type">ANOM_LOGIN_ACCT</field>
         <description>Auditd: account login attempt ended abnormally.</description>
-        <group>audit_anom,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,pci_dss_10.6.1,gpg13_7.9,gdpr_IV_35.7.d,gdpr_IV_32.2,gdpr_IV_30.1.g,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,nist_800_53_IA.10,nist_800_53_AU.6,</group>
+        <group>audit_anom,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,pci_dss_10.6.1,gpg13_7.9,gdpr_IV_35.7.d,gdpr_IV_32.2,gdpr_IV_30.1.g,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,nist_800_53_AU.6,</group>
     </rule>
 
     <!--

--- a/rules/0365-auditd_rules.xml
+++ b/rules/0365-auditd_rules.xml
@@ -76,7 +76,7 @@
         <field name="audit.type">ANOM_PROMISCUOUS</field>
         <match>prom=256</match>
         <description>Auditd: device enables promiscuous mode</description>
-        <group>audit_anom,pci_dss_11.4,pci_dss_10.6.1,gpg13_4.14,gdpr_IV_35.7.d,gdpr_IV_30.1.g,hipaa_164.312.b,nist_800_53_SC.7,nist_800_53_AU.6,</group>
+        <group>audit_anom,pci_dss_11.4,pci_dss_10.6.1,gpg13_4.14,gdpr_IV_35.7.d,gdpr_IV_30.1.g,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AU.6,</group>
     </rule>
 
     <!--
@@ -86,7 +86,7 @@
         <if_sid>80700</if_sid>
         <field name="audit.type">ANOM_ABEND</field>
         <description>Auditd: process ended abnormally</description>
-        <group>audit_anom,pci_dss_11.4,pci_dss_10.6.1,gpg13_4.14,gdpr_IV_35.7.d,gdpr_IV_30.1.g,hipaa_164.312.b,nist_800_53_SC.7,nist_800_53_AU.6,</group>
+        <group>audit_anom,pci_dss_11.4,pci_dss_10.6.1,gpg13_4.14,gdpr_IV_35.7.d,gdpr_IV_30.1.g,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AU.6,</group>
     </rule>
 
     <!--
@@ -96,7 +96,7 @@
         <if_sid>80700</if_sid>
         <field name="audit.type">ANOM_EXEC</field>
         <description>Auditd: execution of a file ended abnormally</description>
-        <group>audit_anom,pci_dss_11.4,pci_dss_10.6.1,gpg13_4.14,gdpr_IV_35.7.d,gdpr_IV_30.1.g,hipaa_164.312.b,nist_800_53_SC.7,nist_800_53_AU.6,</group>
+        <group>audit_anom,pci_dss_11.4,pci_dss_10.6.1,gpg13_4.14,gdpr_IV_35.7.d,gdpr_IV_30.1.g,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AU.6,</group>
     </rule>
 
     <!--
@@ -106,7 +106,7 @@
         <if_sid>80700</if_sid>
         <field name="audit.type">ANOM_MK_EXEC</field>
         <description>Auditd: file is made executable</description>
-        <group>audit_anom,pci_dss_11.4,pci_dss_10.6.1,gpg13_4.6,gdpr_IV_35.7.d,gdpr_IV_30.1.g,hipaa_164.312.b,nist_800_53_SC.7,nist_800_53_AU.6,</group>
+        <group>audit_anom,pci_dss_11.4,pci_dss_10.6.1,gpg13_4.6,gdpr_IV_35.7.d,gdpr_IV_30.1.g,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AU.6,</group>
     </rule>
 
     <!--
@@ -116,7 +116,7 @@
         <if_sid>80700</if_sid>
         <field name="audit.type">ANOM_ACCESS_FS</field>
         <description>Auditd: file or a directory access ended abnormally</description>
-        <group>audit_anom,pci_dss_11.4,pci_dss_10.6.1,gdpr_IV_35.7.d,gdpr_IV_30.1.g,hipaa_164.312.b,nist_800_53_SC.7,nist_800_53_AU.6,</group>
+        <group>audit_anom,pci_dss_11.4,pci_dss_10.6.1,gdpr_IV_35.7.d,gdpr_IV_30.1.g,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AU.6,</group>
     </rule>
 
     <!--
@@ -126,7 +126,7 @@
         <if_sid>80700</if_sid>
         <field name="audit.type">ANOM_AMTU_FAIL</field>
         <description>Auditd: failure of the Abstract Machine Test Utility (AMTU) detected</description>
-        <group>audit_anom,pci_dss_11.4,pci_dss_10.6.1,gdpr_IV_35.7.d,gdpr_IV_30.1.g,hipaa_164.312.b,nist_800_53_SC.7,nist_800_53_AU.6,</group>
+        <group>audit_anom,pci_dss_11.4,pci_dss_10.6.1,gdpr_IV_35.7.d,gdpr_IV_30.1.g,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AU.6,</group>
     </rule>
 
     <!--
@@ -137,7 +137,7 @@
         <if_sid>80700</if_sid>
         <field name="audit.type">ANOM_MAX_DAC|ANOM_MAX_MAC</field>
         <description>Auditd: maximum amount of Discretionary Access Control (DAC) or Mandatory Access Control (MAC) failures reached</description>
-        <group>audit_anom,pci_dss_11.4,pci_dss_10.6.1,gdpr_IV_35.7.d,gdpr_IV_30.1.g,hipaa_164.312.b,nist_800_53_SC.7,nist_800_53_AU.6,</group>
+        <group>audit_anom,pci_dss_11.4,pci_dss_10.6.1,gdpr_IV_35.7.d,gdpr_IV_30.1.g,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AU.6,</group>
     </rule>
 
     <!--
@@ -148,7 +148,7 @@
         <if_sid>80700</if_sid>
         <field name="audit.type">ANOM_RBAC_FAIL|ANOM_RBAC_INTEGRITY_FAIL</field>
         <description>Auditd: Role-Based Access Control (RBAC) failure detected.</description>
-        <group>audit_anom,pci_dss_11.4,pci_dss_10.6.1,gdpr_IV_35.7.d,gdpr_IV_30.1.g,hipaa_164.312.b,nist_800_53_SC.7,nist_800_53_AU.6,</group>
+        <group>audit_anom,pci_dss_11.4,pci_dss_10.6.1,gdpr_IV_35.7.d,gdpr_IV_30.1.g,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AU.6,</group>
     </rule>
 
     <!--
@@ -158,7 +158,7 @@
         <if_sid>80700</if_sid>
         <field name="audit.type">ANOM_ADD_ACCT</field>
         <description>Auditd: user-space account addition ended abnormally.</description>
-        <group>audit_anom,pci_dss_11.4,pci_dss_10.6.1,gpg13_7.9,gdpr_IV_35.7.d,gdpr_IV_30.1.g,hipaa_164.312.b,nist_800_53_SC.7,nist_800_53_AU.6,</group>
+        <group>audit_anom,pci_dss_11.4,pci_dss_10.6.1,gpg13_7.9,gdpr_IV_35.7.d,gdpr_IV_30.1.g,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AU.6,</group>
     </rule>
 
     <!--
@@ -168,7 +168,7 @@
         <if_sid>80700</if_sid>
         <field name="audit.type">ANOM_DEL_ACCT</field>
         <description>Auditd: user-space account deletion ended abnormally.</description>
-        <group>audit_anom,pci_dss_11.4,pci_dss_10.6.1,gpg13_7.9,gdpr_IV_35.7.d,gdpr_IV_30.1.g,hipaa_164.312.b,nist_800_53_SC.7,nist_800_53_AU.6,</group>
+        <group>audit_anom,pci_dss_11.4,pci_dss_10.6.1,gpg13_7.9,gdpr_IV_35.7.d,gdpr_IV_30.1.g,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AU.6,</group>
     </rule>
 
     <!--
@@ -178,7 +178,7 @@
         <if_sid>80700</if_sid>
         <field name="audit.type">ANOM_MOD_ACCT</field>
         <description>Auditd: user-space account modification ended abnormally.</description>
-        <group>audit_anom,pci_dss_11.4,pci_dss_10.6.1,gpg13_7.9,gdpr_IV_35.7.d,gdpr_IV_30.1.g,hipaa_164.312.b,nist_800_53_SC.7,nist_800_53_AU.6,</group>
+        <group>audit_anom,pci_dss_11.4,pci_dss_10.6.1,gpg13_7.9,gdpr_IV_35.7.d,gdpr_IV_30.1.g,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AU.6,</group>
     </rule>
 
     <!--
@@ -188,7 +188,7 @@
         <if_sid>80700</if_sid>
         <field name="audit.type">ANOM_ROOT_TRANS</field>
         <description>Auditd: user becomes root</description>
-        <group>audit_anom,pci_dss_11.4,pci_dss_10.6.1,gpg13_7.9,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_SC.7,nist_800_53_AU.6,</group>
+        <group>audit_anom,pci_dss_11.4,pci_dss_10.6.1,gpg13_7.9,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AU.6,</group>
     </rule>
 
     <!--
@@ -198,7 +198,7 @@
         <if_sid>80700</if_sid>
         <field name="audit.type">ANOM_LOGIN_ACCT</field>
         <description>Auditd: account login attempt ended abnormally.</description>
-        <group>audit_anom,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,pci_dss_10.6.1,gpg13_7.9,gdpr_IV_35.7.d,gdpr_IV_32.2,gdpr_IV_30.1.g,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,nist_800_53_SC.7,nist_800_53_AU.6,</group>
+        <group>audit_anom,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,pci_dss_10.6.1,gpg13_7.9,gdpr_IV_35.7.d,gdpr_IV_32.2,gdpr_IV_30.1.g,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,nist_800_53_IA.10,nist_800_53_AU.6,</group>
     </rule>
 
     <!--
@@ -208,7 +208,7 @@
         <if_sid>80700</if_sid>
         <field name="audit.type">ANOM_LOGIN_FAILURES</field>
         <description>Auditd: limit of failed login attempts reached.</description>
-        <group>audit_anom,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.5,gdpr_IV_35.7.d,gdpr_IV_32.2,gdpr_IV_30.1.g,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+        <group>audit_anom,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.5,gdpr_IV_35.7.d,gdpr_IV_32.2,gdpr_IV_30.1.g,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,</group>
     </rule>
 
     <!--
@@ -218,7 +218,7 @@
         <if_sid>80700</if_sid>
         <field name="audit.type">ANOM_LOGIN_LOCATION</field>
         <description>Auditd: login attempt from a forbidden location.</description>
-        <group>audit_anom,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_10.6.1,gpg13_7.5,gdpr_IV_35.7.d,gdpr_IV_32.2,gdpr_IV_30.1.g,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,nist_800_53_AU.6,</group>
+        <group>audit_anom,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_10.6.1,gpg13_7.5,gdpr_IV_35.7.d,gdpr_IV_32.2,gdpr_IV_30.1.g,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,nist_800_53_AU.6,</group>
     </rule>
 
     <!--
@@ -228,7 +228,7 @@
         <if_sid>80700</if_sid>
         <field name="audit.type">ANOM_LOGIN_SESSIONS</field>
         <description>Auditd: login attempt reached the maximum amount of concurrent sessions.</description>
-        <group>audit_anom,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_10.6.1,gpg13_7.5,gdpr_IV_35.7.d,gdpr_IV_32.2,gdpr_IV_30.1.g,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,nist_800_53_AU.6,</group>
+        <group>audit_anom,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_10.6.1,gpg13_7.5,gdpr_IV_35.7.d,gdpr_IV_32.2,gdpr_IV_30.1.g,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,nist_800_53_AU.6,</group>
     </rule>
 
     <!--
@@ -238,7 +238,7 @@
         <if_sid>80700</if_sid>
         <field name="audit.type">ANOM_LOGIN_TIME</field>
         <description>Auditd: login attempt is made at a time when it is prevented by.</description>
-        <group>audit_anom,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_10.6.1,gpg13_7.5,gdpr_IV_35.7.d,gdpr_IV_32.2,gdpr_IV_30.1.g,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,nist_800_53_AU.6,</group>
+        <group>audit_anom,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_10.6.1,gpg13_7.5,gdpr_IV_35.7.d,gdpr_IV_32.2,gdpr_IV_30.1.g,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,nist_800_53_AU.6,</group>
     </rule>
 
 
@@ -283,7 +283,7 @@
         <if_sid>80700</if_sid>
         <field name="audit.type">CRYPTO_REPLAY_USER</field>
         <description>Auditd: replay attack detected</description>
-        <group>audit_anom,pci_dss_11.4,gdpr_IV_35.7.d,gdpr_IV_30.1.g,nist_800_53_SC.7,</group>
+        <group>audit_anom,pci_dss_11.4,gdpr_IV_35.7.d,gdpr_IV_30.1.g,nist_800_53_IA.10,</group>
     </rule>
 
     <!--

--- a/rules/0390-fortigate_rules.xml
+++ b/rules/0390-fortigate_rules.xml
@@ -57,7 +57,7 @@ ID: 81600 - 80799
         <action>login</action>
         <status>failed</status>
         <description>Fortigate: Login failed.</description>
-        <group>authentication_failed,invalid_login,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+        <group>authentication_failed,invalid_login,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,</group>
     </rule>
 
     <rule id="81607" level="7" frequency="18" timeframe="45" ignore="240">
@@ -65,7 +65,7 @@ ID: 81600 - 80799
         <same_source_ip />
         <options>alert_by_email</options>
         <description>Fortigate: Multiple failed login events from same source.</description>
-        <group>authentication_failures,pci_dss_10.6.1,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.6,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+        <group>authentication_failures,pci_dss_10.6.1,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.6,nist_800_53_IA.10,nist_800_53_AC.7,</group>
     </rule>
 
 
@@ -130,7 +130,7 @@ ID: 81600 - 80799
         <if_sid>81603</if_sid>
         <match>ssl-login-fail</match>
         <description>Fortigate: SSL VPN User failed login attempt</description>
-        <group>authentication_failed,invalid_login,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+        <group>authentication_failed,invalid_login,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,</group>
     </rule>
 
     <rule id="81615" level="7" frequency="18" timeframe="45" ignore="240">
@@ -138,7 +138,7 @@ ID: 81600 - 80799
         <same_source_ip />
         <options>alert_by_email</options>
         <description>Fortigate: Multiple Firewall SSL VPN failed login events from same source.</description>
-        <group>authentication_failures,pci_dss_10.6.1,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.6,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+        <group>authentication_failures,pci_dss_10.6.1,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.6,nist_800_53_IA.10,nist_800_53_AC.7,</group>
     </rule>
 
     <!--
@@ -149,14 +149,14 @@ ID: 81600 - 80799
         <action>logout</action>
         <status>success</status>
         <description>Fortigate: User logout successful</description>
-        <group>pci_dss_10.2.5,gpg13_7.1,gpg13_7.2,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+        <group>pci_dss_10.2.5,gpg13_7.1,gpg13_7.2,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,</group>
     </rule>
 
     <rule id="81617" level="7" frequency="18" timeframe="45" ignore="240">
         <if_matched_sid>81616</if_matched_sid>
         <same_source_ip />
         <description>Fortigate: Multiple Firewall logout events from same source.</description>
-        <group>pci_dss_10.2.5,gpg13_7.1,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+        <group>pci_dss_10.2.5,gpg13_7.1,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,</group>
     </rule>
 
     <!--
@@ -204,14 +204,14 @@ ID: 81600 - 80799
         <match>level=information</match>
         <action>tunnel-up</action>
         <description>Fortigate: VPN User connected.</description>
-        <group>authentication_success,pci_dss_10.2.5,gpg13_7.1,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+        <group>authentication_success,pci_dss_10.2.5,gpg13_7.1,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,</group>
     </rule>
 
     <rule id="81623" level="4" frequency="18" timeframe="45" ignore="240">
         <if_matched_sid>81622</if_matched_sid>
         <same_source_ip />
         <description>Fortigate: Multiple vpn user connected from same source.</description>
-        <group>authentication_success,pci_dss_10.2.5,gpg13_7.1,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+        <group>authentication_success,pci_dss_10.2.5,gpg13_7.1,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,</group>
     </rule>
 
     <!--
@@ -222,14 +222,14 @@ ID: 81600 - 80799
         <match>level=information</match>
         <action>tunnel-down</action>
         <description>Fortigate: VPN User disconnected.</description>
-        <group>pci_dss_10.2.5,gpg13_7.1,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+        <group>pci_dss_10.2.5,gpg13_7.1,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,</group>
     </rule>
 
     <rule id="81625" level="4" frequency="18" timeframe="45" ignore="240">
         <if_matched_sid>81624</if_matched_sid>
         <same_source_ip />
         <description>Fortigate: Multiple user disconnected events from same source.</description>
-        <group>pci_dss_10.2.5,gpg13_7.1,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+        <group>pci_dss_10.2.5,gpg13_7.1,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,</group>
     </rule>
 
     <!--

--- a/rules/0395-hp_rules.xml
+++ b/rules/0395-hp_rules.xml
@@ -98,14 +98,14 @@ Jun  8 11:54:52 HP-5500EI-HO %%10SHELL/4/LOGINAUTHFAIL(t): Trap 1.1.1.1.1.1.2550
         <if_sid>81705</if_sid>
         <match>failed to log in|failed to login|authentication failed|Authentication is failed</match>
         <description>HP 5500 EI - Warning event: Authentication failure</description>
-        <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+        <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,</group>
     </rule>
 
     <rule id="81710" level="10" frequency="8">
       <if_matched_sid>81709</if_matched_sid>
       <same_source_ip />
       <description>HP 5500 EI: Multiple authentication failures.</description>
-      <group>authentication_failures,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,nist_800_53_SC.7,</group>
+      <group>authentication_failures,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,nist_800_53_IA.10,</group>
     </rule>
 
 </group>

--- a/rules/0395-hp_rules.xml
+++ b/rules/0395-hp_rules.xml
@@ -105,7 +105,7 @@ Jun  8 11:54:52 HP-5500EI-HO %%10SHELL/4/LOGINAUTHFAIL(t): Trap 1.1.1.1.1.1.2550
       <if_matched_sid>81709</if_matched_sid>
       <same_source_ip />
       <description>HP 5500 EI: Multiple authentication failures.</description>
-      <group>authentication_failures,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,nist_800_53_IA.10,</group>
+      <group>authentication_failures,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,</group>
     </rule>
 
 </group>

--- a/rules/0400-openvpn_rules.xml
+++ b/rules/0400-openvpn_rules.xml
@@ -21,7 +21,7 @@
         <if_sid>81800</if_sid>
         <match>Peer Connection Initiated with</match>
         <description>OpenVPN: User logged in</description>
-        <group>authentication_success,pci_dss_10.2.5,gpg13_7.1,gpg13_7.2,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+        <group>authentication_success,pci_dss_10.2.5,gpg13_7.1,gpg13_7.2,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,</group>
     </rule>
 
     <rule id="81802" level="3" frequency="3" timeframe="60">

--- a/rules/0405-rsa-auth-manager_rules.xml
+++ b/rules/0405-rsa-auth-manager_rules.xml
@@ -40,7 +40,7 @@
         <if_matched_sid>81903</if_matched_sid>
         <same_user />
         <description>RSA Authentication Manager: Multiple authentication failures.</description>
-        <group>authentication_failures,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,nist_800_53_IA.10,</group>
+        <group>authentication_failures,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,</group>
     </rule>
 
 </group>

--- a/rules/0405-rsa-auth-manager_rules.xml
+++ b/rules/0405-rsa-auth-manager_rules.xml
@@ -25,7 +25,7 @@
         <id>AUTHN_LOGIN_EVENT</id>
         <action>SUCCESS</action>
         <description>RSA Authentication Manager: Authentication success</description>
-        <group>authentication_success,pci_dss_10.2.5,gpg13_7.1,gpg13_7.2,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+        <group>authentication_success,pci_dss_10.2.5,gpg13_7.1,gpg13_7.2,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,</group>
     </rule>
 
     <rule id="81903" level="5">
@@ -33,14 +33,14 @@
         <id>AUTHN_LOGIN_EVENT</id>
         <action>FAIL</action>
         <description>RSA Authentication Manager: Authentication fail</description>
-        <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+        <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,</group>
     </rule>
 
     <rule id="81904" level="10" frequency="8" timeframe="120">
         <if_matched_sid>81903</if_matched_sid>
         <same_user />
         <description>RSA Authentication Manager: Multiple authentication failures.</description>
-        <group>authentication_failures,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,nist_800_53_SC.7,</group>
+        <group>authentication_failures,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,nist_800_53_IA.10,</group>
     </rule>
 
 </group>

--- a/rules/0420-freeipa_rules.xml
+++ b/rules/0420-freeipa_rules.xml
@@ -32,7 +32,7 @@
         <if_sid>82202</if_sid>
         <match>Password incorrect</match>
         <description>FreeIPA: Authentication fail</description>
-        <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+        <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,</group>
     </rule>
 
 </group>

--- a/rules/0425-cisco-estreamer_rules.xml
+++ b/rules/0425-cisco-estreamer_rules.xml
@@ -19,7 +19,7 @@
         <id>SERVER-MYSQL</id>
         <match>failed Oracle Mysql login attempt</match>
         <description>Cisco eStreamer: SERVER-MYSQL failed login attempt</description>
-        <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+        <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,</group>
     </rule>
 
 	<rule id="82402" level="5">
@@ -27,7 +27,7 @@
         <id>SERVER-MYSQL</id>
         <match>login attempt from unauthorized location</match>
         <description>Cisco eStreamer: SERVER-MYSQL login attempt from unauthorized location</description>
-        <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+        <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,</group>
     </rule>
 
 	<rule id="82403" level="5">
@@ -35,7 +35,7 @@
         <id>SERVER-MYSQL</id>
         <match>client authentication bypass attempt</match>
         <description>Cisco eStreamer: SERVER-MYSQL client authentication bypass attempt</description>
-        <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+        <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,</group>
     </rule>
 
 	<rule id="82404" level="5">

--- a/rules/0440-ms_sqlserver_rules.xml
+++ b/rules/0440-ms_sqlserver_rules.xml
@@ -53,7 +53,7 @@
         <if_sid>85000</if_sid>
         <match>Login succeeded for user</match>
         <description>SQL Server login success.</description>
-        <group>sqlserver_login,pci_dss_10.2.5,gpg13_7.1,gpg13_7.2,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+        <group>sqlserver_login,pci_dss_10.2.5,gpg13_7.1,gpg13_7.2,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,</group>
     </rule>
 
 <!--
@@ -64,14 +64,14 @@
         <if_sid>85000</if_sid>
         <match>Login failed for user</match>
         <description>SQL Server login failed.</description>
-        <group>sqlserver_login, authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+        <group>sqlserver_login, authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,</group>
     </rule>
 
     <rule id="85006" level="10" frequency="8">
         <if_matched_sid>85005</if_matched_sid>
         <same_source_ip />
         <description>SQL Server: Multiple authentication failures.</description>
-        <group>identityguard_login,authentication_failures,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,nist_800_53_SC.7,</group>
+        <group>identityguard_login,authentication_failures,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,nist_800_53_IA.10,</group>
     </rule>
 
 <!--

--- a/rules/0440-ms_sqlserver_rules.xml
+++ b/rules/0440-ms_sqlserver_rules.xml
@@ -71,7 +71,7 @@
         <if_matched_sid>85005</if_matched_sid>
         <same_source_ip />
         <description>SQL Server: Multiple authentication failures.</description>
-        <group>identityguard_login,authentication_failures,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,nist_800_53_IA.10,</group>
+        <group>identityguard_login,authentication_failures,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,</group>
     </rule>
 
 <!--

--- a/rules/0445-identity_guard_rules.xml
+++ b/rules/0445-identity_guard_rules.xml
@@ -31,7 +31,7 @@
         <if_matched_sid>85501</if_matched_sid>
         <same_source_ip />
         <description>Identity Guard: Multiple authentication failures.</description>
-        <group>identityguard_login,authentication_failures,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,nist_800_53_IA.10,</group>
+        <group>identityguard_login,authentication_failures,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,</group>
     </rule>
 
 </group>

--- a/rules/0445-identity_guard_rules.xml
+++ b/rules/0445-identity_guard_rules.xml
@@ -23,7 +23,7 @@
         <if_sid>85500</if_sid>
         <match>failed authentication</match>
         <description>Identity Guard: User authentication failed.</description>
-        <group>identityguard_login,authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+        <group>identityguard_login,authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,</group>
     </rule>
 
 
@@ -31,7 +31,7 @@
         <if_matched_sid>85501</if_matched_sid>
         <same_source_ip />
         <description>Identity Guard: Multiple authentication failures.</description>
-        <group>identityguard_login,authentication_failures,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,nist_800_53_SC.7,</group>
+        <group>identityguard_login,authentication_failures,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,nist_800_53_IA.10,</group>
     </rule>
 
 </group>

--- a/rules/0450-mongodb_rules.xml
+++ b/rules/0450-mongodb_rules.xml
@@ -119,7 +119,7 @@ D	Debug, for All Verbosity Levels > 0
       <if_matched_sid>85759</if_matched_sid>
       <same_source_ip />
       <description>MongoDB: Multiple authentication failures.</description>
-      <group>authentication_failures,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,nist_800_53_IA.10,</group>
+      <group>authentication_failures,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,</group>
     </rule>
 
     <!--

--- a/rules/0450-mongodb_rules.xml
+++ b/rules/0450-mongodb_rules.xml
@@ -101,7 +101,7 @@ D	Debug, for All Verbosity Levels > 0
         <field name="mongodb.component">ACCESS</field>
         <match>Successfully authenticated</match>
         <description>MongoDB: Successfully authentication</description>
-        <group>authentication_success,pci_dss_10.2.5,gpg13_7.1,gpg13_7.2,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+        <group>authentication_success,pci_dss_10.2.5,gpg13_7.1,gpg13_7.2,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,</group>
     </rule>
 
     <!--
@@ -112,14 +112,14 @@ D	Debug, for All Verbosity Levels > 0
         <field name="mongodb.component">ACCESS</field>
         <match>authentication failed for</match>
         <description>MongoDB: Failed authentication</description>
-        <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+        <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,</group>
     </rule>
 
     <rule id="85760" level="10" frequency="8">
       <if_matched_sid>85759</if_matched_sid>
       <same_source_ip />
       <description>MongoDB: Multiple authentication failures.</description>
-      <group>authentication_failures,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,nist_800_53_SC.7,</group>
+      <group>authentication_failures,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,nist_800_53_IA.10,</group>
     </rule>
 
     <!--

--- a/rules/0495-proxmox-ve_rules.xml
+++ b/rules/0495-proxmox-ve_rules.xml
@@ -23,7 +23,7 @@
     <if_matched_sid>87201</if_matched_sid>
     <same_source_ip />
     <description>Proxmox VE brute force (multiple failed logins).</description>
-    <group>authentication_failures,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,nist_800_53_IA.10,</group>
+    <group>authentication_failures,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,</group>
   </rule>
 
   <rule id="87203" level="3">

--- a/rules/0495-proxmox-ve_rules.xml
+++ b/rules/0495-proxmox-ve_rules.xml
@@ -16,21 +16,21 @@
     <if_sid>87200</if_sid>
     <match>authentication failure; </match>
     <description>Proxmox VE authentication failed.</description>
-    <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,</group>
   </rule>
 
   <rule id="87202" level="10" frequency="8" timeframe="120">
     <if_matched_sid>87201</if_matched_sid>
     <same_source_ip />
     <description>Proxmox VE brute force (multiple failed logins).</description>
-    <group>authentication_failures,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,nist_800_53_SC.7,</group>
+    <group>authentication_failures,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,nist_800_53_IA.10,</group>
   </rule>
 
   <rule id="87203" level="3">
     <if_sid>87200</if_sid>
     <match> successful auth for user </match>
     <description>Proxmox VE authentication succeeded.</description>
-    <group>authentication_success,pci_dss_10.2.5,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>authentication_success,pci_dss_10.2.5,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,</group>
   </rule>
 
 </group>

--- a/rules/0500-owncloud_rules.xml
+++ b/rules/0500-owncloud_rules.xml
@@ -58,21 +58,21 @@
     <if_sid>87300,87310</if_sid>
     <match>Login failed: </match>
     <description>ownCloud authentication failed.</description>
-    <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,</group>
   </rule>
 
   <rule id="87302" level="10" frequency="8" timeframe="120">
     <if_matched_sid>87301</if_matched_sid>
     <same_source_ip />
     <description>ownCloud brute force (multiple failed logins).</description>
-    <group>authentication_failures,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,nist_800_53_SC.7,</group>
+    <group>authentication_failures,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,nist_800_53_IA.10,</group>
   </rule>
 
   <rule id="87303" level="6">
     <if_sid>87300,87310</if_sid>
     <match>Passed filename is not valid, might be malicious </match>
     <description>ownCloud possible malicious request.</description>
-    <group>web,appsec,attack,pci_dss_6.5,pci_dss_11.4,gdpr_IV_35.7.d,nist_800_53_SA.11,nist_800_53_SC.7,</group>
+    <group>web,appsec,attack,pci_dss_6.5,pci_dss_11.4,gdpr_IV_35.7.d,nist_800_53_SA.11,nist_800_53_IA.10,</group>
   </rule>
 
   <rule id="87304" level="8">

--- a/rules/0500-owncloud_rules.xml
+++ b/rules/0500-owncloud_rules.xml
@@ -65,7 +65,7 @@
     <if_matched_sid>87301</if_matched_sid>
     <same_source_ip />
     <description>ownCloud brute force (multiple failed logins).</description>
-    <group>authentication_failures,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,nist_800_53_IA.10,</group>
+    <group>authentication_failures,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,</group>
   </rule>
 
   <rule id="87303" level="6">

--- a/rules/0525-openvas_rules.xml
+++ b/rules/0525-openvas_rules.xml
@@ -17,21 +17,21 @@
     <if_sid>87600</if_sid>
     <match>Authentication failure for </match>
     <description>OpenVAS (gsad) authentication failed.</description>
-    <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,</group>
   </rule>
 
   <rule id="87602" level="10" frequency="8" timeframe="120">
     <if_matched_sid>87601</if_matched_sid>
     <same_source_ip />
     <description>OpenVAS (gsad) brute force (multiple failed logins).</description>
-    <group>authentication_failures,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,nist_800_53_SC.7,</group>
+    <group>authentication_failures,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,nist_800_53_IA.10,</group>
   </rule>
 
   <rule id="87603" level="3">
     <if_sid>87600</if_sid>
     <match>Authentication success for </match>
     <description>OpenVAS (gsad) authentication succeeded.</description>
-    <group>authentication_success,pci_dss_10.2.5,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>authentication_success,pci_dss_10.2.5,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,</group>
   </rule>
 
   <rule id="87604" level="6">
@@ -70,14 +70,14 @@
     <if_sid>87608</if_sid>
     <match>Authentication failure for </match>
     <description>OpenVAS (openvasmd) authentication failed.</description>
-    <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,</group>
   </rule>
 
   <rule id="87610" level="10" frequency="8" timeframe="120">
     <if_matched_sid>87609</if_matched_sid>
     <same_source_ip />
     <description>OpenVAS (openvasmd) brute force (multiple failed logins).</description>
-    <group>authentication_failures,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,nist_800_53_SC.7,</group>
+    <group>authentication_failures,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,nist_800_53_IA.10,</group>
   </rule>
 
   <rule id="87611" level="6">

--- a/rules/0525-openvas_rules.xml
+++ b/rules/0525-openvas_rules.xml
@@ -24,7 +24,7 @@
     <if_matched_sid>87601</if_matched_sid>
     <same_source_ip />
     <description>OpenVAS (gsad) brute force (multiple failed logins).</description>
-    <group>authentication_failures,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,nist_800_53_IA.10,</group>
+    <group>authentication_failures,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,</group>
   </rule>
 
   <rule id="87603" level="3">
@@ -77,7 +77,7 @@
     <if_matched_sid>87609</if_matched_sid>
     <same_source_ip />
     <description>OpenVAS (openvasmd) brute force (multiple failed logins).</description>
-    <group>authentication_failures,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,nist_800_53_IA.10,</group>
+    <group>authentication_failures,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,</group>
   </rule>
 
   <rule id="87611" level="6">

--- a/rules/0530-mysql_audit_rules.xml
+++ b/rules/0530-mysql_audit_rules.xml
@@ -36,14 +36,14 @@ logcollector must be configured with the following labels
       <field name="audit_record.name">^Connect$</field>
       <field name="audit_record.status">^0$</field>
       <description>Percona audit: authentication success.</description>
-      <group>authentication_success,pci_dss_10.2.5,pci_dss_8.7,gpg13_7.1,gpg13_7.2,gdpr_IV_32.2,hipaa_164.312.b,hipaa_164.312.d,hipaa_164.312.e.1,hipaa_164.312.e.2.I,hipaa_164.312.e.2.II,nist_800_53_AU.3.1,nist_800_53_IA.10,nist_800_53_SC.2,</group>
+      <group>authentication_success,pci_dss_10.2.5,pci_dss_8.7,gpg13_7.1,gpg13_7.2,gdpr_IV_32.2,hipaa_164.312.b,hipaa_164.312.d,hipaa_164.312.e.1,hipaa_164.312.e.2.I,hipaa_164.312.e.2.II,nist_800_53_IA.10,nist_800_53_AC.7,nist_800_53_SC.2,</group>
     </rule>
 
     <rule id="88002" level="3">
       <if_sid>88000</if_sid>
       <field name="audit_record.name">^Quit$</field>
       <description>Percona audit: user logout.</description>
-      <group>pci_dss_10.2.5,pci_dss_8.7,gpg13_7.1,gpg13_7.2,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,hipaa_164.312.d,hipaa_164.312.e.1,hipaa_164.312.e.2.I,hipaa_164.312.e.2.II,nist_800_53_AU.3.1,nist_800_53_IA.10,nist_800_53_SC.2,</group>
+      <group>pci_dss_10.2.5,pci_dss_8.7,gpg13_7.1,gpg13_7.2,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,hipaa_164.312.d,hipaa_164.312.e.1,hipaa_164.312.e.2.I,hipaa_164.312.e.2.II,nist_800_53_IA.10,nist_800_53_AC.7,nist_800_53_SC.2,</group>
     </rule>
 
     <rule id="88003" level="9">
@@ -51,7 +51,7 @@ logcollector must be configured with the following labels
       <field name="audit_record.name">^Connect$</field>
       <field name="audit_record.status">^1</field>
       <description>Percona audit: authentication failure.</description>
-      <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_8.7,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,hipaa_164.312.d,hipaa_164.312.e.1,hipaa_164.312.e.2.I,hipaa_164.312.e.2.II,nist_800_53_AU.3.1,nist_800_53_IA.10,nist_800_53_SC.2,</group>
+      <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_8.7,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,hipaa_164.312.d,hipaa_164.312.e.1,hipaa_164.312.e.2.I,hipaa_164.312.e.2.II,nist_800_53_IA.10,nist_800_53_AC.7,nist_800_53_SC.2,</group>
     </rule>
 
     <rule id="88004" level="3">
@@ -96,21 +96,21 @@ logcollector must be configured with the following labels
       <if_sid>89050</if_sid>
       <field name="cmd">^Connect$</field>
       <description>McAfee MySQL audit: authentication attempt.</description>
-      <group>pci_dss_10.2.5,pci_dss_8.7,gpg13_7.1,gpg13_7.2,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,hipaa_164.312.d,hipaa_164.312.e.1,hipaa_164.312.e.2.I,hipaa_164.312.e.2.II,nist_800_53_AU.3.1,nist_800_53_IA.10,nist_800_53_SC.2,</group>
+      <group>pci_dss_10.2.5,pci_dss_8.7,gpg13_7.1,gpg13_7.2,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,hipaa_164.312.d,hipaa_164.312.e.1,hipaa_164.312.e.2.I,hipaa_164.312.e.2.II,nist_800_53_IA.10,nist_800_53_AC.7,nist_800_53_SC.2,</group>
     </rule>
 
     <rule id="89052" level="3">
       <if_sid>89050</if_sid>
       <field name="cmd">^Quit$</field>
       <description>McAfee MySQL audit: user logout.</description>
-      <group>pci_dss_10.2.5,pci_dss_8.7,gpg13_7.1,gpg13_7.2,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,hipaa_164.312.d,hipaa_164.312.e.1,hipaa_164.312.e.2.I,hipaa_164.312.e.2.II,nist_800_53_AU.3.1,nist_800_53_IA.10,nist_800_53_SC.2,</group>
+      <group>pci_dss_10.2.5,pci_dss_8.7,gpg13_7.1,gpg13_7.2,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,hipaa_164.312.d,hipaa_164.312.e.1,hipaa_164.312.e.2.I,hipaa_164.312.e.2.II,nist_800_53_IA.10,nist_800_53_AC.7,nist_800_53_SC.2,</group>
     </rule>
 
     <rule id="89053" level="9">
       <if_sid>89050</if_sid>
       <field name="cmd">^Failed Login$</field>
       <description>McAfee MySQL audit: authentication failure.</description>
-      <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_8.7,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,hipaa_164.312.d,hipaa_164.312.e.1,hipaa_164.312.e.2.I,hipaa_164.312.e.2.II,nist_800_53_AU.3.1,nist_800_53_IA.10,nist_800_53_SC.2,</group>
+      <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_8.7,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,hipaa_164.312.d,hipaa_164.312.e.1,hipaa_164.312.e.2.I,hipaa_164.312.e.2.II,nist_800_53_IA.10,nist_800_53_AC.7,nist_800_53_SC.2,</group>
     </rule>
 
     <rule id="89054" level="3">

--- a/rules/0560-docker_integration_rules.xml
+++ b/rules/0560-docker_integration_rules.xml
@@ -22,7 +22,7 @@ ID: 87900 - 87999
         <if_sid>87900</if_sid>
         <field name="docker.status">^create$</field>
         <description>Docker: Container $(docker.Actor.Attributes.name) created</description>
-        <group>pci_dss_10.2.7,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+        <group>pci_dss_10.2.7,hipaa_164.312.b,nist_800_53_IA.10,</group>
         <options>no_full_log</options>
     </rule>
 
@@ -30,7 +30,7 @@ ID: 87900 - 87999
         <if_sid>87900</if_sid>
         <field name="docker.status">^destroy$</field>
         <description>Docker: Container $(docker.Actor.Attributes.name) destroyed</description>
-        <group>pci_dss_10.2.7,pci_dss_11.5,hipaa_164.312.b,hipaa_164.312.c.1,hipaa_164.312.c.2,nist_800_53_AU.3.1,nist_800_53_IA.10,nist_800_53_SI.7,</group>
+        <group>pci_dss_10.2.7,pci_dss_11.5,hipaa_164.312.b,hipaa_164.312.c.1,hipaa_164.312.c.2,nist_800_53_IA.10,nist_800_53_SI.7,</group>
         <options>no_full_log</options>
     </rule>
 
@@ -74,7 +74,7 @@ ID: 87900 - 87999
         <if_sid>87907</if_sid>
         <field name="docker.status">^exec_start: bash $|^exec_start: /bin/bash $|^exec_start: sh $|^exec_start: dash $|^exec_start: /bin/dash $</field>
         <description>Docker: Started shell session in container $(docker.Actor.Attributes.name)</description>
-        <group>pci_dss_10.2.7,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+        <group>pci_dss_10.2.7,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,</group>
         <options>no_full_log</options>
     </rule>
 
@@ -112,7 +112,7 @@ ID: 87900 - 87999
         <if_sid>87912</if_sid>
         <field name="docker.Action">^create$</field>
         <description>Docker: Volume created in $(docker.Actor.Attributes.driver)</description>
-        <group>pci_dss_10.2.7,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+        <group>pci_dss_10.2.7,hipaa_164.312.b,nist_800_53_IA.10,</group>
         <options>no_full_log</options>
     </rule>
 
@@ -120,7 +120,7 @@ ID: 87900 - 87999
         <if_sid>87912</if_sid>
         <field name="docker.Action">^destroy$</field>
         <description>Docker: Volume destroyed in $(docker.Actor.Attributes.driver)</description>
-        <group>pci_dss_10.2.7,pci_dss_11.5,hipaa_164.312.b,hipaa_164.312.c.1,hipaa_164.312.c.2,nist_800_53_AU.3.1,nist_800_53_IA.10,nist_800_53_SI.7,</group>
+        <group>pci_dss_10.2.7,pci_dss_11.5,hipaa_164.312.b,hipaa_164.312.c.1,hipaa_164.312.c.2,nist_800_53_IA.10,nist_800_53_SI.7,</group>
         <options>no_full_log</options>
     </rule>
 
@@ -128,7 +128,7 @@ ID: 87900 - 87999
         <if_sid>87912</if_sid>
         <field name="docker.Action">^mount$</field>
         <description>Docker: Volume mounted on $(docker.Actor.Attributes.destination)</description>
-        <group>pci_dss_10.2.7,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+        <group>pci_dss_10.2.7,hipaa_164.312.b,nist_800_53_IA.10,</group>
         <options>no_full_log</options>
     </rule>
 
@@ -136,7 +136,7 @@ ID: 87900 - 87999
         <if_sid>87912</if_sid>
         <field name="docker.Action">^unmount$</field>
         <description>Docker: Volume unmounted from $(docker.Actor.Attributes.driver)</description>
-        <group>pci_dss_10.2.7,pci_dss_11.5,hipaa_164.312.b,hipaa_164.312.c.1,hipaa_164.312.c.2,nist_800_53_AU.3.1,nist_800_53_IA.10,nist_800_53_SI.7,</group>
+        <group>pci_dss_10.2.7,pci_dss_11.5,hipaa_164.312.b,hipaa_164.312.c.1,hipaa_164.312.c.2,nist_800_53_IA.10,nist_800_53_SI.7,</group>
         <options>no_full_log</options>
     </rule>
 
@@ -144,7 +144,7 @@ ID: 87900 - 87999
         <if_sid>87900</if_sid>
         <field name="docker.status">^commit$</field>
         <description>Docker: Committed an image from container $(docker.Actor.Attributes.name)</description>
-        <group>pci_dss_10.2.7,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+        <group>pci_dss_10.2.7,hipaa_164.312.b,nist_800_53_IA.10,</group>
         <options>no_full_log</options>
     </rule>
 
@@ -166,7 +166,7 @@ ID: 87900 - 87999
         <if_sid>87900</if_sid>
         <field name="docker.status">^import$</field>
         <description>Docker: Image created from imported data</description>
-        <group>pci_dss_10.2.7,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+        <group>pci_dss_10.2.7,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,</group>
         <options>no_full_log</options>
     </rule>
 
@@ -174,7 +174,7 @@ ID: 87900 - 87999
         <if_sid>87900</if_sid>
         <field name="docker.status">^delete$</field>
         <description>Docker: Container $(docker.Actor.Attributes.name) deleted</description>
-        <group>pci_dss_10.2.7,pci_dss_11.5,hipaa_164.312.b,hipaa_164.312.c.1,hipaa_164.312.c.2,nist_800_53_AU.3.1,nist_800_53_IA.10,nist_800_53_SI.7,</group>
+        <group>pci_dss_10.2.7,pci_dss_11.5,hipaa_164.312.b,hipaa_164.312.c.1,hipaa_164.312.c.2,nist_800_53_IA.10,nist_800_53_SI.7,</group>
         <options>no_full_log</options>
     </rule>
 
@@ -189,7 +189,7 @@ ID: 87900 - 87999
         <if_sid>87900</if_sid>
         <field name="docker.status">^export$</field>
         <description>Docker: Filesystem of container $(docker.Actor.Attributes.name) exported</description>
-        <group>pci_dss_10.2.7,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+        <group>pci_dss_10.2.7,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,</group>
         <options>no_full_log</options>
     </rule>
 
@@ -241,7 +241,7 @@ ID: 87900 - 87999
         <if_sid>87927</if_sid>
         <field name="docker.Action">^create$</field>
         <description>Docker: Network $(docker.Actor.Attributes.name) created</description>
-        <group>pci_dss_10.2.7,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+        <group>pci_dss_10.2.7,hipaa_164.312.b,nist_800_53_IA.10,</group>
         <options>no_full_log</options>
     </rule>
 
@@ -249,7 +249,7 @@ ID: 87900 - 87999
         <if_sid>87927</if_sid>
         <field name="docker.Action">^destroy$</field>
         <description>Docker: Network $(docker.Actor.Attributes.name) deleted</description>
-        <group>pci_dss_10.2.7,pci_dss_11.5,hipaa_164.312.b,hipaa_164.312.c.1,hipaa_164.312.c.2,nist_800_53_AU.3.1,nist_800_53_IA.10,nist_800_53_SI.7,</group>
+        <group>pci_dss_10.2.7,pci_dss_11.5,hipaa_164.312.b,hipaa_164.312.c.1,hipaa_164.312.c.2,nist_800_53_IA.10,nist_800_53_SI.7,</group>
         <options>no_full_log</options>
     </rule>
 
@@ -257,7 +257,7 @@ ID: 87900 - 87999
         <if_sid>87900</if_sid>
         <field name="docker.status">^pull$</field>
         <description>Docker: Image or repository $(docker.Actor.Attributes.name) pulled</description>
-        <group>pci_dss_10.2.7,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+        <group>pci_dss_10.2.7,hipaa_164.312.b,nist_800_53_IA.10,</group>
         <options>no_full_log</options>
     </rule>
 
@@ -279,7 +279,7 @@ ID: 87900 - 87999
         <if_sid>87900</if_sid>
         <field name="docker.status">^rename$</field>
         <description>Docker: Container renamed from $(docker.Actor.Attributes.oldName) to $(docker.Actor.Attributes.name)</description>
-        <group>pci_dss_10.2.5,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+        <group>pci_dss_10.2.5,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,</group>
         <options>no_full_log</options>
     </rule>
 
@@ -294,7 +294,7 @@ ID: 87900 - 87999
         <if_sid>87936</if_sid>
         <field name="docker.Action">^create$</field>
         <description>Docker: $(docker.Actor.Attributes.name) config created</description>
-        <group>pci_dss_10.2.7,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+        <group>pci_dss_10.2.7,hipaa_164.312.b,nist_800_53_IA.10,</group>
         <options>no_full_log</options>
     </rule>
 
@@ -302,7 +302,7 @@ ID: 87900 - 87999
         <if_sid>87936</if_sid>
         <field name="docker.Action">^remove$</field>
         <description>Docker: $(docker.Actor.Attributes.name) config deleted</description>
-        <group>pci_dss_10.2.7,pci_dss_11.5,hipaa_164.312.b,hipaa_164.312.c.1,hipaa_164.312.c.2,nist_800_53_AU.3.1,nist_800_53_IA.10,nist_800_53_SI.7,</group>
+        <group>pci_dss_10.2.7,pci_dss_11.5,hipaa_164.312.b,hipaa_164.312.c.1,hipaa_164.312.c.2,nist_800_53_IA.10,nist_800_53_SI.7,</group>
         <options>no_full_log</options>
     </rule>
 
@@ -317,7 +317,7 @@ ID: 87900 - 87999
         <if_sid>87939</if_sid>
         <field name="docker.Action">^create$</field>
         <description>Docker: Secret '$(docker.Actor.Attributes.name)' created</description>
-        <group>pci_dss_10.2.7,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+        <group>pci_dss_10.2.7,hipaa_164.312.b,nist_800_53_IA.10,</group>
         <options>no_full_log</options>
     </rule>
 
@@ -325,7 +325,7 @@ ID: 87900 - 87999
         <if_sid>87939</if_sid>
         <field name="docker.Action">^remove$</field>
         <description>Docker: Secret '$(docker.Actor.Attributes.name)' removed</description>
-        <group>pci_dss_10.2.7,pci_dss_11.5,hipaa_164.312.b,hipaa_164.312.c.1,hipaa_164.312.c.2,nist_800_53_AU.3.1,nist_800_53_IA.10,nist_800_53_SI.7,</group>
+        <group>pci_dss_10.2.7,pci_dss_11.5,hipaa_164.312.b,hipaa_164.312.c.1,hipaa_164.312.c.2,nist_800_53_IA.10,nist_800_53_SI.7,</group>
         <options>no_full_log</options>
     </rule>
 
@@ -340,7 +340,7 @@ ID: 87900 - 87999
         <if_sid>87942</if_sid>
         <field name="docker.Action">^pull$</field>
         <description>Docker: Plugin $(docker.Actor.Attributes.name) pulled</description>
-        <group>pci_dss_10.2.7,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+        <group>pci_dss_10.2.7,hipaa_164.312.b,nist_800_53_IA.10,</group>
         <options>no_full_log</options>
     </rule>
 
@@ -362,7 +362,7 @@ ID: 87900 - 87999
         <if_sid>87942</if_sid>
         <field name="docker.Action">^remove$</field>
         <description>Docker: Plugin $(docker.Actor.Attributes.name) removed</description>
-        <group>pci_dss_10.2.7,pci_dss_11.5,hipaa_164.312.b,hipaa_164.312.c.1,hipaa_164.312.c.2,nist_800_53_AU.3.1,nist_800_53_IA.10,nist_800_53_SI.7,</group>
+        <group>pci_dss_10.2.7,pci_dss_11.5,hipaa_164.312.b,hipaa_164.312.c.1,hipaa_164.312.c.2,nist_800_53_IA.10,nist_800_53_SI.7,</group>
         <options>no_full_log</options>
     </rule>
 
@@ -370,7 +370,7 @@ ID: 87900 - 87999
         <if_sid>87942</if_sid>
         <field name="docker.Action">^create$</field>
         <description>Docker: Plugin $(docker.Actor.Attributes.name) created</description>
-        <group>pci_dss_10.2.7,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+        <group>pci_dss_10.2.7,hipaa_164.312.b,nist_800_53_IA.10,</group>
         <options>no_full_log</options>
     </rule>
 
@@ -385,7 +385,7 @@ ID: 87900 - 87999
         <if_sid>87948</if_sid>
         <field name="docker.Action">^create$</field>
         <description>Docker: Node created</description>
-        <group>pci_dss_10.2.7,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+        <group>pci_dss_10.2.7,hipaa_164.312.b,nist_800_53_IA.10,</group>
         <options>no_full_log</options>
     </rule>
 
@@ -402,7 +402,7 @@ ID: 87900 - 87999
         <field name="docker.Actor.Attributes.role.new">\.+</field>
         <field name="docker.Actor.Attributes.role.old">\.+</field>
         <description>Docker: Role for node $(docker.Actor.Attributes.name) has changed from $(docker.Actor.Attributes.role.old) to $(docker.Actor.Attributes.role.new)</description>
-        <group>pci_dss_10.2.5,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+        <group>pci_dss_10.2.5,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,</group>
         <options>no_full_log</options>
     </rule>
 
@@ -417,7 +417,7 @@ ID: 87900 - 87999
         <if_sid>87900</if_sid>
         <field name="docker.status">^checkpoint$</field>
         <description>Docker: Checkpoint set at container $(docker.Actor.Attributes.name)</description>
-        <group>pci_dss_10.2.7,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+        <group>pci_dss_10.2.7,hipaa_164.312.b,nist_800_53_IA.10,</group>
         <options>no_full_log</options>
     </rule>
 
@@ -432,7 +432,7 @@ ID: 87900 - 87999
         <if_sid>87954</if_sid>
         <field name="docker.Action">^create$</field>
         <description>Docker: Service $(docker.Actor.Attributes.name) created</description>
-        <group>pci_dss_10.2.7,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+        <group>pci_dss_10.2.7,hipaa_164.312.b,nist_800_53_IA.10,</group>
         <options>no_full_log</options>
     </rule>
 
@@ -448,7 +448,7 @@ ID: 87900 - 87999
         <if_sid>87954</if_sid>
         <field name="docker.Action">^remove$</field>
         <description>Docker: Service $(docker.Actor.Attributes.name) deleted</description>+
-        <group>pci_dss_10.2.7,pci_dss_11.5,hipaa_164.312.b,hipaa_164.312.c.1,hipaa_164.312.c.2,nist_800_53_AU.3.1,nist_800_53_IA.10,nist_800_53_SI.7,</group>
+        <group>pci_dss_10.2.7,pci_dss_11.5,hipaa_164.312.b,hipaa_164.312.c.1,hipaa_164.312.c.2,nist_800_53_IA.10,nist_800_53_SI.7,</group>
         <options>no_full_log</options>
     </rule>
 
@@ -456,7 +456,7 @@ ID: 87900 - 87999
         <if_sid>87900</if_sid>
         <field name="docker.status">^push$</field>
         <description>Docker: Image $(docker.Actor.Attributes.name) pushed</description>
-        <group>pci_dss_10.2.7,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+        <group>pci_dss_10.2.7,hipaa_164.312.b,nist_800_53_IA.10,</group>
         <options>no_full_log</options>
     </rule>
 </group>

--- a/rules/0580-win-security_rules.xml
+++ b/rules/0580-win-security_rules.xml
@@ -265,7 +265,7 @@
     <field name="win.system.eventID">^539$</field>
     <description>Logon Failure - Account locked out</description>
     <options>no_full_log</options>
-    <group>win_authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_8.1.6,gpg13_7.5,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,hipaa_164.312.a.1,nist_800_53_IA.10,nist_800_53_AC.7,nist_800_53_AC.7,</group>
+    <group>win_authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_8.1.6,gpg13_7.5,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,hipaa_164.312.a.1,nist_800_53_IA.10,nist_800_53_AC.7,</group>
   </rule>
 
   <rule id="60131" level="5">
@@ -289,7 +289,7 @@
     <field name="win.system.eventID">^671$|^4767$</field>
     <description>User account unlocked</description>
     <options>no_full_log</options>
-    <group>account_changed,pci_dss_10.2.5,pci_dss_8.1.6,gpg13_7.10,gdpr_IV_32.2,hipaa_164.312.b,hipaa_164.312.a.1,nist_800_53_IA.10,nist_800_53_AC.7,nist_800_53_AC.7,</group>
+    <group>account_changed,pci_dss_10.2.5,pci_dss_8.1.6,gpg13_7.10,gdpr_IV_32.2,hipaa_164.312.b,hipaa_164.312.a.1,nist_800_53_IA.10,nist_800_53_AC.7,</group>
   </rule>
 
   <rule id="60134" level="8">
@@ -792,7 +792,7 @@
     <description>Windows DC integrity check on decrypted</description>
     <options>no_full_log</options>
     <description>field failed</description>
-    <group>win_authentication_failed,attacks,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,nist_800_53_IA.10,</group>
+    <group>win_authentication_failed,attacks,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,</group>
   </rule>
 
   <rule id="60196" level="10">
@@ -800,7 +800,7 @@
     <field name="win.eventdata.failureCode">0x22</field>
     <description>Windows DC - Possible replay attack</description>
     <options>no_full_log</options>
-    <group>win_authentication_failed,attacks,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,nist_800_53_IA.10,</group>
+    <group>win_authentication_failed,attacks,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,</group>
   </rule>
 
   <rule id="60197" level="7">
@@ -808,7 +808,7 @@
     <field name="win.eventdata.failureCode">0x25</field>
     <description>Windows DC - Clock skew too great</description>
     <options>no_full_log</options>
-    <group>win_authentication_failed,attacks,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,nist_800_53_IA.10,</group>
+    <group>win_authentication_failed,attacks,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,</group>
   </rule>
 
   <!-- MS SQL rules -->
@@ -861,7 +861,7 @@
     <same_field>win.eventdata.targetUserName</same_field>
     <description>Multiple failed attempts to perform a privileged operation by the same user</description>
     <options>no_full_log</options>
-    <group>pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,nist_800_53_IA.10,</group>
+    <group>pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,</group>
   </rule>
 
   <rule id="60204" level="10" frequency="$MS_FREQ" timeframe="240">
@@ -869,7 +869,7 @@
     <same_field>win.eventdata.ipAddress</same_field>
     <description>Multiple Windows Logon Failures</description>
     <options>no_full_log</options>
-    <group>authentication_failures,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,nist_800_53_IA.10,</group>
+    <group>authentication_failures,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,</group>
   </rule>
 
   <rule id="60205" level="10" frequency="$MS_FREQ" timeframe="240">

--- a/rules/0580-win-security_rules.xml
+++ b/rules/0580-win-security_rules.xml
@@ -53,7 +53,7 @@
     <field name="win.system.eventID">^529$|^530$|^531$|^532$|^533$|^534$|^535$|^536$|^537$|^539$|^4625$</field>
     <description>Windows Logon Failure</description>
     <options>no_full_log</options>
-    <group>win_authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>win_authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,</group>
   </rule>
 
   <!--{"win":{"system":{"providerName":"Microsoft-Windows-Security-Auditing","providerGuid":"{54849625-5478-4994-A5BA-3E3B0328C30D}","eventID":"4624","version":"1","level":"0","task":"12544","opcode":"0","keywords":"0x802000000000000","systemTime":"2018-12-18T10:55:48.073081500Z","eventRecordID":"7017","processID":"548","threadID":"3212","channel":"Security","computer":"qnu","severityValue":"AUDIT_SUCCESS","message":"L’ouverture de session d’un compte s’est correctement déroulée."},"eventdata":{"subjectUserSid":"S-1-5-18","subjectUserName":"QNU$","subjectDomainName":"WORKGROUP","subjectLogonId":"0x3e7","targetUserSid":"S-1-5-18","targetUserName":"Système","targetDomainName":"AUTORITE NT","targetLogonId":"0x3e7","logonType":"5","logonProcessName":"Advapi  ","authenticationPackageName":"Negotiate","workstationName":"-","logonGuid":"{00000000-0000-0000-0000-000000000000}","transmittedServices":"-","lmPackageName":"-","keyLength":"0","processId":"0x21c","processName":"C:\\\\Windows\\\\System32\\\\services.exe","ipAddress":"-","ipPort":"-","impersonationLevel":"%%1833"}}}-->
@@ -63,7 +63,7 @@
     <field name="win.system.eventID">^528$|^540$|^673$|^4624$|^4769$</field>
     <description>Windows Logon Success</description>
     <options>no_full_log</options>
-    <group>authentication_success,pci_dss_10.2.5,gpg13_7.1,gpg13_7.2,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>authentication_success,pci_dss_10.2.5,gpg13_7.1,gpg13_7.2,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,</group>
   </rule>
 
   <rule id="60107" level="4">
@@ -71,7 +71,7 @@
     <field name="win.system.eventID">^577$|^4673$</field>
     <description>Failed attempt to perform a privileged operation</description>
     <options>no_full_log</options>
-    <group>authentication_success,pci_dss_10.2.2,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>authentication_success,pci_dss_10.2.2,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.6,</group>
   </rule>
 
   <!-- Rules based on AUDIT SUCCESS -->
@@ -90,7 +90,7 @@
     <description>User account enabled or created</description>
     <options>no_full_log</options>
     <group>adduser,account_changed,</group>
-    <group>pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.a.2.I,hipaa_164.312.a.2.II,hipaa_164.312.b,nist_800_53_AC.2,nist_800_53_IA.4,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.a.2.I,hipaa_164.312.a.2.II,hipaa_164.312.b,nist_800_53_AC.2,nist_800_53_IA.4,nist_800_53_IA.10,nist_800_53_AC.7,</group>
   </rule>
 
   <rule id="60110" level="8">
@@ -99,7 +99,7 @@
     <description>User account changed</description>
     <options>no_full_log</options>
     <group>account_changed,</group>
-    <group>pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.a.2.I,hipaa_164.312.a.2.II,hipaa_164.312.b,nist_800_53_AC.2,nist_800_53_IA.4,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.a.2.I,hipaa_164.312.a.2.II,hipaa_164.312.b,nist_800_53_AC.2,nist_800_53_IA.4,nist_800_53_IA.10,nist_800_53_AC.7,</group>
   </rule>
 
   <rule id="60111" level="8">
@@ -107,7 +107,7 @@
     <field name="win.system.eventID">^630$|^629$|^4725$|^4726$</field>
     <description>User account disabled or deleted</description>
     <options>no_full_log</options>
-    <group>adduser,account_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.a.2.I,hipaa_164.312.a.2.II,hipaa_164.312.b,nist_800_53_AC.2,nist_800_53_IA.4,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>adduser,account_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.a.2.I,hipaa_164.312.a.2.II,hipaa_164.312.b,nist_800_53_AC.2,nist_800_53_IA.4,nist_800_53_IA.10,nist_800_53_AC.7,</group>
   </rule>
 
   <rule id="60112" level="8">
@@ -127,7 +127,7 @@
             |^665$|^4761$|^666$|^4762$</field>
     <description>Group Account Changed</description>
     <options>no_full_log</options>
-    <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.a.2.I,hipaa_164.312.a.2.II,hipaa_164.312.b,nist_800_53_AC.2,nist_800_53_IA.4,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.a.2.I,hipaa_164.312.a.2.II,hipaa_164.312.b,nist_800_53_AC.2,nist_800_53_IA.4,nist_800_53_IA.10,nist_800_53_AC.7,</group>
   </rule>
 
   <rule id="60114" level="8">
@@ -135,7 +135,7 @@
     <field name="win.system.eventID">^640$</field>
     <description>General account database changed</description>
     <options>no_full_log</options>
-    <group>adduser,account_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.a.2.I,hipaa_164.312.a.2.II,hipaa_164.312.b,nist_800_53_AC.2,nist_800_53_IA.4,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>adduser,account_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.a.2.I,hipaa_164.312.a.2.II,hipaa_164.312.b,nist_800_53_AC.2,nist_800_53_IA.4,nist_800_53_IA.10,nist_800_53_AC.7,</group>
   </rule>
 
   <rule id="60115" level="9">
@@ -143,7 +143,7 @@
     <field name="win.system.eventID">^644$|^4740$</field>
     <description>User account locked out (multiple login errors)</description>
     <options>no_full_log</options>
-    <group>authentication_failures,pci_dss_8.1.6,pci_dss_11.4,gpg13_7.5,gdpr_IV_35.7.d,hipaa_164.312.a.1,nist_800_53_AC.7,nist_800_53_SC.7,</group>
+    <group>authentication_failures,pci_dss_8.1.6,pci_dss_11.4,gpg13_7.5,gdpr_IV_35.7.d,hipaa_164.312.a.1,nist_800_53_AC.7,nist_800_53_IA.10,</group>
   </rule>
 
   <rule id="60116" level="7">
@@ -168,7 +168,7 @@
     <field name="win.eventdata.logonType">^2$</field>
     <description>Windows Workstation Logon Success</description>
     <options>no_full_log</options>
-    <group>authentication_success,pci_dss_10.2.5,gpg13_7.1,gpg13_7.2,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>authentication_success,pci_dss_10.2.5,gpg13_7.1,gpg13_7.2,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,</group>
   </rule>
 
   <rule id="60119" level="3">
@@ -177,7 +177,7 @@
     <if_fts />
     <description>First time this user logged in this system</description>
     <options>no_full_log</options>
-    <group>authentication_success,pci_dss_10.2.5,gpg13_7.1,gpg13_7.2,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>authentication_success,pci_dss_10.2.5,gpg13_7.1,gpg13_7.2,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,</group>
   </rule>
 
   <rule id="60120" level="0">
@@ -192,7 +192,7 @@
     <field name="win.system.eventID">^646$|^645$|^647$|^4741$|^4742$|^4743$</field>
     <description>Computer account added/changed/deleted</description>
     <options>no_full_log</options>
-    <group>account_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.a.2.I,hipaa_164.312.a.2.II,hipaa_164.312.b,nist_800_53_AC.2,nist_800_53_IA.4,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>account_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.a.2.I,hipaa_164.312.a.2.II,hipaa_164.312.b,nist_800_53_AC.2,nist_800_53_IA.4,nist_800_53_IA.10,nist_800_53_AC.7,</group>
   </rule>
 
     <!-- Granular windows login rules -->
@@ -201,7 +201,7 @@
     <field name="win.system.eventID">^529$|^4625$</field>
     <description>Logon Failure - Unknown user or bad password</description>
     <options>no_full_log</options>
-    <group>win_authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>win_authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,</group>
   </rule>
 
   <rule id="60123" level="5">
@@ -209,7 +209,7 @@
     <field name="win.system.eventID">^530$</field>
     <description>Logon Failure - Account logon time restriction violation</description>
     <options>no_full_log</options>
-    <group>win_authentication_failed,login_denied,pci_dss_10.2.5,pci_dss_8.1.5,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,hipaa_164.312.a.1,nist_800_53_AU.3.1,nist_800_53_IA.10,nist_800_53_AC.2,</group>
+    <group>win_authentication_failed,login_denied,pci_dss_10.2.5,pci_dss_8.1.5,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,hipaa_164.312.a.1,nist_800_53_IA.10,nist_800_53_AC.7,nist_800_53_AC.2,</group>
   </rule>
 
   <rule id="60124" level="5">
@@ -217,7 +217,7 @@
     <field name="win.system.eventID">^531$</field>
     <description>Logon Failure - Account currently disabled</description>
     <options>no_full_log</options>
-    <group>win_authentication_failed,login_denied,pci_dss_10.2.5,pci_dss_8.1.4,gpg13_7.5,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,hipaa_164.312.a.1,nist_800_53_AU.3.1,nist_800_53_IA.10,nist_800_53_AC.2,</group>
+    <group>win_authentication_failed,login_denied,pci_dss_10.2.5,pci_dss_8.1.4,gpg13_7.5,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,hipaa_164.312.a.1,nist_800_53_IA.10,nist_800_53_AC.7,nist_800_53_AC.2,</group>
   </rule>
 
   <rule id="60125" level="5">
@@ -225,7 +225,7 @@
     <field name="win.system.eventID">^532$</field>
     <description>Logon Failure - Specified account expired</description>
     <options>no_full_log</options>
-    <group>win_authentication_failed,login_denied,pci_dss_10.2.5,pci_dss_8.1.5,gpg13_7.5,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,hipaa_164.312.a.1,nist_800_53_AU.3.1,nist_800_53_IA.10,nist_800_53_AC.2,</group>
+    <group>win_authentication_failed,login_denied,pci_dss_10.2.5,pci_dss_8.1.5,gpg13_7.5,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,hipaa_164.312.a.1,nist_800_53_IA.10,nist_800_53_AC.7,nist_800_53_AC.2,</group>
   </rule>
 
   <rule id="60126" level="7">
@@ -233,7 +233,7 @@
     <field name="win.system.eventID">^533$</field>
     <description>Logon Failure - User not allowed to login at this computer</description>
     <options>no_full_log</options>
-    <group>win_authentication_failed,login_denied,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.5,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>win_authentication_failed,login_denied,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.5,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,</group>
   </rule>
 
   <rule id="60127" level="5">
@@ -241,7 +241,7 @@
     <field name="win.system.eventID">^534$</field>
     <description>Logon Failure - User not granted logon type</description>
     <options>no_full_log</options>
-    <group>win_authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.5,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>win_authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.5,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,</group>
   </rule>
 
   <rule id="60128" level="5">
@@ -249,7 +249,7 @@
     <field name="win.system.eventID">^535$</field>
     <description>Logon Failure - Account's password expired</description>
     <options>no_full_log</options>
-    <group>win_authentication_failed,pci_dss_10.2.5,pci_dss_8.2.4,gpg13_7.5,gdpr_IV_32.2,hipaa_164.312.b,hipaa_164.312.d,nist_800_53_AU.3.1,nist_800_53_IA.10,nist_800_53_IA.5,</group>
+    <group>win_authentication_failed,pci_dss_10.2.5,pci_dss_8.2.4,gpg13_7.5,gdpr_IV_32.2,hipaa_164.312.b,hipaa_164.312.d,nist_800_53_IA.10,nist_800_53_AC.7,nist_800_53_IA.5,</group>
   </rule>
 
   <rule id="60129" level="5">
@@ -257,7 +257,7 @@
     <field name="win.system.eventID">^536$|^537$</field>
     <description>Logon Failure - Internal error</description>
     <options>no_full_log</options>
-    <group>win_authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>win_authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,</group>
   </rule>
 
   <rule id="60130" level="7">
@@ -265,7 +265,7 @@
     <field name="win.system.eventID">^539$</field>
     <description>Logon Failure - Account locked out</description>
     <options>no_full_log</options>
-    <group>win_authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_8.1.6,gpg13_7.5,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,hipaa_164.312.a.1,nist_800_53_AU.3.1,nist_800_53_IA.10,nist_800_53_AC.7,</group>
+    <group>win_authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_8.1.6,gpg13_7.5,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,hipaa_164.312.a.1,nist_800_53_IA.10,nist_800_53_AC.7,nist_800_53_AC.7,</group>
   </rule>
 
   <rule id="60131" level="5">
@@ -273,7 +273,7 @@
     <field name="win.system.eventID">^673$|^675$|^681$|^4769$</field>
     <description>Windows DC Logon Failure</description>
     <options>no_full_log</options>
-    <group>win_authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>win_authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,</group>
   </rule>
 
   <rule id="60132" level="5">
@@ -289,7 +289,7 @@
     <field name="win.system.eventID">^671$|^4767$</field>
     <description>User account unlocked</description>
     <options>no_full_log</options>
-    <group>account_changed,pci_dss_10.2.5,pci_dss_8.1.6,gpg13_7.10,gdpr_IV_32.2,hipaa_164.312.b,hipaa_164.312.a.1,nist_800_53_AU.3.1,nist_800_53_IA.10,nist_800_53_AC.7,</group>
+    <group>account_changed,pci_dss_10.2.5,pci_dss_8.1.6,gpg13_7.10,gdpr_IV_32.2,hipaa_164.312.b,hipaa_164.312.a.1,nist_800_53_IA.10,nist_800_53_AC.7,nist_800_53_AC.7,</group>
   </rule>
 
   <rule id="60134" level="8">
@@ -297,7 +297,7 @@
     <field name="win.system.eventID">^631$|^635$|^658$</field>
     <description>Security enabled group created</description>
     <options>no_full_log</options>
-    <group>adduser,account_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.a.2.I,hipaa_164.312.a.2.II,hipaa_164.312.b,nist_800_53_AC.2,nist_800_53_IA.4,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>adduser,account_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.a.2.I,hipaa_164.312.a.2.II,hipaa_164.312.b,nist_800_53_AC.2,nist_800_53_IA.4,nist_800_53_IA.10,nist_800_53_AC.7,</group>
   </rule>
 
   <rule id="60135" level="8">
@@ -305,7 +305,7 @@
     <field name="win.system.eventID">^634$|^638$|^662$</field>
     <description>Security enabled group deleted</description>
     <options>no_full_log</options>
-    <group>adduser,account_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.a.2.I,hipaa_164.312.a.2.II,hipaa_164.312.b,nist_800_53_AC.2,nist_800_53_IA.4,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>adduser,account_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.a.2.I,hipaa_164.312.a.2.II,hipaa_164.312.b,nist_800_53_AC.2,nist_800_53_IA.4,nist_800_53_IA.10,nist_800_53_AC.7,</group>
   </rule>
 
   <rule id="60136" level="3">
@@ -320,7 +320,7 @@
     <field name="win.system.eventID">^538$|^551$|^4634$|^4647$</field>
     <description>Windows User Logoff</description>
     <options>no_full_log</options>
-    <group>pci_dss_10.2.5,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>pci_dss_10.2.5,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,</group>
   </rule>
 
   <!-- Granular group rules -->
@@ -330,7 +330,7 @@
                 ^4749$|^663$|^4759$</field>
     <description>Group Account Created</description>
     <options>no_full_log</options>
-    <group>group_created,win_group_created,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.a.2.I,hipaa_164.312.a.2.II,hipaa_164.312.b,nist_800_53_AC.2,nist_800_53_IA.4,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>group_created,win_group_created,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.a.2.I,hipaa_164.312.a.2.II,hipaa_164.312.b,nist_800_53_AC.2,nist_800_53_IA.4,nist_800_53_IA.10,nist_800_53_AC.7,</group>
   </rule>
 
   <rule id="60139" level="5">
@@ -339,7 +339,7 @@
             ^657$|^4753$|^667$|^4763$</field>
     <description>Group Account Deleted</description>
     <options>no_full_log</options>
-    <group>group_deleted,win_group_deleted,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.a.2.I,hipaa_164.312.a.2.II,hipaa_164.312.b,nist_800_53_AC.2,nist_800_53_IA.4,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>group_deleted,win_group_deleted,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.a.2.I,hipaa_164.312.a.2.II,hipaa_164.312.b,nist_800_53_AC.2,nist_800_53_IA.4,nist_800_53_IA.10,nist_800_53_AC.7,</group>
   </rule>
 
   <rule id="60140" level="5">
@@ -347,7 +347,7 @@
     <field name="win.system.eventID">^631$|^4727$</field>
     <description>Security Enabled Global Group Created</description>
     <options>no_full_log</options>
-    <group>group_created,win_group_created,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.a.2.I,hipaa_164.312.a.2.II,hipaa_164.312.b,nist_800_53_AC.2,nist_800_53_IA.4,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>group_created,win_group_created,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.a.2.I,hipaa_164.312.a.2.II,hipaa_164.312.b,nist_800_53_AC.2,nist_800_53_IA.4,nist_800_53_IA.10,nist_800_53_AC.7,</group>
   </rule>
 
   <rule id="60141" level="5">
@@ -355,7 +355,7 @@
     <field name="win.system.eventID">^632$|^4728$</field>
     <description>Security Enabled Global Group Member Added $(win.eventdata.memberSid)</description>
     <options>no_full_log</options>
-    <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.a.2.I,hipaa_164.312.a.2.II,hipaa_164.312.b,nist_800_53_AC.2,nist_800_53_IA.4,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.a.2.I,hipaa_164.312.a.2.II,hipaa_164.312.b,nist_800_53_AC.2,nist_800_53_IA.4,nist_800_53_IA.10,nist_800_53_AC.7,</group>
   </rule>
 
   <rule id="60142" level="5">
@@ -363,7 +363,7 @@
     <field name="win.system.eventID">^633$|^4729$</field>
     <description>Security Enabled Global Group Member Removed $(win.eventdata.memberSid)</description>
     <options>no_full_log</options>
-    <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.a.2.I,hipaa_164.312.a.2.II,hipaa_164.312.b,nist_800_53_AC.2,nist_800_53_IA.4,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.a.2.I,hipaa_164.312.a.2.II,hipaa_164.312.b,nist_800_53_AC.2,nist_800_53_IA.4,nist_800_53_IA.10,nist_800_53_AC.7,</group>
   </rule>
 
   <rule id="60143" level="5">
@@ -371,7 +371,7 @@
     <field name="win.system.eventID">^635$|^4731$</field>
     <description>Security Enabled Local Group Created $(win.eventdata.memberSid)</description>
     <options>no_full_log</options>
-    <group>group_created,win_group_created,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.a.2.I,hipaa_164.312.a.2.II,hipaa_164.312.b,nist_800_53_AC.2,nist_800_53_IA.4,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>group_created,win_group_created,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.a.2.I,hipaa_164.312.a.2.II,hipaa_164.312.b,nist_800_53_AC.2,nist_800_53_IA.4,nist_800_53_IA.10,nist_800_53_AC.7,</group>
   </rule>
 
   <rule id="60144" level="5">
@@ -379,7 +379,7 @@
     <field name="win.system.eventID">^636$|^4732$</field>
     <description>Security Enabled Local Group Member Added $(win.eventdata.memberSid)</description>
     <options>no_full_log</options>
-   <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.a.2.I,hipaa_164.312.a.2.II,hipaa_164.312.b,nist_800_53_AC.2,nist_800_53_IA.4,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+   <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.a.2.I,hipaa_164.312.a.2.II,hipaa_164.312.b,nist_800_53_AC.2,nist_800_53_IA.4,nist_800_53_IA.10,nist_800_53_AC.7,</group>
   </rule>
 
   <rule id="60145" level="5">
@@ -387,7 +387,7 @@
     <field name="win.system.eventID">^637$|^4733$</field>
     <description>Security Enabled Local Group Member Removed $(win.eventdata.memberSid)</description>
     <options>no_full_log</options>
-    <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.a.2.I,hipaa_164.312.a.2.II,hipaa_164.312.b,nist_800_53_AC.2,nist_800_53_IA.4,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.a.2.I,hipaa_164.312.a.2.II,hipaa_164.312.b,nist_800_53_AC.2,nist_800_53_IA.4,nist_800_53_IA.10,nist_800_53_AC.7,</group>
   </rule>
 
   <rule id="60146" level="5">
@@ -395,7 +395,7 @@
     <field name="win.system.eventID">^638$|^4734$</field>
     <description>Security Enabled Local Group Deleted</description>
     <options>no_full_log</options>
-    <group>group_deleted,win_group_deleted,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.a.2.I,hipaa_164.312.a.2.II,hipaa_164.312.b,nist_800_53_AC.2,nist_800_53_IA.4,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>group_deleted,win_group_deleted,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.a.2.I,hipaa_164.312.a.2.II,hipaa_164.312.b,nist_800_53_AC.2,nist_800_53_IA.4,nist_800_53_IA.10,nist_800_53_AC.7,</group>
   </rule>
 
   <rule id="60147" level="5">
@@ -403,7 +403,7 @@
     <field name="win.system.eventID">^639$|^4735$</field>
     <description>Security Enabled Local Group Changed</description>
     <options>no_full_log</options>
-    <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.a.2.I,hipaa_164.312.a.2.II,hipaa_164.312.b,nist_800_53_AC.2,nist_800_53_IA.4,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.a.2.I,hipaa_164.312.a.2.II,hipaa_164.312.b,nist_800_53_AC.2,nist_800_53_IA.4,nist_800_53_IA.10,nist_800_53_AC.7,</group>
   </rule>
 
   <rule id="60148" level="5">
@@ -411,7 +411,7 @@
     <field name="win.system.eventID">^641$|^4737$</field>
     <description>Security Enabled Global Group Changed</description>
     <options>no_full_log</options>
-    <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.a.2.I,hipaa_164.312.a.2.II,hipaa_164.312.b,nist_800_53_AC.2,nist_800_53_IA.4,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.a.2.I,hipaa_164.312.a.2.II,hipaa_164.312.b,nist_800_53_AC.2,nist_800_53_IA.4,nist_800_53_IA.10,nist_800_53_AC.7,</group>
   </rule>
 
   <rule id="60149" level="5">
@@ -419,7 +419,7 @@
     <field name="win.system.eventID">^658$|^4754$</field>
     <description>Security Enabled Universal Group Created</description>
     <options>no_full_log</options>
-    <group>group_created,win_group_created,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.a.2.I,hipaa_164.312.a.2.II,hipaa_164.312.b,nist_800_53_AC.2,nist_800_53_IA.4,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>group_created,win_group_created,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.a.2.I,hipaa_164.312.a.2.II,hipaa_164.312.b,nist_800_53_AC.2,nist_800_53_IA.4,nist_800_53_IA.10,nist_800_53_AC.7,</group>
   </rule>
 
   <rule id="60150" level="5">
@@ -427,7 +427,7 @@
     <field name="win.system.eventID">^659$|^4755$</field>
     <description>Security Enabled Universal Group Changed</description>
     <options>no_full_log</options>
-    <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.a.2.I,hipaa_164.312.a.2.II,hipaa_164.312.b,nist_800_53_AC.2,nist_800_53_IA.4,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.a.2.I,hipaa_164.312.a.2.II,hipaa_164.312.b,nist_800_53_AC.2,nist_800_53_IA.4,nist_800_53_IA.10,nist_800_53_AC.7,</group>
   </rule>
 
   <rule id="60151" level="5">
@@ -435,7 +435,7 @@
     <field name="win.system.eventID">^660$|^4756$</field>
     <description>Security Enabled Universal Group Member Added</description>
     <options>no_full_log</options>
-    <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.a.2.I,hipaa_164.312.a.2.II,hipaa_164.312.b,nist_800_53_AC.2,nist_800_53_IA.4,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.a.2.I,hipaa_164.312.a.2.II,hipaa_164.312.b,nist_800_53_AC.2,nist_800_53_IA.4,nist_800_53_IA.10,nist_800_53_AC.7,</group>
   </rule>
 
   <rule id="60152" level="5">
@@ -443,7 +443,7 @@
     <field name="win.system.eventID">^661$|^4757$</field>
     <description>Security Enabled Universal Group Member Removed</description>
     <options>no_full_log</options>
-    <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.a.2.I,hipaa_164.312.a.2.II,hipaa_164.312.b,nist_800_53_AC.2,nist_800_53_IA.4,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.a.2.I,hipaa_164.312.a.2.II,hipaa_164.312.b,nist_800_53_AC.2,nist_800_53_IA.4,nist_800_53_IA.10,nist_800_53_AC.7,</group>
   </rule>
 
   <rule id="60153" level="5">
@@ -451,7 +451,7 @@
     <field name="win.system.eventID">^662$|^4758$</field>
     <description>Security Enabled Universal Group Deleted</description>
     <options>no_full_log</options>
-    <group>group_deleted,win_group_deleted,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.a.2.I,hipaa_164.312.a.2.II,hipaa_164.312.b,nist_800_53_AC.2,nist_800_53_IA.4,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>group_deleted,win_group_deleted,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.a.2.I,hipaa_164.312.a.2.II,hipaa_164.312.b,nist_800_53_AC.2,nist_800_53_IA.4,nist_800_53_IA.10,nist_800_53_AC.7,</group>
   </rule>
 
   <rule id="60154" level="12">
@@ -459,7 +459,7 @@
     <field name="win.eventdata.subjectUserSid">^\p*S-1-5-32-544$</field>
     <description>Administrators Group Changed</description>
     <options>no_full_log</options>
-    <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.a.2.I,hipaa_164.312.a.2.II,hipaa_164.312.b,nist_800_53_AC.2,nist_800_53_IA.4,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.a.2.I,hipaa_164.312.a.2.II,hipaa_164.312.b,nist_800_53_AC.2,nist_800_53_IA.4,nist_800_53_IA.10,nist_800_53_AC.7,</group>
   </rule>
 
   <rule id="60155" level="5">
@@ -467,7 +467,7 @@
     <field name="win.eventdata.subjectUserSid">^%{S-1-1-0}$|^S-1-1-0$</field>
     <description>Everyone Group Changed</description>
     <options>no_full_log</options>
-    <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.a.2.I,hipaa_164.312.a.2.II,hipaa_164.312.b,nist_800_53_AC.2,nist_800_53_IA.4,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.a.2.I,hipaa_164.312.a.2.II,hipaa_164.312.b,nist_800_53_AC.2,nist_800_53_IA.4,nist_800_53_IA.10,nist_800_53_AC.7,</group>
   </rule>
 
   <rule id="60156" level="12">
@@ -475,7 +475,7 @@
     <field name="win.eventdata.subjectUserSid">^%{S-1-5-9}$|^S-1-5-9$</field>
     <description>Enterprise Domain Controllers Group Changed</description>
     <options>no_full_log</options>
-    <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.a.2.I,hipaa_164.312.a.2.II,hipaa_164.312.b,nist_800_53_AC.2,nist_800_53_IA.4,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.a.2.I,hipaa_164.312.a.2.II,hipaa_164.312.b,nist_800_53_AC.2,nist_800_53_IA.4,nist_800_53_IA.10,nist_800_53_AC.7,</group>
   </rule>
 
   <rule id="60157" level="5">
@@ -483,7 +483,7 @@
     <field name="win.eventdata.subjectUserSid">^%{S-1-5-11}$|^S-1-5-11$</field>
     <description>Authenticated Users Group Changed</description>
     <options>no_full_log</options>
-    <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.a.2.I,hipaa_164.312.a.2.II,hipaa_164.312.b,nist_800_53_AC.2,nist_800_53_IA.4,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.a.2.I,hipaa_164.312.a.2.II,hipaa_164.312.b,nist_800_53_AC.2,nist_800_53_IA.4,nist_800_53_IA.10,nist_800_53_AC.7,</group>
   </rule>
 
   <rule id="60158" level="5">
@@ -491,7 +491,7 @@
     <field name="win.eventdata.subjectUserSid">^%{S-1-5-13}$|^S-1-5-13$</field>
     <description>Terminal Server Users Group Changed</description>
     <options>no_full_log</options>
-    <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.a.2.I,hipaa_164.312.a.2.II,hipaa_164.312.b,nist_800_53_AC.2,nist_800_53_IA.4,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.a.2.I,hipaa_164.312.a.2.II,hipaa_164.312.b,nist_800_53_AC.2,nist_800_53_IA.4,nist_800_53_IA.10,nist_800_53_AC.7,</group>
   </rule>
 
   <rule id="60159" level="12">
@@ -499,7 +499,7 @@
     <field name="win.eventdata.subjectUserSid">^%{S-1-5-21\S+-512}$|^S-1-5-21\S+-512$</field>
     <description>Domain Admins Group Changed</description>
     <options>no_full_log</options>
-    <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.a.2.I,hipaa_164.312.a.2.II,hipaa_164.312.b,nist_800_53_AC.2,nist_800_53_IA.4,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.a.2.I,hipaa_164.312.a.2.II,hipaa_164.312.b,nist_800_53_AC.2,nist_800_53_IA.4,nist_800_53_IA.10,nist_800_53_AC.7,</group>
   </rule>
 
   <rule id="60160" level="5">
@@ -507,7 +507,7 @@
     <field name="win.eventdata.subjectUserSid">^%{S-1-5-21\S+-513}$|^S-1-5-21\S+-513$</field>
     <description>Domain Users Group Changed</description>
     <options>no_full_log</options>
-    <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.a.2.I,hipaa_164.312.a.2.II,hipaa_164.312.b,nist_800_53_AC.2,nist_800_53_IA.4,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.a.2.I,hipaa_164.312.a.2.II,hipaa_164.312.b,nist_800_53_AC.2,nist_800_53_IA.4,nist_800_53_IA.10,nist_800_53_AC.7,</group>
   </rule>
 
   <rule id="60161" level="0">
@@ -523,7 +523,7 @@
     <field name="win.eventdata.subjectUserSid">^%{S-1-5-21\S+-514}$|^S-1-5-21\S+-514$</field>
     <description>Domain Guests Group Changed</description>
     <options>no_full_log</options>
-    <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.a.2.I,hipaa_164.312.a.2.II,hipaa_164.312.b,nist_800_53_AC.2,nist_800_53_IA.4,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.a.2.I,hipaa_164.312.a.2.II,hipaa_164.312.b,nist_800_53_AC.2,nist_800_53_IA.4,nist_800_53_IA.10,nist_800_53_AC.7,</group>
   </rule>
 
   <rule id="60163" level="5">
@@ -531,7 +531,7 @@
     <field name="win.eventdata.subjectUserSid">^%{S-1-5-21\S+-515}$|^S-1-5-21\S+-515$</field>
     <description>Domain Computers Group Changed</description>
     <options>no_full_log</options>
-    <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.a.2.I,hipaa_164.312.a.2.II,hipaa_164.312.b,nist_800_53_AC.2,nist_800_53_IA.4,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.a.2.I,hipaa_164.312.a.2.II,hipaa_164.312.b,nist_800_53_AC.2,nist_800_53_IA.4,nist_800_53_IA.10,nist_800_53_AC.7,</group>
   </rule>
 
   <rule id="60164" level="12">
@@ -539,7 +539,7 @@
     <field name="win.eventdata.subjectUserSid">^%{S-1-5-21\S+-516}$|^S-1-5-21\S+-516$</field>
     <description>Domain Controllers Group Changed</description>
     <options>no_full_log</options>
-    <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.a.2.I,hipaa_164.312.a.2.II,hipaa_164.312.b,nist_800_53_AC.2,nist_800_53_IA.4,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.a.2.I,hipaa_164.312.a.2.II,hipaa_164.312.b,nist_800_53_AC.2,nist_800_53_IA.4,nist_800_53_IA.10,nist_800_53_AC.7,</group>
   </rule>
 
   <rule id="60165" level="10">
@@ -547,7 +547,7 @@
     <field name="win.eventdata.subjectUserSid">^%{S-1-5-21\S+-517}$|^S-1-5-21\S+-517$</field>
     <description>Cert Publishers Group Changed</description>
     <options>no_full_log</options>
-    <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.a.2.I,hipaa_164.312.a.2.II,hipaa_164.312.b,nist_800_53_AC.2,nist_800_53_IA.4,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.a.2.I,hipaa_164.312.a.2.II,hipaa_164.312.b,nist_800_53_AC.2,nist_800_53_IA.4,nist_800_53_IA.10,nist_800_53_AC.7,</group>
   </rule>
 
   <rule id="60166" level="12">
@@ -555,7 +555,7 @@
     <field name="win.eventdata.subjectUserSid">^%{S-1-5-21\S+-518}$|^S-1-5-21\S+-518$</field>
     <description>Schema Admins Group Changed</description>
     <options>no_full_log</options>
-    <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.a.2.I,hipaa_164.312.a.2.II,hipaa_164.312.b,nist_800_53_AC.2,nist_800_53_IA.4,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.a.2.I,hipaa_164.312.a.2.II,hipaa_164.312.b,nist_800_53_AC.2,nist_800_53_IA.4,nist_800_53_IA.10,nist_800_53_AC.7,</group>
   </rule>
 
   <rule id="60167" level="12">
@@ -563,7 +563,7 @@
     <field name="win.eventdata.subjectUserSid">^%{S-1-5-21\S+-519}$|^S-1-5-21\S+-519$</field>
     <description>Enterprise Admins Group Changed</description>
     <options>no_full_log</options>
-    <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.a.2.I,hipaa_164.312.a.2.II,hipaa_164.312.b,nist_800_53_AC.2,nist_800_53_IA.4,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.a.2.I,hipaa_164.312.a.2.II,hipaa_164.312.b,nist_800_53_AC.2,nist_800_53_IA.4,nist_800_53_IA.10,nist_800_53_AC.7,</group>
   </rule>
 
   <rule id="60168" level="10">
@@ -571,7 +571,7 @@
     <field name="win.eventdata.subjectUserSid">^%{S-1-5-21\S+-520}$|^S-1-5-21\S+-520$</field>
     <description>Group Policy Creator Owners Group Changed</description>
     <options>no_full_log</options>
-    <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.a.2.I,hipaa_164.312.a.2.II,hipaa_164.312.b,nist_800_53_AC.2,nist_800_53_IA.4,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.a.2.I,hipaa_164.312.a.2.II,hipaa_164.312.b,nist_800_53_AC.2,nist_800_53_IA.4,nist_800_53_IA.10,nist_800_53_AC.7,</group>
   </rule>
 
   <rule id="60169" level="10">
@@ -579,7 +579,7 @@
     <field name="win.eventdata.subjectUserSid">^%{S-1-5-21\S+-553}$|^S-1-5-21\S+-553$</field>
     <description>RAS and IAS Servers Group Changed</description>
     <options>no_full_log</options>
-    <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.a.2.I,hipaa_164.312.a.2.II,hipaa_164.312.b,nist_800_53_AC.2,nist_800_53_IA.4,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.a.2.I,hipaa_164.312.a.2.II,hipaa_164.312.b,nist_800_53_AC.2,nist_800_53_IA.4,nist_800_53_IA.10,nist_800_53_AC.7,</group>
   </rule>
 
   <rule id="60170" level="5">
@@ -587,7 +587,7 @@
     <field name="win.eventdata.subjectUserSid">^%{S-1-5-32\S+-545}$|^S-1-5-32\S+-545$</field>
     <description>Users Group Changed</description>
     <options>no_full_log</options>
-    <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.a.2.I,hipaa_164.312.a.2.II,hipaa_164.312.b,nist_800_53_AC.2,nist_800_53_IA.4,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.a.2.I,hipaa_164.312.a.2.II,hipaa_164.312.b,nist_800_53_AC.2,nist_800_53_IA.4,nist_800_53_IA.10,nist_800_53_AC.7,</group>
   </rule>
 
   <rule id="60171" level="12">
@@ -595,7 +595,7 @@
     <field name="win.eventdata.subjectUserSid">^%{S-1-5-32\S+-546}$|^S-1-5-32\S+-546$</field>
     <description>Guests Group Changed</description>
     <options>no_full_log</options>
-    <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.a.2.I,hipaa_164.312.a.2.II,hipaa_164.312.b,nist_800_53_AC.2,nist_800_53_IA.4,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.a.2.I,hipaa_164.312.a.2.II,hipaa_164.312.b,nist_800_53_AC.2,nist_800_53_IA.4,nist_800_53_IA.10,nist_800_53_AC.7,</group>
   </rule>
 
   <rule id="60172" level="10">
@@ -603,7 +603,7 @@
     <field name="win.eventdata.subjectUserSid">^%{S-1-5-32\S+-547}$|^S-1-5-32\S+-547$</field>
     <description>Power Users Group Changed</description>
     <options>no_full_log</options>
-    <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.a.2.I,hipaa_164.312.a.2.II,hipaa_164.312.b,nist_800_53_AC.2,nist_800_53_IA.4,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.a.2.I,hipaa_164.312.a.2.II,hipaa_164.312.b,nist_800_53_AC.2,nist_800_53_IA.4,nist_800_53_IA.10,nist_800_53_AC.7,</group>
   </rule>
 
   <rule id="60173" level="10">
@@ -611,7 +611,7 @@
     <field name="win.eventdata.subjectUserSid">^%{S-1-5-32\S+-548}$|^S-1-5-32\S+-548$</field>
     <description>Account Operators Group Changed</description>
     <options>no_full_log</options>
-    <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.a.2.I,hipaa_164.312.a.2.II,hipaa_164.312.b,nist_800_53_AC.2,nist_800_53_IA.4,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.a.2.I,hipaa_164.312.a.2.II,hipaa_164.312.b,nist_800_53_AC.2,nist_800_53_IA.4,nist_800_53_IA.10,nist_800_53_AC.7,</group>
   </rule>
 
   <rule id="60174" level="10">
@@ -619,7 +619,7 @@
     <field name="win.eventdata.subjectUserSid">^%{S-1-5-32\S+-549}$|^S-1-5-32\S+-549$</field>
     <description>Server Operators Group Changed</description>
     <options>no_full_log</options>
-    <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.a.2.I,hipaa_164.312.a.2.II,hipaa_164.312.b,nist_800_53_AC.2,nist_800_53_IA.4,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.a.2.I,hipaa_164.312.a.2.II,hipaa_164.312.b,nist_800_53_AC.2,nist_800_53_IA.4,nist_800_53_IA.10,nist_800_53_AC.7,</group>
   </rule>
 
   <rule id="60175" level="8">
@@ -627,7 +627,7 @@
     <field name="win.eventdata.subjectUserSid">^%{S-1-5-32\S+-550}$|^S-1-5-32\S+-550$</field>
     <description>Print Operators Group Changed</description>
     <options>no_full_log</options>
-    <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.a.2.I,hipaa_164.312.a.2.II,hipaa_164.312.b,nist_800_53_AC.2,nist_800_53_IA.4,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.a.2.I,hipaa_164.312.a.2.II,hipaa_164.312.b,nist_800_53_AC.2,nist_800_53_IA.4,nist_800_53_IA.10,nist_800_53_AC.7,</group>
   </rule>
 
   <rule id="60176" level="12">
@@ -635,7 +635,7 @@
     <field name="win.eventdata.subjectUserSid">^%{S-1-5-32\S+-551}$|^S-1-5-32\S+-551$</field>
     <description>Backup Operators Group Changed</description>
     <options>no_full_log</options>
-    <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.a.2.I,hipaa_164.312.a.2.II,hipaa_164.312.b,nist_800_53_AC.2,nist_800_53_IA.4,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.a.2.I,hipaa_164.312.a.2.II,hipaa_164.312.b,nist_800_53_AC.2,nist_800_53_IA.4,nist_800_53_IA.10,nist_800_53_AC.7,</group>
   </rule>
 
   <rule id="60177" level="10">
@@ -643,7 +643,7 @@
     <field name="win.eventdata.subjectUserSid">^%{S-1-5-32\S+-552}$|^S-1-5-32\S+-552$</field>
     <description>Replicators Group Changed</description>
     <options>no_full_log</options>
-    <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.a.2.I,hipaa_164.312.a.2.II,hipaa_164.312.b,nist_800_53_AC.2,nist_800_53_IA.4,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.a.2.I,hipaa_164.312.a.2.II,hipaa_164.312.b,nist_800_53_AC.2,nist_800_53_IA.4,nist_800_53_IA.10,nist_800_53_AC.7,</group>
   </rule>
 
   <rule id="60178" level="8">
@@ -651,7 +651,7 @@
     <field name="win.eventdata.subjectUserSid">^%{S-1-5-32\S+-554}$|^S-1-5-32\S+-554$</field>
     <description>Pre-Windows 2000 Compatible Access Group Changed</description>
     <options>no_full_log</options>
-    <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.a.2.I,hipaa_164.312.a.2.II,hipaa_164.312.b,nist_800_53_AC.2,nist_800_53_IA.4,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.a.2.I,hipaa_164.312.a.2.II,hipaa_164.312.b,nist_800_53_AC.2,nist_800_53_IA.4,nist_800_53_IA.10,nist_800_53_AC.7,</group>
   </rule>
 
   <rule id="60179" level="10">
@@ -659,7 +659,7 @@
     <field name="win.eventdata.subjectUserSid">^%{S-1-5-32\S+-555}$|^S-1-5-32\S+-555$</field>
     <description>Remote Desktop Users Group Changed</description>
     <options>no_full_log</options>
-    <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.a.2.I,hipaa_164.312.a.2.II,hipaa_164.312.b,nist_800_53_AC.2,nist_800_53_IA.4,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.a.2.I,hipaa_164.312.a.2.II,hipaa_164.312.b,nist_800_53_AC.2,nist_800_53_IA.4,nist_800_53_IA.10,nist_800_53_AC.7,</group>
   </rule>
 
   <rule id="60180" level="10">
@@ -667,7 +667,7 @@
     <field name="win.eventdata.subjectUserSid">^%{S-1-5-32\S+-556}$|^S-1-5-32\S+-556$</field>
     <description>Network Configuration Operators Group Changed</description>
     <options>no_full_log</options>
-    <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.a.2.I,hipaa_164.312.a.2.II,hipaa_164.312.b,nist_800_53_AC.2,nist_800_53_IA.4,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.a.2.I,hipaa_164.312.a.2.II,hipaa_164.312.b,nist_800_53_AC.2,nist_800_53_IA.4,nist_800_53_IA.10,nist_800_53_AC.7,</group>
   </rule>
 
   <rule id="60181" level="10">
@@ -675,7 +675,7 @@
     <field name="win.eventdata.subjectUserSid">^%{S-1-5-32\S+-557}$|^S-1-5-32\S+-557$</field>
     <description>Incoming Forest Trust Builders Group Changed</description>
     <options>no_full_log</options>
-    <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.a.2.I,hipaa_164.312.a.2.II,hipaa_164.312.b,nist_800_53_AC.2,nist_800_53_IA.4,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.a.2.I,hipaa_164.312.a.2.II,hipaa_164.312.b,nist_800_53_AC.2,nist_800_53_IA.4,nist_800_53_IA.10,nist_800_53_AC.7,</group>
   </rule>
 
   <rule id="60182" level="8">
@@ -683,7 +683,7 @@
     <field name="win.eventdata.subjectUserSid">^%{S-1-5-32\S+-558}$|^S-1-5-32\S+-558$</field>
     <description>Performance Monitor Users Group Changed</description>
     <options>no_full_log</options>
-    <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.a.2.I,hipaa_164.312.a.2.II,hipaa_164.312.b,nist_800_53_AC.2,nist_800_53_IA.4,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.a.2.I,hipaa_164.312.a.2.II,hipaa_164.312.b,nist_800_53_AC.2,nist_800_53_IA.4,nist_800_53_IA.10,nist_800_53_AC.7,</group>
   </rule>
 
   <rule id="60183" level="8">
@@ -691,7 +691,7 @@
     <field name="win.eventdata.subjectUserSid">^%{S-1-5-32\S+-559}$|^S-1-5-32\S+-559$</field>
     <description>Performance Log Users Group Changed</description>
     <options>no_full_log</options>
-    <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.a.2.I,hipaa_164.312.a.2.II,hipaa_164.312.b,nist_800_53_AC.2,nist_800_53_IA.4,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.a.2.I,hipaa_164.312.a.2.II,hipaa_164.312.b,nist_800_53_AC.2,nist_800_53_IA.4,nist_800_53_IA.10,nist_800_53_AC.7,</group>
   </rule>
 
   <rule id="60184" level="8">
@@ -699,7 +699,7 @@
     <field name="win.eventdata.subjectUserSid">^%{S-1-5-32\S+-560}$|^S-1-5-32\S+-560$</field>
     <description>Windows Authorization Access Group Changed</description>
     <options>no_full_log</options>
-    <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.a.2.I,hipaa_164.312.a.2.II,hipaa_164.312.b,nist_800_53_AC.2,nist_800_53_IA.4,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.a.2.I,hipaa_164.312.a.2.II,hipaa_164.312.b,nist_800_53_AC.2,nist_800_53_IA.4,nist_800_53_IA.10,nist_800_53_AC.7,</group>
   </rule>
 
   <rule id="60185" level="8">
@@ -707,7 +707,7 @@
     <field name="win.eventdata.subjectUserSid">^%{S-1-5-32\S+-561}$|^S-1-5-32\S+-561$</field>
     <description>Terminal Server License Servers Group Changed</description>
     <options>no_full_log</options>
-    <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.a.2.I,hipaa_164.312.a.2.II,hipaa_164.312.b,nist_800_53_AC.2,nist_800_53_IA.4,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.a.2.I,hipaa_164.312.a.2.II,hipaa_164.312.b,nist_800_53_AC.2,nist_800_53_IA.4,nist_800_53_IA.10,nist_800_53_AC.7,</group>
   </rule>
 
   <rule id="60186" level="8">
@@ -715,7 +715,7 @@
     <field name="win.eventdata.subjectUserSid">^%{S-1-5-32\S+-562}$|^S-1-5-32\S+-562$</field>
     <description>Distributed COM Users Group Changed</description>
     <options>no_full_log</options>
-    <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.a.2.I,hipaa_164.312.a.2.II,hipaa_164.312.b,nist_800_53_AC.2,nist_800_53_IA.4,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.a.2.I,hipaa_164.312.a.2.II,hipaa_164.312.b,nist_800_53_AC.2,nist_800_53_IA.4,nist_800_53_IA.10,nist_800_53_AC.7,</group>
   </rule>
 
   <rule id="60187" level="12">
@@ -723,7 +723,7 @@
     <field name="win.eventdata.subjectUserSid">^%{S-1-5-\s*21\s*-498}$|^S-1-5-\s*21\s*-498$</field>
     <description>Enterprise Read-only Domain Controllers Group Changed</description>
     <options>no_full_log</options>
-    <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.a.2.I,hipaa_164.312.a.2.II,hipaa_164.312.b,nist_800_53_AC.2,nist_800_53_IA.4,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.a.2.I,hipaa_164.312.a.2.II,hipaa_164.312.b,nist_800_53_AC.2,nist_800_53_IA.4,nist_800_53_IA.10,nist_800_53_AC.7,</group>
   </rule>
 
   <rule id="60188" level="12">
@@ -731,7 +731,7 @@
     <field name="win.eventdata.subjectUserSid">^%{S-1-5-\s*21\s*-529}$|^S-1-5-\s*21\s*-529$</field>
     <description>Read-only Domain Controllers Group Changed</description>
     <options>no_full_log</options>
-    <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.a.2.I,hipaa_164.312.a.2.II,hipaa_164.312.b,nist_800_53_AC.2,nist_800_53_IA.4,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.a.2.I,hipaa_164.312.a.2.II,hipaa_164.312.b,nist_800_53_AC.2,nist_800_53_IA.4,nist_800_53_IA.10,nist_800_53_AC.7,</group>
   </rule>
 
   <rule id="60189" level="12">
@@ -739,7 +739,7 @@
     <field name="win.eventdata.subjectUserSid">^%{S-1-5-32-569}$|^S-1-5-32-569$</field>
     <description>Cryptographic Operators Group Changed</description>
     <options>no_full_log</options>
-    <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.a.2.I,hipaa_164.312.a.2.II,hipaa_164.312.b,nist_800_53_AC.2,nist_800_53_IA.4,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.a.2.I,hipaa_164.312.a.2.II,hipaa_164.312.b,nist_800_53_AC.2,nist_800_53_IA.4,nist_800_53_IA.10,nist_800_53_AC.7,</group>
   </rule>
 
   <rule id="60190" level="10">
@@ -747,7 +747,7 @@
     <field name="win.eventdata.subjectUserSid">^%{S-1-5-\s*21\s*-571}$|^S-1-5-\s*21\s*-571$</field>
     <description>Allowed RODC Password Replication Group Changed</description>
     <options>no_full_log</options>
-    <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.a.2.I,hipaa_164.312.a.2.II,hipaa_164.312.b,nist_800_53_AC.2,nist_800_53_IA.4,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.a.2.I,hipaa_164.312.a.2.II,hipaa_164.312.b,nist_800_53_AC.2,nist_800_53_IA.4,nist_800_53_IA.10,nist_800_53_AC.7,</group>
   </rule>
 
   <rule id="60191" level="10">
@@ -755,7 +755,7 @@
     <field name="win.eventdata.subjectUserSid">^%{S-1-5-\s*21\s*-572}$|^S-1-5-\s*21\s*-572$</field>
     <description>Denied RODC Password Replication Group Changed</description>
     <options>no_full_log</options>
-    <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.a.2.I,hipaa_164.312.a.2.II,hipaa_164.312.b,nist_800_53_AC.2,nist_800_53_IA.4,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.a.2.I,hipaa_164.312.a.2.II,hipaa_164.312.b,nist_800_53_AC.2,nist_800_53_IA.4,nist_800_53_IA.10,nist_800_53_AC.7,</group>
   </rule>
 
   <rule id="60192" level="10">
@@ -763,7 +763,7 @@
     <field name="win.eventdata.subjectUserSid">^%{S-1-5-32-573}$|^S-1-5-32-573$</field>
     <description>Event Log Readers Group Changed</description>
     <options>no_full_log</options>
-    <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.a.2.I,hipaa_164.312.a.2.II,hipaa_164.312.b,nist_800_53_AC.2,nist_800_53_IA.4,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.a.2.I,hipaa_164.312.a.2.II,hipaa_164.312.b,nist_800_53_AC.2,nist_800_53_IA.4,nist_800_53_IA.10,nist_800_53_AC.7,</group>
   </rule>
 
   <rule id="60193" level="10">
@@ -771,7 +771,7 @@
     <field name="win.eventdata.subjectUserSid">^%{S-1-5-32-574}$|^S-1-5-32-574$</field>
     <description>Certificate Service DCOM Access Group Changed</description>
     <options>no_full_log</options>
-    <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.a.2.I,hipaa_164.312.a.2.II,hipaa_164.312.b,nist_800_53_AC.2,nist_800_53_IA.4,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>group_changed,win_group_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.a.2.I,hipaa_164.312.a.2.II,hipaa_164.312.b,nist_800_53_AC.2,nist_800_53_IA.4,nist_800_53_IA.10,nist_800_53_AC.7,</group>
   </rule>
 
   <!-- Ignore Login events, type 5, from Advapi for:
@@ -783,7 +783,7 @@
     <field name="win.eventdata.subjectUserName">^LOCAL SERVICE|^NETWORK SERVICE|^ANONYMOUS LOGON</field>
     <description>Windows Logon Success (ignored)</description>
     <options>no_full_log</options>
-    <group>pci_dss_10.2.5,gpg13_7.1,gpg13_7.2,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>pci_dss_10.2.5,gpg13_7.1,gpg13_7.2,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,</group>
   </rule>
 
   <rule id="60195" level="10">
@@ -792,7 +792,7 @@
     <description>Windows DC integrity check on decrypted</description>
     <options>no_full_log</options>
     <description>field failed</description>
-    <group>win_authentication_failed,attacks,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,nist_800_53_SC.7,</group>
+    <group>win_authentication_failed,attacks,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,nist_800_53_IA.10,</group>
   </rule>
 
   <rule id="60196" level="10">
@@ -800,7 +800,7 @@
     <field name="win.eventdata.failureCode">0x22</field>
     <description>Windows DC - Possible replay attack</description>
     <options>no_full_log</options>
-    <group>win_authentication_failed,attacks,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,nist_800_53_SC.7,</group>
+    <group>win_authentication_failed,attacks,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,nist_800_53_IA.10,</group>
   </rule>
 
   <rule id="60197" level="7">
@@ -808,14 +808,14 @@
     <field name="win.eventdata.failureCode">0x25</field>
     <description>Windows DC - Clock skew too great</description>
     <options>no_full_log</options>
-    <group>win_authentication_failed,attacks,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,nist_800_53_SC.7,</group>
+    <group>win_authentication_failed,attacks,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,nist_800_53_IA.10,</group>
   </rule>
 
   <!-- MS SQL rules -->
   <rule id="60198" level="5">
     <if_sid>60104</if_sid>
     <field name="win.system.eventID">^18456$</field>
-    <group>win_authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>win_authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,</group>
     <description>MS SQL Server Logon Failure</description>
     <options>no_full_log</options>
   </rule>
@@ -825,7 +825,7 @@
     <field name="win.system.eventID">^18454$|^18453$</field>
     <description>MS SQL Server Logon Success</description>
     <options>no_full_log</options>
-    <group>authentication_success,pci_dss_10.2.5,gpg13_7.1,gpg13_7.2,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>authentication_success,pci_dss_10.2.5,gpg13_7.1,gpg13_7.2,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,</group>
   </rule>
 
 <!-- Detail logon rules -->
@@ -835,7 +835,7 @@
     <field name="win.eventdata.logonType">^8$</field>
     <description>IIS NetworkCleartext Logon Success</description>
     <options>no_full_log</options>
-    <group>pci_dss_10.2.5,gpg13_7.1,gpg13_7.2,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>pci_dss_10.2.5,gpg13_7.1,gpg13_7.2,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,</group>
   </rule>
 
   <rule id="60201" level="0">
@@ -844,7 +844,7 @@
     <field name="win.eventdata.logonType">^8$</field>
     <description>MS Exchange User Logoff</description>
     <options>no_full_log</options>
-    <group>pci_dss_10.2.5,gpg13_7.1,gpg13_7.2,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>pci_dss_10.2.5,gpg13_7.1,gpg13_7.2,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,</group>
   </rule>
 
   <rule id="60202" level="5">
@@ -852,7 +852,7 @@
     <field name="win.system.eventID">^634$|^4730$</field>
     <description>Security Enabled Global Group Deleted $(win.eventdata.memberSid)</description>
     <options>no_full_log</options>
-    <group>group_deleted,win_group_deleted,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.a.2.I,hipaa_164.312.a.2.II,hipaa_164.312.b,nist_800_53_AC.2,nist_800_53_IA.4,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>group_deleted,win_group_deleted,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_7.10,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.a.2.I,hipaa_164.312.a.2.II,hipaa_164.312.b,nist_800_53_AC.2,nist_800_53_IA.4,nist_800_53_IA.10,nist_800_53_AC.7,</group>
   </rule>
 
   <!-- Multiple events -->
@@ -861,7 +861,7 @@
     <same_field>win.eventdata.targetUserName</same_field>
     <description>Multiple failed attempts to perform a privileged operation by the same user</description>
     <options>no_full_log</options>
-    <group>pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,nist_800_53_SC.7,</group>
+    <group>pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,nist_800_53_IA.10,</group>
   </rule>
 
   <rule id="60204" level="10" frequency="$MS_FREQ" timeframe="240">
@@ -869,7 +869,7 @@
     <same_field>win.eventdata.ipAddress</same_field>
     <description>Multiple Windows Logon Failures</description>
     <options>no_full_log</options>
-    <group>authentication_failures,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,nist_800_53_SC.7,</group>
+    <group>authentication_failures,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,nist_800_53_IA.10,</group>
   </rule>
 
   <rule id="60205" level="10" frequency="$MS_FREQ" timeframe="240">

--- a/rules/0595-win-sysmon_rules.xml
+++ b/rules/0595-win-sysmon_rules.xml
@@ -158,7 +158,7 @@
     <if_group>sysmon_event1</if_group>
     <field name="win.eventdata.image">svchost.exe</field>
     <description>Sysmon - Suspicious Process - svchost.exe</description>
-    <group>pci_dss_10.6.1,pci_dss_11.4,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.6,nist_800_53_SC.7,</group>
+    <group>pci_dss_10.6.1,pci_dss_11.4,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.6,nist_800_53_IA.10,</group>
   </rule>
 
   <rule id="61619" level="0">
@@ -171,7 +171,7 @@
     <if_group>sysmon_event1</if_group>
     <field name="win.eventdata.image">lsm.exe</field>
     <description>Sysmon - Suspicious Process - lsm.exe</description>
-    <group>pci_dss_10.6.1,pci_dss_11.4,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.6,nist_800_53_SC.7,</group>
+    <group>pci_dss_10.6.1,pci_dss_11.4,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.6,nist_800_53_IA.10,</group>
   </rule>
 
   <rule id="61621" level="0">
@@ -184,14 +184,14 @@
     <if_group>sysmon_event1</if_group>
     <field name="win.eventdata.parentImage">lsm.exe</field>
     <description>Sysmon - Suspicious Process - lsm.exe is a Parent Image</description>
-    <group>pci_dss_10.6.1,pci_dss_11.4,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.6,nist_800_53_SC.7,</group>
+    <group>pci_dss_10.6.1,pci_dss_11.4,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.6,nist_800_53_IA.10,</group>
   </rule>
 
   <rule id="61623" level="12">
     <if_group>sysmon_event1</if_group>
     <field name="win.eventdata.image">csrss.exe</field>
     <description>Sysmon - Suspicious Process - csrss.exe</description>
-    <group>pci_dss_10.6.1,pci_dss_11.4,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.6,nist_800_53_SC.7,</group>
+    <group>pci_dss_10.6.1,pci_dss_11.4,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.6,nist_800_53_IA.10,</group>
   </rule>
 
   <rule id="61624" level="0">
@@ -204,7 +204,7 @@
     <if_group>sysmon_event1</if_group>
     <field name="win.eventdata.image">lsass.exe</field>
     <description>Sysmon - Suspicious Process - lsass</description>
-    <group>pci_dss_10.6.1,pci_dss_11.4,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.6,nist_800_53_SC.7,</group>
+    <group>pci_dss_10.6.1,pci_dss_11.4,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.6,nist_800_53_IA.10,</group>
   </rule>
 
   <rule id="61626" level="0">
@@ -217,14 +217,14 @@
     <if_group>sysmon_event1</if_group>
     <field name="win.eventdata.parentImage">lsass.exe</field>
     <description>Sysmon - Suspicious Process - lsass.exe is a Parent Image</description>
-    <group>pci_dss_10.6.1,pci_dss_11.4,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.6,nist_800_53_SC.7,</group>
+    <group>pci_dss_10.6.1,pci_dss_11.4,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.6,nist_800_53_IA.10,</group>
   </rule>
 
   <rule id="61628" level="12">
     <if_group>sysmon_event1</if_group>
     <field name="win.eventdata.image">winlogon.exe</field>
     <description>Sysmon - Suspicious Process - winlogon.exe</description>
-    <group>pci_dss_10.6.1,pci_dss_11.4,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.6,nist_800_53_SC.7,</group>
+    <group>pci_dss_10.6.1,pci_dss_11.4,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.6,nist_800_53_IA.10,</group>
   </rule>
 
   <rule id="61629" level="0">
@@ -237,7 +237,7 @@
     <if_group>sysmon_event1</if_group>
     <field name="win.eventdata.image">wininit.exe</field>
     <description>Sysmon - Suspicious Process - wininit</description>
-    <group>pci_dss_10.6.1,pci_dss_11.4,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.6,nist_800_53_SC.7,</group>
+    <group>pci_dss_10.6.1,pci_dss_11.4,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.6,nist_800_53_IA.10,</group>
   </rule>
 
   <rule id="61631" level="0">
@@ -250,7 +250,7 @@
     <if_group>sysmon_event1</if_group>
     <field name="win.eventdata.image">smss.exe</field>
     <description>Sysmon - Suspicious Process - smss.exe</description>
-    <group>pci_dss_10.6.1,pci_dss_11.4,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.6,nist_800_53_SC.7,</group>
+    <group>pci_dss_10.6.1,pci_dss_11.4,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.6,nist_800_53_IA.10,</group>
   </rule>
 
   <rule id="61633" level="0">
@@ -263,7 +263,7 @@
     <if_group>sysmon_event1</if_group>
     <field name="win.eventdata.image">taskhost.exe</field>
     <description>Sysmon - Suspicious Process - taskhost.exe</description>
-    <group>pci_dss_10.6.1,pci_dss_11.4,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.6,nist_800_53_SC.7,</group>
+    <group>pci_dss_10.6.1,pci_dss_11.4,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.6,nist_800_53_IA.10,</group>
   </rule>
 
   <rule id="61635" level="0">
@@ -276,7 +276,7 @@
     <if_group>sysmon_event1</if_group>
     <field name="win.eventdata.image">/services.exe</field>
     <description>Sysmon - Suspicious Process - services.exe</description>
-    <group>pci_dss_10.6.1,pci_dss_11.4,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.6,nist_800_53_SC.7,</group>
+    <group>pci_dss_10.6.1,pci_dss_11.4,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.6,nist_800_53_IA.10,</group>
   </rule>
 
   <rule id="61637" level="0">
@@ -289,7 +289,7 @@
     <if_group>sysmon_event1</if_group>
     <field name="win.eventdata.image">dllhost.exe</field>
     <description>Sysmon - Suspicious Process - dllhost.exe</description>
-    <group>pci_dss_10.6.1,pci_dss_11.4,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.6,nist_800_53_SC.7,</group>
+    <group>pci_dss_10.6.1,pci_dss_11.4,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.6,nist_800_53_IA.10,</group>
   </rule>
 
   <rule id="61639" level="0">
@@ -302,7 +302,7 @@
     <if_group>sysmon_event1</if_group>
     <field name="win.eventdata.image">\\explorer.exe</field>
     <description>Sysmon - Suspicious Process - explorer.exe</description>
-    <group>pci_dss_10.6.1,pci_dss_11.4,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.6,nist_800_53_SC.7,</group>
+    <group>pci_dss_10.6.1,pci_dss_11.4,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.6,nist_800_53_IA.10,</group>
   </rule>
 
   <rule id="61641" level="0">

--- a/rules/0605-win-mcafee_rules.xml
+++ b/rules/0605-win-mcafee_rules.xml
@@ -63,21 +63,21 @@
   <rule id="62606" level="12">
     <if_sid>62600,62601,62602</if_sid>
     <field name="win.system.message">$MCAFEE_VIRUS</field>
-    <group>virus,pci_dss_5.1,pci_dss_5.2,pci_dss_10.6.1,pci_dss_11.4,gpg13_4.2,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_SI.5,nist_800_53_AU.6,nist_800_53_SC.7,</group>
+    <group>virus,pci_dss_5.1,pci_dss_5.2,pci_dss_10.6.1,pci_dss_11.4,gpg13_4.2,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_SI.3,nist_800_53_AU.6,nist_800_53_IA.10,</group>
     <description>McAfee Windows AV - Virus detected and not removed</description>
   </rule>
 
   <rule id="62607" level="7">
     <if_sid>62606</if_sid>
     <field name="win.system.message">$MCAFEE_VIRUS_OK</field>
-    <group>virus,pci_dss_5.1,pci_dss_5.2,pci_dss_10.6.1,pci_dss_11.4,gpg13_4.2,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_SI.5,nist_800_53_AU.6,nist_800_53_SC.7,</group>
+    <group>virus,pci_dss_5.1,pci_dss_5.2,pci_dss_10.6.1,pci_dss_11.4,gpg13_4.2,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_SI.3,nist_800_53_AU.6,nist_800_53_IA.10,</group>
     <description>McAfee Windows AV - Virus detected and properly removed</description>
   </rule>
 
   <rule id="62608" level="7">
     <if_sid>62606</if_sid>
     <field name="win.system.message">Will be deleted</field>
-    <group>virus,pci_dss_5.1,pci_dss_5.2,pci_dss_10.6.1,pci_dss_11.4,gpg13_4.2,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_SI.5,nist_800_53_AU.6,nist_800_53_SC.7,</group>
+    <group>virus,pci_dss_5.1,pci_dss_5.2,pci_dss_10.6.1,pci_dss_11.4,gpg13_4.2,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_SI.3,nist_800_53_AU.6,nist_800_53_IA.10,</group>
     <description>McAfee Windows AV - Virus detected and file will be deleted</description>
   </rule>
 
@@ -85,7 +85,7 @@
     <if_sid>62600,62601,62602</if_sid>
     <field name="win.system.message">scan started|scan stopped</field>
     <description>McAfee Windows AV - Scan started or stopped</description>
-    <group>pci_dss_5.1,pci_dss_10.2.6,pci_dss_10.6.1,gpg13_4.14,gpg13_10.1,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_SI.5,nist_800_53_AU.3.1,nist_800_53_IA.10,nist_800_53_AU.6,</group>
+    <group>pci_dss_5.1,pci_dss_10.2.6,pci_dss_10.6.1,gpg13_4.14,gpg13_10.1,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_SI.3,nist_800_53_IA.10,nist_800_53_AU.5,nist_800_53_AU.6,</group>
   </rule>
 
   <rule id="62610" level="3">
@@ -93,42 +93,42 @@
     <field name="win.system.eventID">^257$</field>
     <field name="win.system.message">completed. No detections</field>
     <description>McAfee Windows AV - Scan completed with no viruses found</description>
-    <group>pci_dss_5.1,pci_dss_10.2.6,pci_dss_10.6.1,gpg13_4.14,gpg13_10.1,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_SI.5,nist_800_53_AU.3.1,nist_800_53_IA.10,nist_800_53_AU.6,</group>
+    <group>pci_dss_5.1,pci_dss_10.2.6,pci_dss_10.6.1,gpg13_4.14,gpg13_10.1,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_SI.3,nist_800_53_IA.10,nist_800_53_AU.5,nist_800_53_AU.6,</group>
   </rule>
 
   <rule id="62611" level="5">
     <if_sid>62600,62601,62602</if_sid>
     <field name="win.system.message">scan was cancelled |has taken too long</field>
     <description>McAfee Windows AV - Virus scan cancelled</description>
-    <group>pci_dss_5.1,pci_dss_10.2.6,pci_dss_10.6.1,gpg13_4.14,gpg13_10.1,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_SI.5,nist_800_53_AU.3.1,nist_800_53_IA.10,nist_800_53_AU.6,</group>
+    <group>pci_dss_5.1,pci_dss_10.2.6,pci_dss_10.6.1,gpg13_4.14,gpg13_10.1,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_SI.3,nist_800_53_IA.10,nist_800_53_AU.5,nist_800_53_AU.6,</group>
   </rule>
 
   <rule id="62612" level="5">
     <if_sid>62600,62601,62602</if_sid>
     <field name="win.system.message">scan was canceled because</field>
     <description>McAfee Windows AV - Virus scan cancelled due to shutdown</description>
-    <group>pci_dss_5.1,pci_dss_10.2.6,pci_dss_10.6.1,gpg13_4.14,gpg13_10.1,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_SI.5,nist_800_53_AU.3.1,nist_800_53_IA.10,nist_800_53_AU.6,</group>
+    <group>pci_dss_5.1,pci_dss_10.2.6,pci_dss_10.6.1,gpg13_4.14,gpg13_10.1,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_SI.3,nist_800_53_IA.10,nist_800_53_AU.5,nist_800_53_AU.6,</group>
   </rule>
 
   <rule id="62613" level="3">
     <if_sid>62600,62601,62602</if_sid>
     <field name="win.system.message">update was successful</field>
     <description>McAfee Windows AV - Virus program or DAT update succeeded</description>
-    <group>pci_dss_5.1,pci_dss_10.6.1,pci_dss_5.2,gpg13_4.4,gpg13_4.14,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_SI.5,nist_800_53_AU.6,</group>
+    <group>pci_dss_5.1,pci_dss_10.6.1,pci_dss_5.2,gpg13_4.4,gpg13_4.14,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_SI.3,nist_800_53_AU.6,</group>
   </rule>
 
   <rule id="62614" level="7">
     <if_sid>62600,62601,62602</if_sid>
     <field name="win.system.message">update failed</field>
     <description>McAfee Windows AV - Virus program or DAT update failed</description>
-    <group>pci_dss_5.1,pci_dss_10.6.1,pci_dss_5.2,gpg13_4.14,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_SI.5,nist_800_53_AU.6,</group>
+    <group>pci_dss_5.1,pci_dss_10.6.1,pci_dss_5.2,gpg13_4.14,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_SI.3,nist_800_53_AU.6,</group>
   </rule>
 
   <rule id="62615" level="7">
     <if_sid>62600,62601,62602</if_sid>
     <field name="win.system.message">update was cancelled</field>
     <description>McAfee Windows AV - Virus program or DAT update cancelled</description>
-    <group>pci_dss_5.1,pci_dss_10.6.1,pci_dss_5.2,gpg13_4.14,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_SI.5,nist_800_53_AU.6,</group>
+    <group>pci_dss_5.1,pci_dss_10.6.1,pci_dss_5.2,gpg13_4.14,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_SI.3,nist_800_53_AU.6,</group>
   </rule>
 
   <rule id="62616" level="5">
@@ -143,13 +143,13 @@
   <rule id="62617" level="10" frequency="$MCAFEE_FREQ" timeframe="240">
     <if_matched_sid>62604</if_matched_sid>
     <description>Multiple McAfee AV warning events</description>
-    <group>pci_dss_5.1,pci_dss_10.6.1,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_SI.5,nist_800_53_AU.6,</group>
+    <group>pci_dss_5.1,pci_dss_10.6.1,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_SI.3,nist_800_53_AU.6,</group>
   </rule>
 
   <rule id="62618" level="10" frequency="$MCAFEE_FREQ" timeframe="240">
     <if_matched_sid>62605</if_matched_sid>
     <description>Multiple McAfee AV error events</description>
-    <group>pci_dss_5.1,pci_dss_10.6.1,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_SI.5,nist_800_53_AU.6,</group>
+    <group>pci_dss_5.1,pci_dss_10.6.1,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_SI.3,nist_800_53_AU.6,</group>
   </rule>
 
 </group>

--- a/rules/0615-win-ms-se_rules.xml
+++ b/rules/0615-win-ms-se_rules.xml
@@ -38,7 +38,7 @@
   <rule id="63603" level="12">
     <if_sid>63600,63601,63602</if_sid>
     <field name="win.system.eventID">^1118$|^1119$</field>
-    <group>virus,pci_dss_5.1,pci_dss_5.2,pci_dss_10.6.1,pci_dss_11.4,gpg13_4.2,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_SI.5,nist_800_53_AU.6,nist_800_53_SC.7,</group>
+    <group>virus,pci_dss_5.1,pci_dss_5.2,pci_dss_10.6.1,pci_dss_11.4,gpg13_4.2,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_SI.3,nist_800_53_AU.6,nist_800_53_IA.10,</group>
     <description>Microsoft Security Essentials - Virus detected, but unable to remove</description>
     <options>no_full_log</options>
   </rule>
@@ -46,7 +46,7 @@
   <rule id="63604" level="7">
     <if_sid>63600,63601,63602</if_sid>
     <field name="win.system.eventID">^1107$</field>
-    <group>virus,pci_dss_5.1,pci_dss_5.2,pci_dss_10.6.1,pci_dss_11.4,gpg13_4.2,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_SI.5,nist_800_53_AU.6,nist_800_53_SC.7,</group>
+    <group>virus,pci_dss_5.1,pci_dss_5.2,pci_dss_10.6.1,pci_dss_11.4,gpg13_4.2,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_SI.3,nist_800_53_AU.6,nist_800_53_IA.10,</group>
     <description>Microsoft Security Essentials - Virus detected and properly removed</description>
     <options>no_full_log</options>
   </rule>
@@ -54,7 +54,7 @@
   <rule id="63605" level="7">
     <if_sid>63601</if_sid>
     <field name="win.system.eventID">^1119$|^1118$|^1117$|^1116$</field>
-    <group>virus,pci_dss_5.1,pci_dss_5.2,pci_dss_10.6.1,pci_dss_11.4,gpg13_4.2,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_SI.5,nist_800_53_AU.6,nist_800_53_SC.7,</group>
+    <group>virus,pci_dss_5.1,pci_dss_5.2,pci_dss_10.6.1,pci_dss_11.4,gpg13_4.2,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_SI.3,nist_800_53_AU.6,nist_800_53_IA.10,</group>
     <description>Microsoft Security Essentials - Virus detected</description>
     <options>no_full_log</options>
   </rule>
@@ -62,7 +62,7 @@
    <rule id="63606" level="7">
     <if_sid>63600,63601,63602</if_sid>
     <field name="win.system.eventID">^1015$</field>
-    <group>virus,pci_dss_5.1,pci_dss_5.2,pci_dss_10.6.1,pci_dss_11.4,gpg13_4.2,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_SI.5,nist_800_53_AU.6,nist_800_53_SC.7,</group>
+    <group>virus,pci_dss_5.1,pci_dss_5.2,pci_dss_10.6.1,pci_dss_11.4,gpg13_4.2,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_SI.3,nist_800_53_AU.6,nist_800_53_IA.10,</group>
     <description>Microsoft Security Essentials - Suspicious activity detected</description>
     <options>no_full_log</options>
   </rule>
@@ -72,7 +72,7 @@
     <field name="win.system.eventID">^5007$</field>
     <description>Microsoft Security Essentials - Configuration changed</description>
     <options>no_full_log</options>
-    <group>policy_changed,pci_dss_10.2.7,pci_dss_10.6.1,gpg13_4.4,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,nist_800_53_AU.6,</group>
+    <group>policy_changed,pci_dss_10.2.7,pci_dss_10.6.1,gpg13_4.4,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AU.6,</group>
   </rule>
 
   <rule id="63608" level="9">

--- a/rules/0620-win-generic_rules.xml
+++ b/rules/0620-win-generic_rules.xml
@@ -84,14 +84,14 @@
     <if_matched_sid>64101</if_matched_sid>
     <description>Multiple remote access login failures</description>
     <options>no_full_log</options>
-    <group>authentication_failures,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,pci_dss_8.1.5,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,hipaa_164.312.a.1,nist_800_53_IA.10,nist_800_53_AC.7,nist_800_53_IA.10,nist_800_53_AC.2,</group>
+    <group>authentication_failures,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,pci_dss_8.1.5,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,hipaa_164.312.a.1,nist_800_53_IA.10,nist_800_53_AC.7,nist_800_53_AC.2,</group>
   </rule>
 
   <rule id="64110" level="10" frequency="$MS_FREQ" timeframe="240">
     <if_matched_sid>64107</if_matched_sid>
     <description>Multiple TS Gateway login failures</description>
     <options>no_full_log</options>
-    <group>authentication_failures,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,nist_800_53_IA.10,</group>
+    <group>authentication_failures,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,</group>
   </rule>
 
 </group>

--- a/rules/0620-win-generic_rules.xml
+++ b/rules/0620-win-generic_rules.xml
@@ -24,7 +24,7 @@
     <field name="win.system.eventID">^20187$|^20014$|^20078$|^20050$|^20049$|^20189$</field>
     <description>Remote access login failure</description>
     <options>no_full_log</options>
-    <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_8.1.5,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,hipaa_164.312.a.1,nist_800_53_AU.3.1,nist_800_53_IA.10,nist_800_53_AC.2,</group>
+    <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_8.1.5,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,hipaa_164.312.a.1,nist_800_53_IA.10,nist_800_53_AC.7,nist_800_53_AC.2,</group>
   </rule>
 
   <rule id="64102" level="3">
@@ -32,7 +32,7 @@
     <field name="win.system.eventID">^20158$</field>
     <description>Remote access login success</description>
     <options>no_full_log</options>
-    <group>authentication_success,pci_dss_10.2.5,pci_dss_8.1.5,gpg13_7.1,gpg13_7.2,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,hipaa_164.312.a.1,nist_800_53_AU.3.1,nist_800_53_IA.10,nist_800_53_AC.2,</group>
+    <group>authentication_success,pci_dss_10.2.5,pci_dss_8.1.5,gpg13_7.1,gpg13_7.2,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,hipaa_164.312.a.1,nist_800_53_IA.10,nist_800_53_AC.7,nist_800_53_AC.2,</group>
   </rule>
 
   <rule id="64103" level="8">
@@ -55,7 +55,7 @@
     <field name="win.system.eventID">^200$|^300$|^302$</field>
     <description>TS Gateway login success</description>
     <options>no_full_log</options>
-    <group>authentication_success,pci_dss_10.2.5,gpg13_7.1,gpg13_7.2,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>authentication_success,pci_dss_10.2.5,gpg13_7.1,gpg13_7.2,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,</group>
   </rule>
 
   <rule id="64106" level="0">
@@ -70,7 +70,7 @@
     <field name="win.system.eventID">^201$|^203$|^204$|^301$|^304$|^305$|^306$|^1001$</field>
     <description>TS Gateway login failure</description>
     <options>no_full_log</options>
-    <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,</group>
+    <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,</group>
   </rule>
 
   <rule id="64108" level="3">
@@ -84,14 +84,14 @@
     <if_matched_sid>64101</if_matched_sid>
     <description>Multiple remote access login failures</description>
     <options>no_full_log</options>
-    <group>authentication_failures,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,pci_dss_8.1.5,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,hipaa_164.312.a.1,nist_800_53_AU.3.1,nist_800_53_IA.10,nist_800_53_SC.7,nist_800_53_AC.2,</group>
+    <group>authentication_failures,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,pci_dss_8.1.5,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,hipaa_164.312.a.1,nist_800_53_IA.10,nist_800_53_AC.7,nist_800_53_IA.10,nist_800_53_AC.2,</group>
   </rule>
 
   <rule id="64110" level="10" frequency="$MS_FREQ" timeframe="240">
     <if_matched_sid>64107</if_matched_sid>
     <description>Multiple TS Gateway login failures</description>
     <options>no_full_log</options>
-    <group>authentication_failures,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.3.1,nist_800_53_IA.10,nist_800_53_SC.7,</group>
+    <group>authentication_failures,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_IA.10,nist_800_53_AC.7,nist_800_53_IA.10,</group>
   </rule>
 
 </group>

--- a/tools/map-security-standard/map_standard.py
+++ b/tools/map-security-standard/map_standard.py
@@ -64,10 +64,11 @@ def standard_to_any(path, schema):
                 for group in match.groups():
                     for current_standard in group.split(','):
                         if current_standard in list(json_data.keys()):
-                            if json_data[current_standard] not in group.split(','):
-                                if json_data[current_standard] not in added:
-                                    added.append(json_data[current_standard])
-                                    added.append(',')
+                            for split_current_standard in json_data[current_standard].split(','):
+                                if split_current_standard not in group.split(','):
+                                    if split_current_standard not in added:
+                                        added.append(split_current_standard)
+                                        added.append(',')
                 if len(added) > 1:
                     new_line = line.split(',')
                     new_line.insert(-1, "".join(added[0:-1]))

--- a/tools/map-security-standard/map_standard.py
+++ b/tools/map-security-standard/map_standard.py
@@ -28,7 +28,7 @@ def delete_standard(path, standard):
                 for group in match.groups():
                     groups = group.split(',')
                     for current_standard in groups:
-                        if current_standard != standard:
+                        if not current_standard.startswith(standard):
                             new_line += current_standard + ','
                         else:
                             changed = True
@@ -38,10 +38,12 @@ def delete_standard(path, standard):
                 new_line = ''
             else:
                 new_file += line
-        if changed:
-            print('[DELETE] Deleted {} in file {}'.format(standard, file))
+
         with open(file, 'w') as f:
             f.write(new_file)
+
+        if changed:
+            print('[DELETE] Deleted {} in file {}'.format(standard, file))
 
 
 def standard_to_any(path, schema):


### PR DESCRIPTION
This PR closes #394.

The script tool to update the ruleset has been modified to delete a standard, so the process to update the ruleset has been:
  - Delete all `nist_800_53` groups from rules
  - Apply again the new mapping specified in https://github.com/wazuh/wazuh-ruleset/issues/394#issuecomment-498318881