### PR TITLE
Fix check 11522 of Solaris SCA policy

### DIFF
--- a/sca/sunos/cis_solaris11_rcl.yml
+++ b/sca/sunos/cis_solaris11_rcl.yml
@@ -316,7 +316,6 @@ checks:
     - cis: "6.2"
    condition: any
    rules:
-     - 'f!:/etc/default/keyserv;'
      - 'f:/etc/default/keyserv -> !r:^ENABLE\.NOBODY\.KEYS\pNO;'
      - 'f:/etc/default/keyserv -> IN !r:^# && r:ENABLE\.NOBODY\.KEYS\pYES;'
  - id: 11523


### PR DESCRIPTION
There was a typo in the first rule of the check 11522. It causes the following error:

```
2019/06/03 09:05:06 sca: ERROR: (1252): Invalid rule: 'f!:/etc/default/keyserv;'.
```

That rule particularly is not necessary since the missing of the configuration file should lead to a `Not applicable` state.

Regards.