### PR TITLE
Added "no_full_log" for rules using JSON decoder

### DIFF
--- a/rules/0350-amazon_rules.xml
+++ b/rules/0350-amazon_rules.xml
@@ -17,6 +17,7 @@ ID: 80200 - 80499
         <decoded_as>json</decoded_as>
         <field name="integration">aws</field>
         <description>AWS alert.</description>
+        <options>no_full_log</options>
     </rule>
 
 
@@ -29,6 +30,7 @@ ID: 80200 - 80499
         <list field="aws.eventName" lookup="match_key">etc/lists/amazon/aws-eventnames</list>
         <description>AWS Cloudtrail: $(aws.eventSource) - $(aws.eventName).</description>
         <group>aws_cloudtrail,pci_dss_10.6.1,gdpr_IV_35.7.d,</group>
+        <options>no_full_log</options>
     </rule>
 
     <!-- If there is an error code: increase the level and change description -->
@@ -37,6 +39,7 @@ ID: 80200 - 80499
         <field name="aws.errorCode">\.+</field>
         <description>AWS Cloudtrail: $(aws.eventSource) - $(aws.eventName). Error: $(aws.errorCode).</description>
         <group>aws_cloudtrail,pci_dss_10.6.1,amazon-error,gdpr_IV_35.7.d,</group>
+        <options>no_full_log</options>
     </rule>
 
     <!-- Specific rules -->
@@ -47,6 +50,7 @@ ID: 80200 - 80499
         <field name="aws.errorCode">AccessDenied</field>
         <description>AWS Cloudtrail: $(aws.eventSource) - $(aws.eventName). Error: $(aws.errorCode).</description>
         <group>aws_cloudtrail,pci_dss_10.6.1,pci_dss_10.2.4,pci_dss_10.2.5,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
+        <options>no_full_log</options>
     </rule>
 
     <!-- Events with no errors -->
@@ -55,12 +59,14 @@ ID: 80200 - 80499
         <field name="aws.eventName">DeleteObjects</field>
         <description>AWS Cloudtrail: $(aws.eventSource) - $(aws.eventName).</description>
         <group>aws_cloudtrail,pci_dss_10.6.1,gdpr_IV_35.7.d,</group>
+        <options>no_full_log</options>
     </rule>
 
     <rule id="80252" level="10" frequency="22" timeframe="600">
         <if_matched_sid>80251</if_matched_sid>
         <description>AWS Cloudtrail: $(aws.eventSource) - $(aws.eventName) - high number of deleted object.</description>
         <group>aws_cloudtrail,pci_dss_10.6.1,gdpr_IV_35.7.d,</group>
+        <options>no_full_log</options>
     </rule>
 
     <!-- Logins -->
@@ -69,6 +75,7 @@ ID: 80200 - 80499
         <field name="aws.eventName">ConsoleLogin</field>
         <description>AWS Cloudtrail: $(aws.eventSource) - $(aws.eventName) - User Login Success.</description>
         <group>aws_cloudtrail,authentication_success,pci_dss_10.2.5,gdpr_IV_32.2,</group>
+        <options>no_full_log</options>
     </rule>
 
     <rule id="80254" level="5">
@@ -76,12 +83,14 @@ ID: 80200 - 80499
         <field name="aws.responseElements.ConsoleLogin">Failure</field>
         <description>AWS Cloudtrail: $(aws.eventSource) - $(aws.eventName) - User Login failed.</description>
         <group>aws_cloudtrail,authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
+        <options>no_full_log</options>
     </rule>
 
     <rule id="80255" level="10" frequency="6" timeframe="360">
         <if_matched_sid>80254</if_matched_sid>
         <description>AWS Cloudtrail: $(aws.eventSource) - $(aws.eventName) - Possible breaking attempt (high number of login attempts).</description>
         <group>aws_cloudtrail,authentication_failures,pci_dss_11.4,pci_dss_10.2.4,pci_dss_10.2.5,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
+        <options>no_full_log</options>
     </rule>
 
 
@@ -92,6 +101,7 @@ ID: 80200 - 80499
         <field name="aws.source">guardduty</field>
         <description>AWS Guard​Duty alert.</description>
         <group>aws_guardduty,</group>
+        <options>no_full_log</options>
     </rule>
 
     <!-- Guard Duty severity levels: https://docs.aws.amazon.com/guardduty/latest/ug/guardduty_findings.html#guardduty_findings-severity -->
@@ -100,18 +110,21 @@ ID: 80200 - 80499
         <field name="aws.severity">0|1|2|3</field>
         <description>AWS Guard​Duty: $(aws.service.action.actionType) - $(aws.title)</description>
         <group>aws_guardduty,</group>
+        <options>no_full_log</options>
     </rule>
     <rule id="80302" level="6">
         <if_sid>80300</if_sid>
         <field name="aws.severity">4|5|6</field>
         <description>AWS Guard​Duty: $(aws.service.action.actionType) - $(aws.title)</description>
         <group>aws_guardduty,</group>
+        <options>no_full_log</options>
     </rule>
     <rule id="80303" level="10">
         <if_sid>80300</if_sid>
         <field name="aws.severity">7|8|9</field>
         <description>AWS Guard​Duty: $(aws.service.action.actionType) - $(aws.title)</description>
         <group>aws_guardduty,</group>
+        <options>no_full_log</options>
     </rule>
 
     <!-- PORT_PROBE rules -->
@@ -120,6 +133,7 @@ ID: 80200 - 80499
         <field name="aws.service.action.actionType">PORT_PROBE</field>
         <description>AWS Guard​Duty: $(aws.service.action.actionType) - $(aws.title) [IP: $(aws.service.action.portProbeAction.portProbeDetails.remoteIpDetails.ipAddressV4)] [Port: $(aws.service.action.portProbeAction.portProbeDetails.localPortDetails.port)]</description>
         <group>aws_guardduty,</group>
+        <options>no_full_log</options>
     </rule>
 
     <rule id="80306" level="6">
@@ -127,6 +141,7 @@ ID: 80200 - 80499
         <field name="aws.service.action.actionType">PORT_PROBE</field>
         <description>AWS Guard​Duty: $(aws.service.action.actionType) - $(aws.title) [IP: $(aws.service.action.portProbeAction.portProbeDetails.remoteIpDetails.ipAddressV4)] [Port: $(aws.service.action.portProbeAction.portProbeDetails.localPortDetails.port)]</description>
         <group>aws_guardduty,</group>
+        <options>no_full_log</options>
     </rule>
 
     <rule id="80307" level="10">
@@ -134,6 +149,7 @@ ID: 80200 - 80499
         <field name="aws.service.action.actionType">PORT_PROBE</field>
         <description>AWS Guard​Duty: $(aws.service.action.actionType) - $(aws.title) [IP: $(aws.service.action.portProbeAction.portProbeDetails.remoteIpDetails.ipAddressV4)] [Port: $(aws.service.action.portProbeAction.portProbeDetails.localPortDetails.port)]</description>
         <group>aws_guardduty,</group>
+        <options>no_full_log</options>
     </rule>
 
 
@@ -144,6 +160,7 @@ ID: 80200 - 80499
         <field name="aws.source">macie</field>
         <description>AWS Macie alert.</description>
         <group>aws_macie,</group>
+        <options>no_full_log</options>
     </rule>
 
     <rule id="80351" level="3">
@@ -151,6 +168,7 @@ ID: 80200 - 80499
         <field name="aws.severity">INFO</field>
         <description>AWS Macie $(aws.severity): $(aws.name) - $(aws.summary.description)</description>
         <group>aws_macie,</group>
+        <options>no_full_log</options>
     </rule>
 
     <rule id="80352" level="4">
@@ -158,6 +176,7 @@ ID: 80200 - 80499
         <field name="aws.severity">LOW</field>
         <description>AWS Macie $(aws.severity): $(aws.name) - $(aws.summary.description)</description>
         <group>aws_macie,</group>
+        <options>no_full_log</options>
     </rule>
 
     <rule id="80353" level="6">
@@ -165,6 +184,7 @@ ID: 80200 - 80499
         <field name="aws.severity">MEDIUM</field>
         <description>AWS Macie $(aws.severity): $(aws.name) - $(aws.summary.description)</description>
         <group>aws_macie,</group>
+        <options>no_full_log</options>
     </rule>
 
     <rule id="80354" level="8">
@@ -172,6 +192,7 @@ ID: 80200 - 80499
         <field name="aws.severity">HIGH</field>
         <description>AWS Macie $(aws.severity): $(aws.name) - $(aws.summary.description)</description>
         <group>aws_macie,</group>
+        <options>no_full_log</options>
     </rule>
 
     <rule id="80355" level="12">
@@ -179,6 +200,7 @@ ID: 80200 - 80499
         <field name="aws.severity">CRITICAL</field>
         <description>AWS Macie $(aws.severity): $(aws.name) - $(aws.summary.description)</description>
         <group>aws_macie,</group>
+        <options>no_full_log</options>
     </rule>
 
 
@@ -189,6 +211,7 @@ ID: 80200 - 80499
         <field name="aws.source">vpc</field>
         <description>AWS VPC Flow alert.</description>
         <group>aws_vpcflow,</group>
+        <options>no_full_log</options>
     </rule>
 
     <rule id="80401" level="3">
@@ -196,6 +219,7 @@ ID: 80200 - 80499
         <field name="aws.action">ACCEPT</field>
         <description>AWS VPC Flow: [$(aws.action)] - Interface: $(aws.interface_id) - Protocol: $(aws.protocol)</description>
         <group>aws_vpcflow,</group>
+        <options>no_full_log</options>
     </rule>
 
     <rule id="80402" level="4">
@@ -203,6 +227,7 @@ ID: 80200 - 80499
         <field name="aws.action">REJECT</field>
         <description>AWS VPC Flow: [$(aws.action)] - Interface: $(aws.interface_id) - Protocol: $(aws.protocol)</description>
         <group>aws_vpcflow,</group>
+        <options>no_full_log</options>
     </rule>
 
 
@@ -213,6 +238,7 @@ ID: 80200 - 80499
         <field name="aws.source">config</field>
         <description>AWS Config alert.</description>
         <group>aws_config,</group>
+        <options>no_full_log</options>
     </rule>
 
     <!-- ConfigHistory vs ConfigSnapshot -->
@@ -221,6 +247,7 @@ ID: 80200 - 80499
         <field name="aws.log_info.log_file">\.+ConfigHistory</field>
         <description>AWS Config - History</description>
         <group>aws_config,aws_config_history,</group>
+        <options>no_full_log</options>
     </rule>
 
     <rule id="80452" level="0">
@@ -228,6 +255,7 @@ ID: 80200 - 80499
         <field name="aws.log_info.log_file">\.+ConfigSnapshot</field>
         <description>AWS Config - Snapshot</description>
         <group>aws_config,aws_config_snapshot,</group>
+        <options>no_full_log</options>
     </rule>
 
     <!-- Config history -->
@@ -235,6 +263,7 @@ ID: 80200 - 80499
         <if_sid>80451</if_sid>
         <description>AWS Config - History [$(aws.awsAccountId) $(aws.awsRegion)] [$(aws.resourceType)]: $(aws.resourceId) ($(aws.configurationItemStatus))</description>
         <group>aws_config,aws_config_history,</group>
+        <options>no_full_log</options>
     </rule>
 
     <!-- Config Snapshot -->
@@ -242,6 +271,7 @@ ID: 80200 - 80499
         <if_sid>80452</if_sid>
         <description>AWS Config - Snapshot [$(aws.awsAccountId) $(aws.awsRegion)] [$(aws.resourceType)]: $(aws.resourceId) ($(aws.configurationItemStatus))</description>
         <group>aws_config,aws_config_snapshot,</group>
+        <options>no_full_log</options>
     </rule>
 
     <rule id="80476" level="6">
@@ -249,6 +279,7 @@ ID: 80200 - 80499
         <field name="aws.configuration.complianceType">\.+</field>
         <description>AWS Config - Snapshot Compliance [$(aws.awsAccountId) $(aws.awsRegion)] [$(aws.resourceType)] [$(aws.configuration.configRuleList.configRuleName)]: $(aws.resourceId) ($(aws.configurationItemStatus)) $(aws.configuration.complianceType)</description>
         <group>aws_config,aws_config_snapshot,aws_config_snapshot_compliance,</group>
+        <options>no_full_log</options>
     </rule>
 
 
@@ -259,6 +290,7 @@ ID: 80200 - 80499
         <field name="aws.source">trustedadvisor</field>
         <description>AWS Trusted Advisor alert.</description>
         <group>aws_trusted_advisor,</group>
+        <options>no_full_log</options>
     </rule>
 
     <rule id="80481" level="5">
@@ -266,6 +298,7 @@ ID: 80200 - 80499
         <field name="aws.status">ERROR</field>
         <description>AWS Trusted Advisor - [$(aws.uuid)] [$(aws.check-name)]: $(aws.status)</description>
         <group>aws_trusted_advisor,</group>
+        <options>no_full_log</options>
     </rule>
 
     <rule id="80482" level="4">
@@ -273,6 +306,7 @@ ID: 80200 - 80499
         <field name="aws.status">WARN</field>
         <description>AWS Trusted Advisor - [$(aws.uuid)] [$(aws.check-name)]: $(aws.status)</description>
         <group>aws_trusted_advisor,</group>
+        <options>no_full_log</options>
     </rule>
 
     <rule id="80483" level="3">
@@ -280,6 +314,7 @@ ID: 80200 - 80499
         <field name="aws.status">OK</field>
         <description>AWS Trusted Advisor - [$(aws.uuid)] [$(aws.check-name)]: $(aws.status)</description>
         <group>aws_trusted_advisor,</group>
+        <options>no_full_log</options>
     </rule>
 
 
@@ -290,12 +325,14 @@ ID: 80200 - 80499
         <field name="aws.source">kms</field>
         <description>AWS KMS alert.</description>
         <group>aws_kms,</group>
+        <options>no_full_log</options>
     </rule>
 
     <rule id="80491" level="3">
         <if_sid>80490</if_sid>
         <description>AWS KMS: [$(aws.eventName)] $(aws.userIdentity.type)</description>
         <group>aws_kms,</group>
+        <options>no_full_log</options>
     </rule>
 
     <rule id="80492" level="3">
@@ -303,6 +340,7 @@ ID: 80200 - 80499
         <field name="aws.userIdentity.userName">\.+</field>
         <description>AWS KMS: [$(aws.eventName)] $(aws.userIdentity.type) - $(aws.userIdentity.userName) - $(aws.sourceIPAddress)</description>
         <group>aws_kms,</group>
+        <options>no_full_log</options>
     </rule>
 
     <rule id="80493" level="0">
@@ -310,6 +348,7 @@ ID: 80200 - 80499
         <field name="aws.userIdentity.invokedBy">AWS Internal</field>
         <description>AWS KMS: [$(aws.eventName)] $(aws.userIdentity.type)</description>
         <group>aws_kms,</group>
+        <options>no_full_log</options>
     </rule>
 
     <rule id="80494" level="0">
@@ -317,6 +356,7 @@ ID: 80200 - 80499
         <field name="aws.userIdentity.invokedBy">AWS Internal</field>
         <description>AWS KMS: [$(aws.eventName)] $(aws.userIdentity.type) - $(aws.userIdentity.userName) - $(aws.sourceIPAddress)</description>
         <group>aws_kms,</group>
+        <options>no_full_log</options>
     </rule>
 
 
@@ -328,6 +368,7 @@ ID: 80200 - 80499
         <field name="aws.source">inspector</field>
         <description>AWS Inspector - Network assessment [$(aws.createdAt)]: $(aws.title) [$(aws.severity)]</description>
         <group>aws_inspector,</group>
+        <options>no_full_log</options>
     </rule>
 
     <rule id="80496" level="10">
@@ -335,6 +376,7 @@ ID: 80200 - 80499
         <field name="aws.severity">High</field>
         <description>AWS Inspector - Network assessment [$(aws.createdAt)]: $(aws.title) [$(aws.severity)]</description>
         <group>aws_inspector,</group>
+        <options>no_full_log</options>
     </rule>
 
     <rule id="80497" level="7">
@@ -342,6 +384,7 @@ ID: 80200 - 80499
         <field name="aws.severity">Medium</field>
         <description>AWS Inspector - Network assessment [$(aws.createdAt)]: $(aws.title) [$(aws.severity)]</description>
         <group>aws_inspector,</group>
+        <options>no_full_log</options>
     </rule>
 
     <rule id="80498" level="4">
@@ -349,6 +392,7 @@ ID: 80200 - 80499
         <field name="aws.severity">Low</field>
         <description>AWS Inspector - Network assessment [$(aws.createdAt)]: $(aws.title) [$(aws.severity)]</description>
         <group>aws_inspector,</group>
+        <options>no_full_log</options>
     </rule>
 
     <rule id="80499" level="3">
@@ -356,6 +400,7 @@ ID: 80200 - 80499
         <field name="aws.severity">Informational</field>
         <description>AWS Inspector - Network assessment [$(aws.createdAt)]: $(aws.title) [$(aws.severity)]</description>
         <group>aws_inspector,</group>
+        <options>no_full_log</options>
     </rule>
 
 

--- a/rules/0475-suricata_rules.xml
+++ b/rules/0475-suricata_rules.xml
@@ -17,30 +17,35 @@
         <field name="timestamp">\.+</field>
         <field name="event_type">\.+</field>
         <description>Suricata messages.</description>
+        <options>no_full_log</options>
     </rule>
 
     <rule id="86601" level="3">
         <if_sid>86600</if_sid>
         <field name="event_type">^alert$</field>
         <description>Suricata: Alert - $(alert.signature)</description>
+        <options>no_full_log</options>
     </rule>
 
     <rule id="86602" level="0">
         <if_sid>86600</if_sid>
         <field name="event_type">^http$</field>
         <description>Suricata: HTTP.</description>
+        <options>no_full_log</options>
     </rule>
 
     <rule id="86603" level="0">
         <if_sid>86600</if_sid>
         <field name="event_type">^dns$</field>
         <description>Suricata: DNS.</description>
+        <options>no_full_log</options>
     </rule>
 
     <rule id="86604" level="0">
         <if_sid>86600</if_sid>
         <field name="event_type">^tls$</field>
         <description>Suricata: TLS.</description>
+        <options>no_full_log</options>
     </rule>
 
 </group>

--- a/rules/0490-virustotal_rules.xml
+++ b/rules/0490-virustotal_rules.xml
@@ -13,12 +13,14 @@
         <decoded_as>json</decoded_as>
         <field name="integration">virustotal</field>
         <description>VirusTotal integration messages.</description>
+        <options>no_full_log</options>
     </rule>
 
     <rule id="87101" level="3">
         <if_sid>87100</if_sid>
         <field name="virustotal.error">204</field>
         <description>VirusTotal: Error: Public API request rate limit reached</description>
+        <options>no_full_log</options>
     </rule>
 
     <rule id="87102" level="3">
@@ -26,12 +28,14 @@
         <field name="virustotal.error">403</field>
         <description>VirusTotal: Error: Check credentials</description>
         <group>gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
+        <options>no_full_log</options>
     </rule>
 
     <rule id="87103" level="3">
         <if_sid>87100</if_sid>
         <field name="virustotal.found">0</field>
         <description>VirusTotal: Alert - No records in VirusTotal database</description>
+        <options>no_full_log</options>
     </rule>
 
     <rule id="87104" level="3">
@@ -39,6 +43,7 @@
         <field name="virustotal.found">1</field>
         <field name="virustotal.malicious">0</field>
         <description>VirusTotal: Alert - $(virustotal.source.file) - No positives found</description>
+        <options>no_full_log</options>
     </rule>
 
     <rule id="87105" level="12">
@@ -46,6 +51,7 @@
         <field name="virustotal.malicious">1</field>
         <description>VirusTotal: Alert - $(virustotal.source.file) - $(virustotal.positives) engines detected this file</description>
         <group>gdpr_IV_35.7.d,</group>
+        <options>no_full_log</options>
     </rule>
 
 </group>

--- a/rules/0500-owncloud_rules.xml
+++ b/rules/0500-owncloud_rules.xml
@@ -46,19 +46,21 @@
     <decoded_as>json</decoded_as>
     <field name="@source">ownCloud</field>
     <description>ownCloud messages grouped.</description>
+    <options>no_full_log</options>
   </rule>
 
   <rule id="87310" level="0">
     <decoded_as>owncloud</decoded_as>
     <description>ownCloud messages grouped.</description>
+    <options>no_full_log</options>
   </rule>
-
 
   <rule id="87301" level="6">
     <if_sid>87300,87310</if_sid>
     <match>Login failed: </match>
     <description>ownCloud authentication failed.</description>
     <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
+    <options>no_full_log</options>
   </rule>
 
   <rule id="87302" level="10" frequency="8" timeframe="120">
@@ -66,6 +68,7 @@
     <same_source_ip />
     <description>ownCloud brute force (multiple failed logins).</description>
     <group>authentication_failures,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
+    <options>no_full_log</options>
   </rule>
 
   <rule id="87303" level="6">
@@ -73,6 +76,7 @@
     <match>Passed filename is not valid, might be malicious </match>
     <description>ownCloud possible malicious request.</description>
     <group>web,appsec,attack,pci_dss_6.5,pci_dss_11.4,gdpr_IV_35.7.d,</group>
+    <options>no_full_log</options>
   </rule>
 
   <rule id="87304" level="8">
@@ -80,30 +84,35 @@
     <status>^4$</status>
     <description>ownCloud FATAL message.</description>
     <group>gdpr_IV_35.7.d,</group>
+    <options>no_full_log</options>
   </rule>
 
- <rule id="87305" level="4">
+  <rule id="87305" level="4">
     <if_sid>87300,87310</if_sid>
     <status>^3$</status>
     <description>ownCloud ERROR message.</description>
+    <options>no_full_log</options>
   </rule>
 
   <rule id="87306" level="3">
     <if_sid>87300,87310</if_sid>
     <status>^2$</status>
     <description>ownCloud WARN message.</description>
+    <options>no_full_log</options>
   </rule>
 
   <rule id="87307" level="0">
     <if_sid>87300,87310</if_sid>
     <status>^1$</status>
     <description>ownCloud INFO message.</description>
+    <options>no_full_log</options>
   </rule>
 
   <rule id="87308" level="0">
     <if_sid>87300,87310</if_sid>
     <status>^0$</status>
     <description>ownCloud DEBUG message.</description>
+    <options>no_full_log</options>
   </rule>
 
 </group>

--- a/rules/0505-vuls_rules.xml
+++ b/rules/0505-vuls_rules.xml
@@ -21,6 +21,7 @@
     <decoded_as>json</decoded_as>
     <field name="vuls.integration">vuls</field>
     <description>Vuls integration event.</description>
+    <options>no_full_log</options>
   </rule>
 
   <rule id="22402" level="7">
@@ -29,6 +30,7 @@
       <match>has a update date lower</match>
       <description>$(vuls.scanned_cve) has a update date lower than $(vuls.days) days.</description>
       <group>gdpr_IV_35.7.d,</group>
+    <options>no_full_log</options>
   </rule>
 
   <rule id="22403" level="5">
@@ -36,6 +38,7 @@
       <field name="vuls.affected_packages">\.+</field>
       <description>Low vulnerability $(vuls.scanned_cve) detected in scanning launched on c with $(vuls.assurance) reliability ($(vuls.detection_method)). Score: $(vuls.core) ($(vuls.source)). Affected packages: $(vuls.affected_packages)</description>
       <group>gdpr_IV_35.7.d,</group>
+    <options>no_full_log</options>
   </rule>
 
   <rule id="22404" level="7">
@@ -43,6 +46,7 @@
       <field name="vuls.score">^4|^5|^6</field>
       <description>Medium vulnerability $(vuls.scanned_cve) detected in scanning launched on $(vuls.scan_date) with $(vuls.assurance) reliability ($(vuls.detection_method)). $(vuls.tittle). Score: $(vuls.score) ($(vuls.source)). Affected packages: $(vuls.affected_packages)</description>
       <group>gdpr_IV_35.7.d,</group>
+    <options>no_full_log</options>
   </rule>
 
   <rule id="22405" level="10">
@@ -50,6 +54,7 @@
       <field name="vuls.score">^7|^8</field>
       <description>High vulnerability $(vuls.scanned_cve) detected in scanning launched on $(vuls.scan_date) with $(vuls.assurance) reliability ($(vuls.detection_method)). $(vuls.tittle). Score: $(vuls.score) ($(vuls.source)). Affected packages: $(vuls.affected_packages)</description>
       <group>gdpr_IV_35.7.d,</group>
+    <options>no_full_log</options>
   </rule>
 
   <rule id="22406" level="13">
@@ -57,6 +62,7 @@
       <field name="vuls.score">^9|^10</field>
       <description>Critical vulnerability $(vuls.scanned_cve) detected in scanning launched on $(vuls.scan_date) with $(vuls.assurance) reliability ($(vuls.detection_method)). $(vuls.tittle). Score: $(vuls.score) ($(vuls.source)). Affected packages: $(vuls.affected_packages)</description>
       <group>gdpr_IV_35.7.d,</group>
+    <options>no_full_log</options>
   </rule>
 
   <rule id="22407" level="7">
@@ -64,6 +70,7 @@
       <field name="vuls.affected_packages">kernel</field>
       <description>Vulnerability $(vuls.scanned_cve) affects critical parts of the system.</description>
       <group>gdpr_IV_35.7.d,</group>
+    <options>no_full_log</options>
   </rule>
 
 </group>

--- a/rules/0510-ciscat_rules.xml
+++ b/rules/0510-ciscat_rules.xml
@@ -22,6 +22,7 @@
     <category>ossec</category>
     <decoded_as>ciscat</decoded_as>
     <description>Event decoded by CIS-CAT decoder</description>
+    <options>no_full_log</options>
   </rule>
 
   <rule id="87402" level="0">
@@ -30,6 +31,7 @@
     <field name="scan_id">\.+</field>
     <match>"cis":{</match>
     <description>CIS-CAT events.</description>
+    <options>no_full_log</options>
   </rule>
 
   <rule id="87403" level="0">
@@ -38,121 +40,138 @@
     <field name="scan_id">\.+</field>
     <match>"cis-data":{</match>
     <description>Old CIS-CAT events.</description>
+    <options>no_full_log</options>
   </rule>
 
   <rule id="87404" level="3">
-      <if_sid>87401, 87402</if_sid>
-      <field name="type">^scan_info$</field>
-      <description>CIS-CAT: assessment information for scan $(scan_id)</description>
-      <group></group>
+    <if_sid>87401, 87402</if_sid>
+    <field name="type">^scan_info$</field>
+    <description>CIS-CAT: assessment information for scan $(scan_id)</description>
+    <group></group>
+    <options>no_full_log</options>
   </rule>
 
   <!-- Rule to support CIS-CAT rules of Wazuh 3.1 -->
   <rule id="87405" level="3">
-      <if_sid>87403</if_sid>
-      <field name="type">^scan_info$</field>
-      <description>CIS-CAT: assessment information for scan $(scan_id)</description>
-      <group></group>
+    <if_sid>87403</if_sid>
+    <field name="type">^scan_info$</field>
+    <description>CIS-CAT: assessment information for scan $(scan_id)</description>
+    <group></group>
+    <options>no_full_log</options>
   </rule>
 
   <rule id="87406" level="0">
-      <if_sid>87401, 87402</if_sid>
-      <field name="type">^scan_result$</field>
-      <field name="cis.result">^pass$</field>
-      <description>CIS-CAT: $(cis.rule_title) (passed)</description>
+    <if_sid>87401, 87402</if_sid>
+    <field name="type">^scan_result$</field>
+    <field name="cis.result">^pass$</field>
+    <description>CIS-CAT: $(cis.rule_title) (passed)</description>
+    <options>no_full_log</options>
   </rule>
 
   <rule id="87407" level="0">
-      <if_sid>87403</if_sid>
-      <field name="type">^scan_result$</field>
-      <field name="cis-data.result">^pass$</field>
-      <description>CIS-CAT: $(cis-data.rule_title) (passed)</description>
+    <if_sid>87403</if_sid>
+    <field name="type">^scan_result$</field>
+    <field name="cis-data.result">^pass$</field>
+    <description>CIS-CAT: $(cis-data.rule_title) (passed)</description>
+    <options>no_full_log</options>
   </rule>
 
   <rule id="87408" level="0">
-      <if_sid>87401, 87402</if_sid>
-      <field name="type">^scan_result$</field>
-      <field name="cis.result">^notchecked$</field>
-      <description>CIS-CAT: $(cis.rule_title) (not checked)</description>
+    <if_sid>87401, 87402</if_sid>
+    <field name="type">^scan_result$</field>
+    <field name="cis.result">^notchecked$</field>
+    <description>CIS-CAT: $(cis.rule_title) (not checked)</description>
+    <options>no_full_log</options>
   </rule>
 
   <rule id="87409" level="0">
-      <if_sid>87403</if_sid>
-      <field name="type">^scan_result$</field>
-      <field name="cis-data.result">^notchecked$</field>
-      <description>CIS-CAT: $(cis-data.rule_title) (not checked)</description>
+    <if_sid>87403</if_sid>
+    <field name="type">^scan_result$</field>
+    <field name="cis-data.result">^notchecked$</field>
+    <description>CIS-CAT: $(cis-data.rule_title) (not checked)</description>
+    <options>no_full_log</options>
   </rule>
 
   <rule id="87410" level="0">
-      <if_sid>87401, 87402</if_sid>
-      <field name="type">^scan_result$</field>
-      <field name="cis.result">^notselected$</field>
-      <description>CIS-CAT: $(cis.rule_title) (not selected)</description>
+    <if_sid>87401, 87402</if_sid>
+    <field name="type">^scan_result$</field>
+    <field name="cis.result">^notselected$</field>
+    <description>CIS-CAT: $(cis.rule_title) (not selected)</description>
+    <options>no_full_log</options>
   </rule>
 
   <rule id="87411" level="0">
-      <if_sid>87403</if_sid>
-      <field name="type">^scan_result$</field>
-      <field name="cis-data.result">^notselected$</field>
-      <description>CIS-CAT: $(cis-data.rule_title) (not selected)</description>
+    <if_sid>87403</if_sid>
+    <field name="type">^scan_result$</field>
+    <field name="cis-data.result">^notselected$</field>
+    <description>CIS-CAT: $(cis-data.rule_title) (not selected)</description>
+    <options>no_full_log</options>
   </rule>
 
   <rule id="87412" level="3">
-      <if_sid>87401, 87402</if_sid>
-      <field name="type">^scan_result$</field>
-      <field name="cis.result">^error$</field>
-      <description>CIS-CAT: $(cis.rule_title) (error)</description>
+    <if_sid>87401, 87402</if_sid>
+    <field name="type">^scan_result$</field>
+    <field name="cis.result">^error$</field>
+    <description>CIS-CAT: $(cis.rule_title) (error)</description>
+    <options>no_full_log</options>
   </rule>
 
   <rule id="87413" level="3">
-      <if_sid>87403</if_sid>
-      <field name="type">^scan_result$</field>
-      <field name="cis-data.result">^error$</field>
-      <description>CIS-CAT: $(cis-data.rule_title) (error)</description>
+    <if_sid>87403</if_sid>
+    <field name="type">^scan_result$</field>
+    <field name="cis-data.result">^error$</field>
+    <description>CIS-CAT: $(cis-data.rule_title) (error)</description>
+    <options>no_full_log</options>
   </rule>
 
   <rule id="87414" level="3">
-      <if_sid>87401, 87402</if_sid>
-      <field name="type">^scan_result$</field>
-      <field name="cis.result">^unknown$</field>
-      <description>CIS-CAT: $(cis.rule_title) (unknown)</description>
+    <if_sid>87401, 87402</if_sid>
+    <field name="type">^scan_result$</field>
+    <field name="cis.result">^unknown$</field>
+    <description>CIS-CAT: $(cis.rule_title) (unknown)</description>
+    <options>no_full_log</options>
   </rule>
 
   <rule id="87415" level="3">
-      <if_sid>87403</if_sid>
-      <field name="type">^scan_result$</field>
-      <field name="cis-data.result">^unknown$</field>
-      <description>CIS-CAT: $(cis-data.rule_title) (unknown)</description>
+    <if_sid>87403</if_sid>
+    <field name="type">^scan_result$</field>
+    <field name="cis-data.result">^unknown$</field>
+    <description>CIS-CAT: $(cis-data.rule_title) (unknown)</description>
+    <options>no_full_log</options>
   </rule>
 
   <rule id="87416" level="1">
-      <if_sid>87401, 87402</if_sid>
-      <field name="type">^scan_result$</field>
-      <field name="cis.result">^informational$</field>
-      <description>CIS-CAT: $(cis.rule_title) (informational)</description>
+    <if_sid>87401, 87402</if_sid>
+    <field name="type">^scan_result$</field>
+    <field name="cis.result">^informational$</field>
+    <description>CIS-CAT: $(cis.rule_title) (informational)</description>
+    <options>no_full_log</options>
   </rule>
 
   <rule id="87417" level="1">
-      <if_sid>87403</if_sid>
-      <field name="type">^scan_result$</field>
-      <field name="cis-data.result">^informational$</field>
-      <description>CIS-CAT: $(cis-data.rule_title) (informational)</description>
+    <if_sid>87403</if_sid>
+    <field name="type">^scan_result$</field>
+    <field name="cis-data.result">^informational$</field>
+    <description>CIS-CAT: $(cis-data.rule_title) (informational)</description>
+    <options>no_full_log</options>
   </rule>
 
   <rule id="87418" level="7">
-      <if_sid>87401, 87402</if_sid>
-      <field name="type">^scan_result$</field>
-      <field name="cis.result">^fail$</field>
-      <description>CIS-CAT: $(cis.rule_title) (failed)</description>
-      <group>gdpr_IV_35.7.d,</group>
+    <if_sid>87401, 87402</if_sid>
+    <field name="type">^scan_result$</field>
+    <field name="cis.result">^fail$</field>
+    <description>CIS-CAT: $(cis.rule_title) (failed)</description>
+    <group>gdpr_IV_35.7.d,</group>
+    <options>no_full_log</options>
   </rule>
 
   <rule id="87419" level="7">
-      <if_sid>87403</if_sid>
-      <field name="type">^scan_result$</field>
-      <field name="cis-data.result">^fail$</field>
-      <description>CIS-CAT: $(cis-data.rule_title) (failed)</description>
-      <group>gdpr_IV_35.7.d,</group>
+    <if_sid>87403</if_sid>
+    <field name="type">^scan_result$</field>
+    <field name="cis-data.result">^fail$</field>
+    <description>CIS-CAT: $(cis-data.rule_title) (failed)</description>
+    <group>gdpr_IV_35.7.d,</group>
+    <options>no_full_log</options>
   </rule>
 
 <!-- Example JSON event
@@ -163,24 +182,28 @@
     <if_sid>87401, 87402</if_sid>
     <field name="cis.score">^8\d</field>
     <description>CIS-CAT Report overview: Score less than 90% ($(cis.score))</description>
+    <options>no_full_log</options>
   </rule>
 
   <rule id="87421" level="4">
     <if_sid>87403</if_sid>
     <field name="cis-data.score">^8\d</field>
     <description>CIS-CAT Report overview: Score less than 90% ($(cis-data.score) %)</description>
+    <options>no_full_log</options>
   </rule>
 
   <rule id="87422" level="5">
     <if_sid>87401, 87402</if_sid>
     <field name="cis.score">^7\d|^6\d|^5\d</field>
     <description>CIS-CAT Report overview: Score less than 80% ($(cis.score))</description>
+    <options>no_full_log</options>
   </rule>
 
   <rule id="87423" level="5">
     <if_sid>87403</if_sid>
     <field name="cis-data.score">^7\d|^6\d|^5\d</field>
     <description>CIS-CAT Report overview: Score less than 80% ($(cis-data.score) %)</description>
+    <options>no_full_log</options>
   </rule>
 
   <rule id="87424" level="7">
@@ -188,6 +211,7 @@
     <field name="cis.score">^4\d|^3\d</field>
     <description>CIS-CAT Report overview: Score less than 50% ($(cis.score))</description>
     <group>gdpr_IV_35.7.d,</group>
+    <options>no_full_log</options>
   </rule>
 
   <rule id="87425" level="7">
@@ -195,6 +219,7 @@
     <field name="cis-data.score">^4\d|^3\d</field>
     <description>CIS-CAT Report overview: Score less than 50% ($(cis-data.score) %)</description>
     <group>gdpr_IV_35.7.d,</group>
+    <options>no_full_log</options>
   </rule>
 
   <rule id="87426" level="9">
@@ -202,6 +227,7 @@
     <field name="cis.score">^2\d|^1\d|^\d$</field>
     <description>CIS-CAT Report overview: Score less than 30% ($(cis.score))</description>
     <group>gdpr_IV_35.7.d,</group>
+    <options>no_full_log</options>
   </rule>
 
   <rule id="87427" level="9">
@@ -209,6 +235,7 @@
     <field name="cis-data.score">^2\d|^1\d|^\d$</field>
     <description>CIS-CAT Report overview: Score less than 30% ($(cis-data.score) %)</description>
     <group>gdpr_IV_35.7.d,</group>
+    <options>no_full_log</options>
   </rule>
 
 </group>

--- a/rules/0520-vulnerability-detector_rules.xml
+++ b/rules/0520-vulnerability-detector_rules.xml
@@ -13,6 +13,7 @@
     <description>$(vulnerability.title)</description>
   </rule>
 
+
   <rule id="23503" level="5">
       <if_sid>23501</if_sid>
       <options>no_full_log</options>
@@ -76,4 +77,5 @@
       <description>It was not possible to verify whether $(vulnerability.cve) affects $(vulnerability.package.name).</description>
       <group>gdpr_IV_35.7.d,</group>
   </rule>
+
 </group>

--- a/rules/0530-mysql_audit_rules.xml
+++ b/rules/0530-mysql_audit_rules.xml
@@ -29,6 +29,7 @@ logcollector must be configured with the following labels
       <decoded_as>json</decoded_as>
       <field name="mysql_audit_log">percona</field>
       <description>Percona Server audit events grouped.</description>
+      <options>no_full_log</options>
     </rule>
 
     <rule id="88001" level="3">
@@ -37,6 +38,7 @@ logcollector must be configured with the following labels
       <field name="audit_record.status">^0$</field>
       <description>Percona audit: authentication success.</description>
       <group>authentication_success,pci_dss_10.2.5,pci_dss_8.7,gpg13_7.1,gpg13_7.2,gdpr_IV_32.2,</group>
+      <options>no_full_log</options>
     </rule>
 
     <rule id="88002" level="3">
@@ -44,6 +46,7 @@ logcollector must be configured with the following labels
       <field name="audit_record.name">^Quit$</field>
       <description>Percona audit: user logout.</description>
       <group>pci_dss_10.2.5,pci_dss_8.7,gpg13_7.1,gpg13_7.2,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
+      <options>no_full_log</options>
     </rule>
 
     <rule id="88003" level="9">
@@ -52,6 +55,7 @@ logcollector must be configured with the following labels
       <field name="audit_record.status">^1</field>
       <description>Percona audit: authentication failure.</description>
       <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_8.7,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
+      <options>no_full_log</options>
     </rule>
 
     <rule id="88004" level="3">
@@ -60,6 +64,7 @@ logcollector must be configured with the following labels
       <field name="audit_record.status">^0$</field>
       <description>Percona audit success: $(audit_record.command_class) statement.</description>
       <group>pci_dss_8.7,gpg13_7.1,gdpr_IV_35.7.d,</group>
+      <options>no_full_log</options>
     </rule>
 
     <rule id="88005" level="5">
@@ -68,6 +73,7 @@ logcollector must be configured with the following labels
       <field name="audit_record.command_class">^drop|^alter|^insert|^update|^grant|^delete</field>
       <description>Percona audit success: $(audit_record.command_class) statement.</description>
       <group>pci_dss_8.7,gpg13_7.1,gdpr_IV_35.7.d,</group>
+      <options>no_full_log</options>
     </rule>
 
     <rule id="88006" level="3">
@@ -76,6 +82,7 @@ logcollector must be configured with the following labels
       <field name="audit_record.status">^1</field>
       <description>Percona audit failed: $(audit_record.command_class) statement.</description>
       <group>pci_dss_8.7,gpg13_7.1,gdpr_IV_35.7.d,</group>
+      <options>no_full_log</options>
     </rule>
 
     <rule id="88007" level="5">
@@ -84,12 +91,14 @@ logcollector must be configured with the following labels
       <field name="audit_record.command_class">^drop|^alter|^insert|^update|^grant|^delete</field>
       <description>Percona audit failed: $(audit_record.command_class) statement.</description>
       <group>pci_dss_8.7,gpg13_7.1,gdpr_IV_35.7.d,</group>
+      <options>no_full_log</options>
     </rule>
 
     <rule id="89050" level="0">
       <decoded_as>json</decoded_as>
       <field name="mysql_audit_log">mcafee</field>
       <description>McAfee AUDIT Plugin for MySQL events grouped.</description>
+      <options>no_full_log</options>
     </rule>
 
     <rule id="89051" level="3">
@@ -97,6 +106,7 @@ logcollector must be configured with the following labels
       <field name="cmd">^Connect$</field>
       <description>McAfee MySQL audit: authentication attempt.</description>
       <group>pci_dss_10.2.5,pci_dss_8.7,gpg13_7.1,gpg13_7.2,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
+      <options>no_full_log</options>
     </rule>
 
     <rule id="89052" level="3">
@@ -104,6 +114,7 @@ logcollector must be configured with the following labels
       <field name="cmd">^Quit$</field>
       <description>McAfee MySQL audit: user logout.</description>
       <group>pci_dss_10.2.5,pci_dss_8.7,gpg13_7.1,gpg13_7.2,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
+      <options>no_full_log</options>
     </rule>
 
     <rule id="89053" level="9">
@@ -111,6 +122,7 @@ logcollector must be configured with the following labels
       <field name="cmd">^Failed Login$</field>
       <description>McAfee MySQL audit: authentication failure.</description>
       <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_8.7,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
+      <options>no_full_log</options>
     </rule>
 
     <rule id="89054" level="3">
@@ -118,6 +130,7 @@ logcollector must be configured with the following labels
       <status>^0$</status>
       <description>McAfee MySQL audit success: $(cmd) statement.</description>
       <group>pci_dss_8.7,gpg13_7.1,gdpr_IV_35.7.d,</group>
+      <options>no_full_log</options>
     </rule>
 
     <rule id="89055" level="5">
@@ -125,6 +138,7 @@ logcollector must be configured with the following labels
       <field name="cmd">^drop|^alter|^insert|^update|^grant|^delete</field>
       <description>McAfee MySQL audit success: $(cmd) statement.</description>
       <group>pci_dss_8.7,gpg13_7.1,gdpr_IV_35.7.d,</group>
+      <options>no_full_log</options>
     </rule>
 
     <rule id="89056" level="3">
@@ -132,6 +146,7 @@ logcollector must be configured with the following labels
       <status>^1</status>
       <description>McAfee MySQL audit failed: $(cmd) statement.</description>
       <group>pci_dss_8.7,gpg13_7.1,gdpr_IV_35.7.d,</group>
+      <options>no_full_log</options>
     </rule>
 
     <rule id="89057" level="5">
@@ -139,6 +154,7 @@ logcollector must be configured with the following labels
       <field name="cmd">^drop|^alter|^insert|^update|^grant|^delete</field>
       <description>McAfee MySQL audit failed: $(cmd) statement.</description>
       <group>pci_dss_8.7,gpg13_7.1,gdpr_IV_35.7.d,</group>
+      <options>no_full_log</options>
     </rule>
 
 </group>

--- a/rules/0545-osquery_rules.xml
+++ b/rules/0545-osquery_rules.xml
@@ -10,54 +10,63 @@
   <rule id="24000" level="3">
     <location>osquery$</location>
     <description>osquery message</description>
+    <options>no_full_log</options>
   </rule>
 
   <rule id="24001" level="5">
     <if_sid>24000</if_sid>
     <regex>^E\d\d\d\d </regex>
     <description>osquery error message</description>
+    <options>no_full_log</options>
   </rule>
 
   <rule id="24002" level="3">
     <if_sid>24000</if_sid>
     <regex>^W\d\d\d\d </regex>
     <description>osquery warning message</description>
+    <options>no_full_log</options>
   </rule>
 
   <rule id="24003" level="2">
     <if_sid>24000</if_sid>
     <regex>^I\d\d\d\d </regex>
     <description>osquery information message</description>
+    <options>no_full_log</options>
   </rule>
 
   <rule id="24010" level="3">
     <if_sid>24000</if_sid>
     <decoded_as>json</decoded_as>
     <description>osquery: $(osquery.name) query result</description>
+    <options>no_full_log</options>
   </rule>
 
   <rule id="24011" level="4">
     <if_sid>24010</if_sid>
     <field name="osquery.name">high_load_average</field>
     <description>osquery: System memory is under $(osquery.columns.threshold)</description>
+    <options>no_full_log</options>
   </rule>
 
   <rule id="24012" level="4">
     <if_sid>24010</if_sid>
     <field name="osquery.name">low_free_memory</field>
     <description>osquery: System memory is under $(osquery.columns.threshold)</description>
+    <options>no_full_log</options>
   </rule>
 
   <rule id="24013" level="4">
     <if_sid>24010</if_sid>
     <field name="osquery.name">low_disk_space</field>
     <description>osquery: Free disk space is under $(osquery.columns.threshold)</description>
+    <options>no_full_log</options>
   </rule>
 
   <rule id="24014" level="4">
     <if_sid>24010</if_sid>
     <field name="osquery.name">disk_time_busy</field>
     <description>osquery: Disk busy time is over $(osquery.columns.threshold)</description>
+    <options>no_full_log</options>
   </rule>
 
   <rule id="24020" level="4">
@@ -65,6 +74,7 @@
     <field name="osquery.pack">^osquery-monitoring$</field>
     <description>osquery: $(osquery.pack) query result</description>
     <group>osquery_monitoring,</group>
+    <options>no_full_log</options>
   </rule>
 
   <rule id="24021" level="4">
@@ -72,6 +82,7 @@
     <field name="osquery.name">schedule</field>
     <description>osquery: $(osquery.pack) $(osquery.subquery): The pack executed is $(osquery.columns.name) and the interval is $(osquery.columns.interval) </description>
     <group>osquery_monitoring,</group>
+    <options>no_full_log</options>
   </rule>
 
   <rule id="24022" level="4">
@@ -79,6 +90,7 @@
     <field name="osquery.name">events</field>
     <description>osquery: $(osquery.pack) $(osquery.subquery): The event executed is $(osquery.columns.name) and the publisher is $(osquery.columns.publisher) </description>
     <group>osquery_monitoring,</group>
+    <options>no_full_log</options>
   </rule>
 
   <rule id="24023" level="4">
@@ -86,6 +98,7 @@
     <field name="osquery.name">osquery_info</field>
     <description>osquery: $(osquery.pack) $(osquery.subquery): Osquery version is $(osquery.columns.version) build on $(osquery.columns.build_platform) $(osquery.columns.build_distro)</description>
     <group>osquery_monitoring,</group>
+    <options>no_full_log</options>
   </rule>
 
   <rule id="24030" level="4">
@@ -93,6 +106,7 @@
     <field name="osquery.pack">^incident-response$</field>
     <description>osquery: $(osquery.pack) query result</description>
     <group>incident_response,</group>
+    <options>no_full_log</options>
   </rule>
 
   <rule id="24031" level="4">
@@ -100,6 +114,7 @@
     <field name="osquery.name">launchd</field>
     <description>osquery: $(osquery.pack) $(osquery.subquery): Running daemon is $(osquery.columns.label) with path $(osquery.columns.program) and username $(osquery.columns.username)</description>
     <group>incident_response,</group>
+    <options>no_full_log</options>
   </rule>
 
   <rule id="24032" level="4">
@@ -107,6 +122,7 @@
     <field name="osquery.name">startup_items</field>
     <description>osquery: $(osquery.pack) $(osquery.subquery): Program $(osquery.columns.name) is launched at system startup</description>
     <group>incident_response,</group>
+    <options>no_full_log</options>
   </rule>
 
     <rule id="24033" level="4">
@@ -114,6 +130,7 @@
     <field name="osquery.name">crontab</field>
     <description>osquery: $(osquery.pack) $(osquery.subquery): Command launched $(osquery.columns.command) at $(osquery.columns.hour):$(osquery.columns.minute) $(osquery.columns.day_of_month) $(osquery.columns.month) </description>
     <group>incident_response,</group>
+    <options>no_full_log</options>
   </rule>
 
   <rule id="24034" level="4">
@@ -121,6 +138,7 @@
     <field name="osquery.name">loginwindow1</field>
     <description>osquery: $(osquery.pack) $(osquery.subquery): Key $(osquery.columns.key), Value $(osquery.columns.value)</description>
     <group>incident_response,</group>
+    <options>no_full_log</options>
   </rule>
 
   <rule id="24035" level="4">
@@ -128,6 +146,7 @@
     <field name="osquery.name">loginwindow2</field>
     <description>osquery: $(osquery.pack) $(osquery.subquery): Key $(osquery.columns.key), Value $(osquery.columns.value)</description>
     <group>incident_response,</group>
+    <options>no_full_log</options>
   </rule>
 
   <rule id="24036" level="4">
@@ -135,6 +154,7 @@
     <field name="osquery.name">loginwindow3</field>
     <description>osquery: $(osquery.pack) $(osquery.subquery): Username $(osquery.columns.username), Key $(osquery.columns.key)</description>
     <group>incident_response,</group>
+    <options>no_full_log</options>
   </rule>
 
   <rule id="24037" level="4">
@@ -142,6 +162,7 @@
     <field name="osquery.name">loginwindow4</field>
     <description>osquery: $(osquery.pack) $(osquery.subquery): Username $(osquery.columns.username), Key $(osquery.columns.key)</description>
     <group>incident_response,</group>
+    <options>no_full_log</options>
   </rule>
 
   <rule id="24038" level="4">
@@ -149,6 +170,7 @@
     <field name="osquery.name">alf</field>
     <description>osquery: $(osquery.pack) $(osquery.subquery): Application Layer Firewall for OSX version $(osquery.columns.version)</description>
     <group>incident_response,</group>
+    <options>no_full_log</options>
   </rule>
 
   <rule id="24039" level="4">
@@ -156,6 +178,7 @@
     <field name="osquery.name">alf</field>
     <description>osquery: $(osquery.pack) $(osquery.subquery): Application Layer Firewall for OSX version $(osquery.columns.version)</description>
     <group>incident_response,</group>
+    <options>no_full_log</options>
   </rule>
 
   <rule id="24040" level="4">
@@ -163,6 +186,7 @@
     <field name="osquery.name">alf_exceptions</field>
     <description>osquery: $(osquery.pack) $(osquery.subquery): Application Layer Firewall for OSX service exceptions path $(osquery.columns.path)</description>
     <group>incident_response,</group>
+    <options>no_full_log</options>
   </rule>
 
     <rule id="24041" level="4">
@@ -170,6 +194,7 @@
     <field name="osquery.name">alf_services</field>
     <description>osquery: $(osquery.pack) $(osquery.subquery): Application Layer Firewall for OSX service $(osquery.columns.service) state $(osquery.columns.state)</description>
     <group>incident_response,</group>
+    <options>no_full_log</options>
   </rule>
 
   <rule id="24042" level="4">
@@ -177,6 +202,7 @@
     <field name="osquery.name">alf_explicit_auths</field>
     <description>osquery: $(osquery.pack) $(osquery.subquery): Process $(osquery.columns.process) has explicit authorization for Application Layer Firewall OSX</description>
     <group>incident_response,</group>
+    <options>no_full_log</options>
   </rule>
 
   <rule id="24043" level="4">
@@ -184,6 +210,7 @@
     <field name="osquery.name">etc_hosts</field>
     <description>osquery: $(osquery.pack) $(osquery.subquery): Address $(osquery.columns.address) Hostnames $(osquery.columns.hostnames)</description>
     <group>incident_response,</group>
+    <options>no_full_log</options>
   </rule>
 
   <rule id="24044" level="4">
@@ -191,6 +218,7 @@
     <field name="osquery.name">kextstat</field>
     <description>osquery: $(osquery.pack) $(osquery.subquery): Kernel module $(osquery.columns.name) version $(osquery.columns.version)</description>
     <group>incident_response,</group>
+    <options>no_full_log</options>
   </rule>
 
   <rule id="24045" level="4">
@@ -199,6 +227,7 @@
     <field name="osquery.columns.status">Live</field>
     <description>osquery: $(osquery.pack) $(osquery.subquery): OS Kernel module $(osquery.columns.name) is enabled and used by $(osquery.columns.used_by)</description>
     <group>incident_response,</group>
+    <options>no_full_log</options>
   </rule>
 
   <rule id="24046" level="4">
@@ -206,6 +235,7 @@
     <field name="osquery.name">last</field>
     <description>osquery: $(osquery.pack) $(osquery.subquery): User $(osquery.columns.username) host $(osquery.columns.host)</description>
     <group>incident_response,</group>
+    <options>no_full_log</options>
   </rule>
 
   <rule id="24047" level="4">
@@ -213,6 +243,7 @@
     <field name="osquery.name">installed_applications</field>
     <description>osquery: $(osquery.pack) $(osquery.subquery): OS X Application $(osquery.columns.name) version $(osquery.columns.bundle_version) is installed</description>
     <group>incident_response,</group>
+    <options>no_full_log</options>
   </rule>
 
   <rule id="24048" level="4">
@@ -220,6 +251,7 @@
     <field name="osquery.name">open_sockets</field>
     <description>osquery: $(osquery.pack) $(osquery.subquery): Process $(osquery.columns.pid) has local port $(osquery.columns.local_port) opened</description>
     <group>incident_response,</group>
+    <options>no_full_log</options>
   </rule>
 
   <rule id="24049" level="4">
@@ -227,6 +259,7 @@
     <field name="osquery.name">open_files</field>
     <description>osquery: $(osquery.pack) $(osquery.subquery): Process $(osquery.columns.pid) has file $(osquery.columns.path) opened</description>
     <group>incident_response,</group>
+    <options>no_full_log</options>
   </rule>
 
   <rule id="24050" level="4">
@@ -234,6 +267,7 @@
     <field name="osquery.name">logged_in_users</field>
     <description>osquery: $(osquery.pack) $(osquery.subquery): User $(osquery.columns.user) is logged from host $(osquery.columns.host) </description>
     <group>incident_response,</group>
+    <options>no_full_log</options>
   </rule>
 
   <rule id="24051" level="4">
@@ -241,6 +275,7 @@
     <field name="osquery.name">ip_forwarding</field>
     <description>osquery: $(osquery.pack) $(osquery.subquery): Status of IP/IPv6 forwarding $(osquery.columns.name) value $(osquery.columns.current_value)</description>
     <group>incident_response,</group>
+    <options>no_full_log</options>
   </rule>
 
   <rule id="24052" level="4">
@@ -248,6 +283,7 @@
     <field name="osquery.name">process_env</field>
     <description>osquery: $(osquery.pack) $(osquery.subquery): Process $(osquery.columns.pid) Environment variable $(osquery.columns.key) value $(osquery.columns.value)</description>
     <group>incident_response,</group>
+    <options>no_full_log</options>
   </rule>
 
   <rule id="24053" level="4">
@@ -255,6 +291,7 @@
     <field name="osquery.name">mounts</field>
     <description>osquery: $(osquery.pack) $(osquery.subquery): Mount point at $(osquery.columns.device) with $(osquery.columns.blocks_free) free blocks</description>
     <group>incident_response,</group>
+    <options>no_full_log</options>
   </rule>
 
   <rule id="24054" level="4">
@@ -262,6 +299,7 @@
     <field name="osquery.name">nfs_shares</field>
     <description>osquery: $(osquery.pack) $(osquery.subquery): Shared NFS $(osquery.columns.share) options $(osquery.columns.options) </description>
     <group>incident_response,</group>
+    <options>no_full_log</options>
   </rule>
 
   <rule id="24055" level="4">
@@ -269,6 +307,7 @@
     <field name="osquery.name">shell_history</field>
     <description>osquery: $(osquery.pack) $(osquery.subquery): User $(osquery.columns.username) history file $(osquery.columns.history_file) executed command $(osquery.columns.command)</description>
     <group>incident_response,</group>
+    <options>no_full_log</options>
   </rule>
 
   <rule id="24056" level="4">
@@ -276,6 +315,7 @@
     <field name="osquery.name">recent_items</field>
     <description>osquery: $(osquery.pack) $(osquery.subquery): User $(osquery.columns.username) opened recent item $(osquery.columns.value)</description>
     <group>incident_response,</group>
+    <options>no_full_log</options>
   </rule>
 
   <rule id="24057" level="4">
@@ -283,6 +323,7 @@
     <field name="osquery.name">ramdisk</field>
     <description>osquery: $(osquery.pack) $(osquery.subquery): Virtual interface $(osquery.columns.name) with uuid $(osquery.columns.uuid) is on the system</description>
     <group>incident_response,</group>
+    <options>no_full_log</options>
   </rule>
 
   <rule id="24058" level="4">
@@ -290,6 +331,7 @@
     <field name="osquery.name">listening_ports</field>
     <description>osquery: $(osquery.pack) $(osquery.subquery): Process $(osquery.columns.pid) has opened port $(osquery.columns.port) address $(osquery.columns.address) </description>
     <group>incident_response,</group>
+    <options>no_full_log</options>
   </rule>
 
   <rule id="24059" level="4">
@@ -297,6 +339,7 @@
     <field name="osquery.name">suid_bin</field>
     <description>osquery: $(osquery.pack) $(osquery.subquery): File $(osquery.columns.path) has setuid enabled</description>
     <group>incident_response,</group>
+    <options>no_full_log</options>
   </rule>
 
   <rule id="24060" level="4">
@@ -304,6 +347,7 @@
     <field name="osquery.name">process_memory</field>
     <description>osquery: $(osquery.pack) $(osquery.subquery): Process $(osquery.columns.pid) $(osquery.columns.path) memory start $(osquery.columns.start), memory end $(osquery.columns.end)</description>
     <group>incident_response,</group>
+    <options>no_full_log</options>
   </rule>
 
   <rule id="24061" level="4">
@@ -311,6 +355,7 @@
     <field name="osquery.name">arp_cache</field>
     <description>osquery: $(osquery.pack) $(osquery.subquery): ARP cache: Address $(osquery.columns.address) MAC $(osquery.columns.mac) Interface $(osquery.columns.interface)</description>
     <group>incident_response,</group>
+    <options>no_full_log</options>
   </rule>
 
   <rule id="24062" level="4">
@@ -318,6 +363,7 @@
     <field name="osquery.name">wireless_networks</field>
     <description>osquery: $(osquery.pack) $(osquery.subquery): Wireless network $(osquery.columns.network_name) is on remembered list</description>
     <group>incident_response,</group>
+    <options>no_full_log</options>
   </rule>
 
   <rule id="24063" level="4">
@@ -325,6 +371,7 @@
     <field name="osquery.name">disk_encryption</field>
     <description>osquery: $(osquery.pack) $(osquery.subquery): Device $(osquery.columns.name) encryption status is $(osquery.columns.encryption_status)</description>
     <group>incident_response,</group>
+    <options>no_full_log</options>
   </rule>
 
   <rule id="24064" level="4">
@@ -332,6 +379,7 @@
     <field name="osquery.name">iptables</field>
     <description>osquery: $(osquery.pack) $(osquery.subquery): Iptable source ip $(osquery.columns.src_ip) with policy $(osquery.columns.policy) and target $(osquery.columns.target) has a packet count of $(osquery.columns.packets)</description>
     <group>incident_response,</group>
+    <options>no_full_log</options>
   </rule>
 
   <rule id="24065" level="4">
@@ -339,6 +387,7 @@
     <field name="osquery.name">app_schemes</field>
     <description>osquery: $(osquery.pack) $(osquery.subquery): App scheme $(osquery.columns.scheme) handler is $(osquery.columns.handler)</description>
     <group>incident_response,</group>
+    <options>no_full_log</options>
   </rule>
 
   <rule id="24066" level="4">
@@ -347,6 +396,7 @@
     <field name="osquery.columns.enabled">1</field>
     <description>osquery: $(osquery.pack) $(osquery.subquery): Sandbox $(osquery.columns.label) with user $(osquery.columns.user) is enabled</description>
     <group>incident_response,</group>
+    <options>no_full_log</options>
   </rule>
 
   <rule id="24100" level="4">
@@ -354,6 +404,7 @@
     <field name="osquery.pack">^it-compliance$</field>
     <description>osquery: $(osquery.pack) query result</description>
     <group>it_compliance,</group>
+    <options>no_full_log</options>
   </rule>
 
   <rule id="24101" level="4">
@@ -361,6 +412,7 @@
     <field name="osquery.name">osquery_info</field>
     <description>osquery: $(osquery.pack) $(osquery.subquery): Osquery version is $(osquery.columns.version) build on $(osquery.columns.build_platform) $(osquery.columns.build_distro)</description>
     <group>it_compliance,</group>
+    <options>no_full_log</options>
   </rule>
 
   <rule id="24102" level="4">
@@ -368,6 +420,7 @@
     <field name="osquery.name">ad_config</field>
     <description>osquery: $(osquery.pack) $(osquery.subquery): Active Directory name $(osquery.columns.name) with domain $(osquery.columns.domain) has a value of $(osquery.columns.value)</description>
     <group>it_compliance,</group>
+    <options>no_full_log</options>
   </rule>
 
   <rule id="24103" level="4">
@@ -375,6 +428,7 @@
     <field name="osquery.name">kernel_info</field>
     <description>osquery: $(osquery.pack) $(osquery.subquery): OS kernel version $(osquery.columns.version), path $(osquery.columns.path)</description>
     <group>it_compliance,</group>
+    <options>no_full_log</options>
   </rule>
 
   <rule id="24104" level="4">
@@ -382,6 +436,7 @@
     <field name="osquery.name">os_version</field>
     <description>osquery: $(osquery.pack) $(osquery.subquery): OS $(osquery.columns.name) $(osquery.columns.version) $(osquery.columns.major).$(osquery.columns.minor) $(osquery.columns.codename)</description>
     <group>it_compliance,</group>
+    <options>no_full_log</options>
   </rule>
 
   <rule id="24105" level="4">
@@ -389,6 +444,7 @@
     <field name="osquery.name">alf</field>
     <description>osquery: $(osquery.pack) $(osquery.subquery): Application Layer Firewall for OSX version $(osquery.columns.version)</description>
     <group>it_compliance,</group>
+    <options>no_full_log</options>
   </rule>
 
   <rule id="24106" level="4">
@@ -396,6 +452,7 @@
     <field name="osquery.name">alf</field>
     <description>osquery: $(osquery.pack) $(osquery.subquery): Application Layer Firewall for OSX version $(osquery.columns.version)</description>
     <group>it_compliance,</group>
+    <options>no_full_log</options>
   </rule>
 
   <rule id="24107" level="4">
@@ -403,6 +460,7 @@
     <field name="osquery.name">alf_exceptions</field>
     <description>osquery: $(osquery.pack) $(osquery.subquery): Application Layer Firewall for OSX service exceptions path $(osquery.columns.path)</description>
     <group>it_compliance,</group>
+    <options>no_full_log</options>
   </rule>
 
   <rule id="24108" level="4">
@@ -410,6 +468,7 @@
     <field name="osquery.name">alf_services</field>
     <description>osquery: $(osquery.pack) $(osquery.subquery): Application Layer Firewall for OSX service $(osquery.columns.service) state $(osquery.columns.state)</description>
     <group>it_compliance,</group>
+    <options>no_full_log</options>
   </rule>
 
   <rule id="24109" level="4">
@@ -417,6 +476,7 @@
     <field name="osquery.name">alf_explicit_auths</field>
     <description>osquery: $(osquery.pack) $(osquery.subquery): Process $(osquery.columns.process) has explicit authorization for Application Layer Firewall OSX</description>
     <group>it_compliance,</group>
+    <options>no_full_log</options>
   </rule>
 
   <rule id="24110" level="4">
@@ -424,6 +484,7 @@
     <field name="osquery.name">mounts</field>
     <description>osquery: $(osquery.pack) $(osquery.subquery): Mount point $(osquery.columns.path) at with $(osquery.columns.blocks_free) free blocks</description>
     <group>it_compliance,</group>
+    <options>no_full_log</options>
   </rule>
 
   <rule id="24111" level="4">
@@ -431,6 +492,7 @@
     <field name="osquery.name">nfs_shares</field>
     <description>osquery: $(osquery.pack) $(osquery.subquery): Shared NFS $(osquery.columns.share) options $(osquery.columns.options)</description>
     <group>it_compliance,</group>
+    <options>no_full_log</options>
   </rule>
 
   <rule id="24112" level="4">
@@ -438,6 +500,7 @@
     <field name="osquery.name">windows_shared_resources</field>
     <description>osquery: $(osquery.pack) $(osquery.subquery): Windows shared resource $(osquery.columns.name) with path $(osquery.columns.path) status is $(osquery.columns.status)</description>
     <group>it_compliance,</group>
+    <options>no_full_log</options>
   </rule>
 
   <rule id="24113" level="4">
@@ -446,6 +509,7 @@
     <field name="osquery.columns.disabled">0</field>
     <description>osquery: $(osquery.pack) $(osquery.subquery): Browser plugin $(osquery.columns.name) is enabled</description>
     <group>it_compliance,</group>
+    <options>no_full_log</options>
   </rule>
 
   <rule id="24114" level="4">
@@ -454,6 +518,7 @@
     <field name="osquery.columns.disabled">1</field>
     <description>osquery: $(osquery.pack) $(osquery.subquery): Browser plugin $(osquery.columns.name) is disabled</description>
     <group>it_compliance,</group>
+    <options>no_full_log</options>
   </rule>
 
   <rule id="24115" level="4">
@@ -461,6 +526,7 @@
     <field name="osquery.name">safari_extensions</field>
     <description>osquery: $(osquery.pack) $(osquery.subquery): Safari extension $(osquery.columns.name) version is $(osquery.columns.version) and the user that owns it is $(osquery.columns.uid)</description>
     <group>it_compliance,</group>
+    <options>no_full_log</options>
   </rule>
 
   <rule id="24116" level="4">
@@ -468,6 +534,7 @@
     <field name="osquery.name">chrome_extensions</field>
     <description>osquery: $(osquery.pack) $(osquery.subquery): Chrome extension $(osquery.columns.name) version is $(osquery.columns.version) and the user that owns it is $(osquery.columns.uid)</description>
     <group>it_compliance,</group>
+    <options>no_full_log</options>
   </rule>
 
   <rule id="24117" level="4">
@@ -475,6 +542,7 @@
     <field name="osquery.name">firefox_addons</field>
     <description>osquery: $(osquery.pack) $(osquery.subquery): Firefox addon $(osquery.columns.name) type is $(osquery.columns.type) and the user that owns it is $(osquery.columns.uid)</description>
     <group>it_compliance,</group>
+    <options>no_full_log</options>
   </rule>
 
   <rule id="24118" level="4">
@@ -482,6 +550,7 @@
     <field name="osquery.name">homebrew_packages</field>
     <description>osquery: $(osquery.pack) $(osquery.subquery): Homebrew package $(osquery.columns.name) version is $(osquery.columns.version)</description>
     <group>it_compliance,</group>
+    <options>no_full_log</options>
   </rule>
 
   <rule id="24119" level="4">
@@ -489,6 +558,7 @@
     <field name="osquery.name">windows_programs</field>
     <description>osquery: $(osquery.pack) $(osquery.subquery): Windows program $(osquery.columns.name) $(osquery.columns.version) is installed on the system</description>
     <group>it_compliance,</group>
+    <options>no_full_log</options>
   </rule>
 
   <rule id="24120" level="4">
@@ -496,6 +566,7 @@
     <field name="osquery.name">windows_patches</field>
     <description>osquery: $(osquery.pack) $(osquery.subquery): Windows patch $(osquery.columns.hotfix_id) is installed on the system</description>
     <group>it_compliance,</group>
+    <options>no_full_log</options>
   </rule>
 
   <rule id="24121" level="4">
@@ -503,6 +574,7 @@
     <field name="osquery.name">package_receipts</field>
     <description>osquery: $(osquery.pack) $(osquery.subquery): OSX package recepit $(osquery.columns.package_id) $(osquery.columns.version) is installed on the system</description>
     <group>it_compliance,</group>
+    <options>no_full_log</options>
   </rule>
 
   <rule id="24122" level="4">
@@ -510,6 +582,7 @@
     <field name="osquery.name">usb_devices</field>
     <description>osquery: $(osquery.pack) $(osquery.subquery): USB device from vendor $(osquery.columns.vendor) is attached to port $(osquery.columns.usb_port)</description>
     <group>it_compliance,</group>
+    <options>no_full_log</options>
   </rule>
 
   <rule id="24123" level="4">
@@ -517,6 +590,7 @@
     <field name="osquery.name">keychain_items</field>
     <description>osquery: $(osquery.pack) $(osquery.subquery): Keychain $(osquery.columns.label) path is $(osquery.columns.path)</description>
     <group>it_compliance,</group>
+    <options>no_full_log</options>
   </rule>
 
   <rule id="24124" level="4">
@@ -524,6 +598,7 @@
     <field name="osquery.name">keychain_items</field>
     <description>osquery: $(osquery.pack) $(osquery.subquery): Keychain $(osquery.columns.label) path is $(osquery.columns.path)</description>
     <group>it_compliance,</group>
+    <options>no_full_log</options>
   </rule>
 
   <rule id="24125" level="4">
@@ -531,6 +606,7 @@
     <field name="osquery.name">deb_packages</field>
     <description>osquery: $(osquery.pack) $(osquery.subquery): Package name $(osquery.columns.name), version $(osquery.columns.version), revision $(osquery.columns.revision),size $(osquery.columns.size) bytes</description>
     <group>it_compliance,</group>
+    <options>no_full_log</options>
   </rule>
 
   <rule id="24126" level="4">
@@ -538,6 +614,7 @@
     <field name="osquery.name">apt_sources</field>
     <description>osquery: $(osquery.pack) $(osquery.subquery): Repository name $(osquery.columns.name), version $(osquery.columns.version), source $(osquery.columns.source),release name $(osquery.columns.release)</description>
     <group>it_compliance,</group>
+    <options>no_full_log</options>
   </rule>
 
   <rule id="24127" level="4">
@@ -545,6 +622,7 @@
     <field name="osquery.name">portage_packages</field>
     <description>osquery: $(osquery.pack) $(osquery.subquery): Portage package $(osquery.columns.package) $(osquery.columns.version) USE flags $(osquery.columns.flags)</description>
     <group>it_compliance,</group>
+    <options>no_full_log</options>
   </rule>
 
   <rule id="24128" level="4">
@@ -552,6 +630,7 @@
     <field name="osquery.name">portage_packages</field>
     <description>osquery: $(osquery.pack) $(osquery.subquery): Portage package $(osquery.columns.package) $(osquery.columns.version) USE flags $(osquery.columns.flags)</description>
     <group>it_compliance,</group>
+    <options>no_full_log</options>
   </rule>
 
   <rule id="24129" level="4">
@@ -560,6 +639,7 @@
     <field name="osquery.columns.status">Live</field>
     <description>osquery: $(osquery.pack) $(osquery.subquery): OS Kernel module $(osquery.columns.name) is enabled and used by $(osquery.columns.used_by)</description>
     <group>it_compliance,</group>
+    <options>no_full_log</options>
   </rule>
 
   <rule id="24130" level="4">
@@ -567,6 +647,7 @@
     <field name="osquery.name">windows_drivers</field>
     <description>osquery: $(osquery.pack) $(osquery.subquery): Windows device $(osquery.columns.device_name) driver is being used</description>
     <group>it_compliance,</group>
+    <options>no_full_log</options>
   </rule>
 
   <rule id="24131" level="4">
@@ -574,6 +655,7 @@
     <field name="osquery.name">rpm_packages</field>
     <description>osquery: $(osquery.pack) $(osquery.subquery): RPM package $(osquery.columns.name) version $(osquery.columns.version) is installed on the system</description>
     <group>it_compliance,</group>
+    <options>no_full_log</options>
   </rule>
 
   <rule id="24132" level="4">
@@ -581,6 +663,7 @@
     <field name="osquery.name">rpm_packages</field>
     <description>osquery: $(osquery.pack) $(osquery.subquery): RPM package $(osquery.columns.name) version $(osquery.columns.version) is installed on the system</description>
     <group>it_compliance,</group>
+    <options>no_full_log</options>
   </rule>
 
   <rule id="24133" level="4">
@@ -588,6 +671,7 @@
     <field name="osquery.name">installed_applications</field>
     <description>osquery: $(osquery.pack) $(osquery.subquery): OS X Application $(osquery.columns.name) version $(osquery.columns.bundle_version) is installed</description>
     <group>it_compliance,</group>
+    <options>no_full_log</options>
   </rule>
 
   <rule id="24134" level="4">
@@ -595,6 +679,7 @@
     <field name="osquery.name">disk_encryption</field>
     <description>osquery: $(osquery.pack) $(osquery.subquery): Device $(osquery.columns.name) encryption status is $(osquery.columns.encryption_status)</description>
     <group>it_compliance,</group>
+    <options>no_full_log</options>
   </rule>
 
   <rule id="24135" level="4">
@@ -602,6 +687,7 @@
     <field name="osquery.name">launchd</field>
     <description>osquery: $(osquery.pack) $(osquery.subquery): Running daemon is $(osquery.columns.label) with path $(osquery.columns.program) and username $(osquery.columns.username)</description>
     <group>it_compliance,</group>
+    <options>no_full_log</options>
   </rule>
 
   <rule id="24136" level="4">
@@ -609,6 +695,7 @@
     <field name="osquery.name">iptables</field>
     <description>osquery: $(osquery.pack) $(osquery.subquery): Iptable source ip $(osquery.columns.src_ip) with policy $(osquery.columns.policy) and target $(osquery.columns.target) has a packet count of $(osquery.columns.packets)</description>
     <group>it_compliance,</group>
+    <options>no_full_log</options>
   </rule>
 
   <rule id="24137" level="4">
@@ -617,6 +704,7 @@
     <field name="osquery.columns.enabled">1</field>
     <description>osquery: $(osquery.pack) $(osquery.subquery): Integrity protection flag $(osquery.columns.config_flag) is enabled</description>
     <group>it_compliance,</group>
+    <options>no_full_log</options>
   </rule>
 
   <rule id="24138" level="4">
@@ -625,6 +713,7 @@
     <field name="osquery.columns.enabled">0</field>
     <description>osquery: $(osquery.pack) $(osquery.subquery): Integrity protection flag $(osquery.columns.config_flag) is disabled</description>
     <group>it_compliance,</group>
+    <options>no_full_log</options>
   </rule>
 
   <rule id="24200" level="4">
@@ -632,6 +721,7 @@
     <field name="osquery.pack">^osx-attacks$</field>
     <description>osquery: $(osquery.pack) $(osquery.subquery): $(osquery.columns.name) malware process detected</description>
     <group>osx_attacks,</group>
+    <options>no_full_log</options>
   </rule>
 
   <rule id="24201" level="4">
@@ -639,6 +729,7 @@
     <field name="osquery.name">Leverage-A_2</field>
     <description>osquery: $(osquery.pack) $(osquery.subquery): Leverage-A_2 malware detected on path $(osquery.columns.path)</description>
     <group>osx_attacks,</group>
+    <options>no_full_log</options>
   </rule>
 
   <rule id="24202" level="4">
@@ -646,6 +737,7 @@
     <field name="osquery.name">iWorkServ</field>
     <description>osquery: $(osquery.pack) $(osquery.subquery): OSX iWorkServ malware detected on path $(osquery.columns.path)</description>
     <group>osx_attacks,</group>
+    <options>no_full_log</options>
   </rule>
 
   <rule id="24203" level="4">
@@ -653,6 +745,7 @@
     <field name="osquery.name">iWorm_1</field>
     <description>osquery: $(osquery.pack) $(osquery.subquery): iWorm_1 malware detected on path $(osquery.columns.path)</description>
     <group>osx_attacks,</group>
+    <options>no_full_log</options>
   </rule>
 
   <rule id="24204" level="4">
@@ -660,6 +753,7 @@
     <field name="osquery.name">HackingTeam_Mac_RAT1</field>
     <description>osquery: $(osquery.pack) $(osquery.subquery): HackingTeam Mac RAT1 malware detected on path $(osquery.columns.path)</description>
     <group>osx_attacks,</group>
+    <options>no_full_log</options>
   </rule>
 
   <rule id="24205" level="4">
@@ -667,6 +761,7 @@
     <field name="osquery.name">HackingTeam_Mac_RAT2</field>
     <description>osquery: $(osquery.pack) $(osquery.subquery): HackingTeam Mac RAT2 malware detected on path $(osquery.columns.path)</description>
     <group>osx_attacks,</group>
+    <options>no_full_log</options>
   </rule>
 
   <rule id="24206" level="4">
@@ -674,6 +769,7 @@
     <field name="osquery.name">HackingTeam_Mac_Persistence</field>
     <description>osquery: $(osquery.pack) $(osquery.subquery): HackingTeam Mac Persistence malware detected on path $(osquery.columns.path)</description>
     <group>osx_attacks,</group>
+    <options>no_full_log</options>
   </rule>
 
   <rule id="24207" level="4">
@@ -681,6 +777,7 @@
     <field name="osquery.name">Keranger_2</field>
     <description>osquery: $(osquery.pack) $(osquery.subquery): Keranger malware detected on path $(osquery.columns.path)</description>
     <group>osx_attacks,</group>
+    <options>no_full_log</options>
   </rule>
 
   <rule id="24208" level="4">
@@ -688,6 +785,7 @@
     <field name="osquery.name">OSX_Backdoor_Mokes</field>
     <description>osquery: $(osquery.pack) $(osquery.subquery): OSX Backdoor Mokes malware detected on path $(osquery.columns.path)</description>
     <group>osx_attacks,</group>
+    <options>no_full_log</options>
   </rule>
 
   <rule id="24209" level="4">
@@ -695,6 +793,7 @@
     <field name="osquery.name">OSX_Komplex</field>
     <description>osquery: $(osquery.pack) $(osquery.subquery): Komplex malware detected on path $(osquery.columns.path)</description>
     <group>osx_attacks,</group>
+    <options>no_full_log</options>
   </rule>
 
   <rule id="24210" level="4">
@@ -702,6 +801,7 @@
     <field name="osquery.name">OceanLotus_dropped_file_1</field>
     <description>osquery: $(osquery.pack) $(osquery.subquery): OceanLotus malware detected on path $(osquery.columns.path)</description>
     <group>osx_attacks,</group>
+    <options>no_full_log</options>
   </rule>
 
   <rule id="24211" level="4">
@@ -709,6 +809,7 @@
     <field name="osquery.name">OSX_DOK_2</field>
     <description>osquery: $(osquery.pack) $(osquery.subquery): OSX/Dok malware detected in certificate $(osquery.columns.common_name)</description>
     <group>osx_attacks,</group>
+    <options>no_full_log</options>
   </rule>
 
   <rule id="24212" level="4">
@@ -716,6 +817,7 @@
     <field name="osquery.name">OSX_DOK_3</field>
     <description>osquery: $(osquery.pack) $(osquery.subquery): OSX/Dok malware detected on path $(osquery.columns.path)</description>
     <group>osx_attacks,</group>
+    <options>no_full_log</options>
   </rule>
 
   <rule id="24213" level="4">
@@ -723,6 +825,7 @@
     <field name="osquery.name">OSX_Snake</field>
     <description>osquery: $(osquery.pack) $(osquery.subquery): Snake malware detected on path $(osquery.columns.path)</description>
     <group>osx_attacks,</group>
+    <options>no_full_log</options>
   </rule>
 
   <rule id="24214" level="4">
@@ -730,6 +833,7 @@
     <field name="osquery.name">OSX_Proton_Files</field>
     <description>osquery: $(osquery.pack) $(osquery.subquery): Proton malware detected on path $(osquery.columns.path)</description>
     <group>osx_attacks,</group>
+    <options>no_full_log</options>
   </rule>
 
   <rule id="24215" level="4">
@@ -737,6 +841,7 @@
     <field name="osquery.name">OSX_MaMi_DNS_Servers</field>
     <description>osquery: $(osquery.pack) $(osquery.subquery): MaMi malware detected, infected DNS address $(osquery.columns.address)</description>
     <group>osx_attacks,</group>
+    <options>no_full_log</options>
   </rule>
 
   <rule id="24216" level="4">
@@ -744,6 +849,7 @@
     <field name="osquery.name">OSX_MaMi_Certificate</field>
     <description>osquery: $(osquery.pack) $(osquery.subquery): MaMi malware detected in certificate $(osquery.columns.common_name)</description>
     <group>osx_attacks,</group>
+    <options>no_full_log</options>
   </rule>
 
   <rule id="24217" level="4">
@@ -751,6 +857,7 @@
     <field name="osquery.name">OSX_ColdRoot_RAT_Files</field>
     <description>osquery: $(osquery.pack) $(osquery.subquery): Coldroot RAT malware detected on path $(osquery.columns.path)</description>
     <group>osx_attacks,</group>
+    <options>no_full_log</options>
   </rule>
 
   <rule id="24218" level="4">
@@ -758,6 +865,7 @@
     <field name="osquery.name">OSX_Dummy_Files</field>
     <description>osquery: $(osquery.pack) $(osquery.subquery): OSX Dummy malware detected on path $(osquery.columns.path)</description>
     <group>osx_attacks,</group>
+    <options>no_full_log</options>
   </rule>
 
   <rule id="24300" level="4">
@@ -765,6 +873,7 @@
     <field name="osquery.pack">^vuln-management$</field>
     <description>osquery: $(osquery.pack) query result</description>
     <group>vuln_management,</group>
+    <options>no_full_log</options>
   </rule>
 
   <rule id="24301" level="4">
@@ -772,6 +881,7 @@
     <field name="osquery.name">kernel_info</field>
     <description>osquery: $(osquery.pack) $(osquery.subquery): Kernel version is $(osquery.columns.version) with path $(osquery.columns.path) and kernel device identifier $(osquery.columns.device) </description>
     <group>vuln_management,</group>
+    <options>no_full_log</options>
   </rule>
 
   <rule id="24302" level="4">
@@ -779,6 +889,7 @@
     <field name="osquery.name">os_version</field>
     <description>osquery: $(osquery.pack) $(osquery.subquery): OS $(osquery.columns.name) $(osquery.columns.version) with minor $(osquery.columns.minor) and major $(osquery.columns.major)</description>
     <group>vuln_management,</group>
+    <options>no_full_log</options>
   </rule>
 
   <rule id="24303" level="4">
@@ -786,6 +897,7 @@
     <field name="osquery.name">kextstat</field>
     <description>osquery: $(osquery.pack) $(osquery.subquery): Kernel module $(osquery.columns.name) version $(osquery.columns.version)</description>
     <group>vuln_management,</group>
+    <options>no_full_log</options>
   </rule>
 
   <rule id="24304" level="4">
@@ -794,6 +906,7 @@
     <field name="osquery.columns.status">Live</field>
     <description>osquery: $(osquery.pack) $(osquery.subquery): OS Kernel module $(osquery.columns.name) is enabled and used by $(osquery.columns.used_by)</description>
     <group>vuln_management,</group>
+    <options>no_full_log</options>
   </rule>
 
   <rule id="24305" level="4">
@@ -801,6 +914,7 @@
     <field name="osquery.name">installed_applications</field>
     <description>osquery: $(osquery.pack) $(osquery.subquery): OS X Application $(osquery.columns.name) version $(osquery.columns.bundle_version) is installed</description>
     <group>vuln_management,</group>
+    <options>no_full_log</options>
   </rule>
 
   <rule id="24306" level="4">
@@ -809,6 +923,7 @@
     <field name="osquery.columns.disabled">0</field>
     <description>osquery: $(osquery.pack) $(osquery.subquery): Browser plugin $(osquery.columns.name) is enabled</description>
     <group>vuln_management,</group>
+    <options>no_full_log</options>
   </rule>
 
   <rule id="24307" level="4">
@@ -817,6 +932,7 @@
     <field name="osquery.columns.disabled">1</field>
     <description>osquery: $(osquery.pack) $(osquery.subquery): Browser plugin $(osquery.columns.name) is disabled</description>
     <group>vuln_management,</group>
+    <options>no_full_log</options>
   </rule>
 
   <rule id="24308" level="4">
@@ -824,6 +940,7 @@
     <field name="osquery.name">safari_extensions</field>
     <description>osquery: $(osquery.pack) $(osquery.subquery): Safari extension $(osquery.columns.name) version is $(osquery.columns.version) and the user that owns it is $(osquery.columns.uid)</description>
     <group>vuln_management,</group>
+    <options>no_full_log</options>
   </rule>
 
   <rule id="24309" level="4">
@@ -831,6 +948,7 @@
     <field name="osquery.name">opera_extensions</field>
     <description>osquery: $(osquery.pack) $(osquery.subquery): Opera extension $(osquery.columns.name) version is $(osquery.columns.version) and the user that owns it is $(osquery.columns.uid)</description>
     <group>vuln_management,</group>
+    <options>no_full_log</options>
   </rule>
 
   <rule id="24310" level="4">
@@ -838,6 +956,7 @@
     <field name="osquery.name">chrome_extensions</field>
     <description>osquery: $(osquery.pack) $(osquery.subquery): Chrome extension $(osquery.columns.name) version is $(osquery.columns.version) and the user that owns it is $(osquery.columns.uid)</description>
     <group>vuln_management,</group>
+    <options>no_full_log</options>
   </rule>
 
   <rule id="24311" level="4">
@@ -845,6 +964,7 @@
     <field name="osquery.name">firefox_addons</field>
     <description>osquery: $(osquery.pack) $(osquery.subquery): Firefox addon $(osquery.columns.name) type is $(osquery.columns.type) and the user that owns it is $(osquery.columns.uid)</description>
     <group>vuln_management,</group>
+    <options>no_full_log</options>
   </rule>
 
   <rule id="24312" level="4">
@@ -852,6 +972,7 @@
     <field name="osquery.name">homebrew_packages</field>
     <description>osquery: $(osquery.pack) $(osquery.subquery): Homebrew package $(osquery.columns.name) version is $(osquery.columns.version)</description>
     <group>vuln_management,</group>
+    <options>no_full_log</options>
   </rule>
 
   <rule id="24313" level="4">
@@ -859,6 +980,7 @@
     <field name="osquery.name">package_receipts</field>
     <description>osquery: $(osquery.pack) $(osquery.subquery): OSX package recepit $(osquery.columns.package_id) $(osquery.columns.version) is installed on the system</description>
     <group>vuln_management,</group>
+    <options>no_full_log</options>
   </rule>
 
   <rule id="24314" level="4">
@@ -866,6 +988,7 @@
     <field name="osquery.name">deb_packages</field>
     <description>osquery: $(osquery.pack) $(osquery.subquery): Package name $(osquery.columns.name), version $(osquery.columns.version), revision $(osquery.columns.revision),size $(osquery.columns.size) bytes</description>
     <group>vuln_management,</group>
+    <options>no_full_log</options>
   </rule>
 
   <rule id="24315" level="4">
@@ -873,6 +996,7 @@
     <field name="osquery.name">apt_sources</field>
     <description>osquery: $(osquery.pack) $(osquery.subquery): Repository name $(osquery.columns.name), version $(osquery.columns.version), source $(osquery.columns.source),release name $(osquery.columns.release)</description>
     <group>vuln_management,</group>
+    <options>no_full_log</options>
   </rule>
 
   <rule id="24316" level="4">
@@ -880,6 +1004,7 @@
     <field name="osquery.name">portage_packages</field>
     <description>osquery: $(osquery.pack) $(osquery.subquery): Portage package $(osquery.columns.package) $(osquery.columns.version) USE flags $(osquery.columns.flags)</description>
     <group>vuln_management,</group>
+    <options>no_full_log</options>
   </rule>
 
   <rule id="24317" level="4">
@@ -887,6 +1012,7 @@
     <field name="osquery.name">rpm_packages</field>
     <description>osquery: $(osquery.pack) $(osquery.subquery): RPM package $(osquery.columns.name) version $(osquery.columns.version) is installed on the system</description>
     <group>vuln_management,</group>
+    <options>no_full_log</options>
   </rule>
 
   <rule id="24318" level="4">
@@ -894,6 +1020,7 @@
     <field name="osquery.name">unauthenticated_sparkle_feeds</field>
     <description>osquery: $(osquery.pack) $(osquery.subquery): Sparkle bundle $(osquery.columns.name) is unauthenticated</description>
     <group>vuln_management,</group>
+    <options>no_full_log</options>
   </rule>
 
   <rule id="24319" level="4">
@@ -901,6 +1028,7 @@
     <field name="osquery.name">backdoored_python_packages</field>
     <description>osquery: $(osquery.pack) $(osquery.subquery): Python package $(osquery.columns.package_name) is backdoored</description>
     <group>vuln_management,</group>
+    <options>no_full_log</options>
   </rule>
 
   <rule id="24400" level="4">
@@ -908,6 +1036,7 @@
     <field name="osquery.pack">^hardware-monitoring$</field>
     <description>osquery: $(osquery.pack) query result</description>
     <group>hardware_monitoring,</group>
+    <options>no_full_log</options>
   </rule>
 
   <rule id="24401" level="4">
@@ -915,6 +1044,7 @@
     <field name="osquery.name">acpi_tables</field>
     <description>osquery: $(osquery.pack) $(osquery.subquery): ACPI table $(osquery.columns.name) size is $(osquery.columns.size)</description>
     <group>hardware_monitoring,</group>
+    <options>no_full_log</options>
   </rule>
 
   <rule id="24402" level="4">
@@ -922,6 +1052,7 @@
     <field name="osquery.name">cpuid</field>
     <description>osquery: $(osquery.pack) $(osquery.subquery): CPU feature $(osquery.columns.feature) and value $(osquery.columns.value)</description>
     <group>hardware_monitoring,</group>
+    <options>no_full_log</options>
   </rule>
 
   <rule id="24403" level="4">
@@ -929,6 +1060,7 @@
     <field name="osquery.name">smbios_tables</field>
     <description>osquery: $(osquery.pack) $(osquery.subquery): ACPI table $(osquery.columns.name) size is $(osquery.columns.size)</description>
     <group>hardware_monitoring,</group>
+    <options>no_full_log</options>
   </rule>
 
   <rule id="24404" level="4">
@@ -936,6 +1068,7 @@
     <field name="osquery.name">nvram</field>
     <description>osquery: $(osquery.pack) $(osquery.subquery): NVRAM variable $(osquery.columns.name) value $(osquery.columns.value)</description>
     <group>hardware_monitoring,</group>
+    <options>no_full_log</options>
   </rule>
 
   <rule id="24405" level="4">
@@ -943,6 +1076,7 @@
     <field name="osquery.name">pci_devices</field>
     <description>osquery: $(osquery.pack) $(osquery.subquery): PCI device $(osquery.columns.model) with vendor $(osquery.columns.vendor) is active</description>
     <group>hardware_monitoring,</group>
+    <options>no_full_log</options>
   </rule>
 
   <rule id="24406" level="4">
@@ -950,6 +1084,7 @@
     <field name="osquery.name">fan_speeds</field>
     <description>osquery: $(osquery.pack) $(osquery.subquery): Fan $(osquery.columns.name) actual speed is $(osquery.columns.actual) rpm</description>
     <group>hardware_monitoring,</group>
+    <options>no_full_log</options>
   </rule>
 
   <rule id="24407" level="4">
@@ -957,6 +1092,7 @@
     <field name="osquery.name">temperatures</field>
     <description>osquery: $(osquery.pack) $(osquery.subquery): Temperature sensor $(osquery.columns.name) is at $(osquery.columns.celsius) celsius</description>
     <group>hardware_monitoring,</group>
+    <options>no_full_log</options>
   </rule>
 
   <rule id="24408" level="4">
@@ -964,6 +1100,7 @@
     <field name="osquery.name">usb_devices</field>
     <description>osquery: $(osquery.pack) $(osquery.subquery): USB device from vendor $(osquery.columns.vendor) is attached to port $(osquery.columns.usb_port)</description>
     <group>hardware_monitoring,</group>
+    <options>no_full_log</options>
   </rule>
 
   <rule id="24409" level="4">
@@ -971,6 +1108,7 @@
     <field name="osquery.name">hardware_events</field>
     <description>osquery: $(osquery.pack) $(osquery.subquery): Hardware device $(osquery.columns.model) triggered action $(osquery.columns.action)</description>
     <group>hardware_monitoring,</group>
+    <options>no_full_log</options>
   </rule>
 
   <rule id="24410" level="4">
@@ -978,6 +1116,7 @@
     <field name="osquery.name">darwin_kernel_system_controls</field>
     <description>osquery: $(osquery.pack) $(osquery.subquery): System control $(osquery.columns.name) oid is $(osquery.columns.oid)</description>
     <group>hardware_monitoring,</group>
+    <options>no_full_log</options>
   </rule>
 
   <rule id="24411" level="4">
@@ -985,6 +1124,7 @@
     <field name="osquery.name">iokit_devicetree</field>
     <description>osquery: $(osquery.pack) $(osquery.subquery): IOKit device $(osquery.columns.name) busy state is $(osquery.columns.busy_state)</description>
     <group>hardware_monitoring,</group>
+    <options>no_full_log</options>
   </rule>
 
   <rule id="24412" level="4">
@@ -992,6 +1132,7 @@
     <field name="osquery.name">efi_file_hashes</field>
     <description>osquery: $(osquery.pack) $(osquery.subquery): EFI file $(osquery.columns.path) sha256 $(osquery.columns.sha256)</description>
     <group>hardware_monitoring,</group>
+    <options>no_full_log</options>
   </rule>
 
   <rule id="24413" level="4">
@@ -999,6 +1140,7 @@
     <field name="osquery.name">kernel_extensions</field>
     <description>osquery: $(osquery.pack) $(osquery.subquery): OS X Kernel extension $(osquery.columns.name) with version $(osquery.columns.version) is loaded</description>
     <group>hardware_monitoring,</group>
+    <options>no_full_log</options>
   </rule>
 
   <rule id="24414" level="4">
@@ -1007,6 +1149,7 @@
     <field name="osquery.columns.status">Live</field>
     <description>osquery: $(osquery.pack) $(osquery.subquery): OS Kernel module $(osquery.columns.name) is enabled and used by $(osquery.columns.used_by)</description>
     <group>hardware_monitoring,</group>
+    <options>no_full_log</options>
   </rule>
 
   <rule id="24415" level="4">
@@ -1014,6 +1157,7 @@
     <field name="osquery.name">windows_drivers</field>
     <description>osquery: $(osquery.pack) $(osquery.subquery): Windows device $(osquery.columns.device_name) driver is being used</description>
     <group>hardware_monitoring,</group>
+    <options>no_full_log</options>
   </rule>
 
   <rule id="24416" level="4">
@@ -1021,6 +1165,7 @@
     <field name="osquery.name">device_nodes</field>
     <description>osquery: $(osquery.pack) $(osquery.subquery): Device $(osquery.columns.path), UID $(osquery.columns.uid), GID $(osquery.columns.gid), type $(osquery.columns.type) </description>
     <group>hardware_monitoring,</group>
+    <options>no_full_log</options>
   </rule>
 
   <rule id="24500" level="4">
@@ -1028,6 +1173,7 @@
     <field name="osquery.pack">^ossec-rootkit$</field>
     <description>osquery: $(osquery.pack) $(osquery.subquery): Ossec rootkit file $(osquery.columns.path) detected</description>
     <group>ossec_rootkit,</group>
+    <options>no_full_log</options>
   </rule>
 
   <rule id="24600" level="4">
@@ -1035,6 +1181,7 @@
     <field name="osquery.pack">^windows-hardening$</field>
     <description>osquery: $(osquery.pack) $(osquery.subquery): Windows Registry key $(osquery.columns.key) value is $(osquery.columns.data)</description>
     <group>windows_hardening,</group>
+    <options>no_full_log</options>
   </rule>
 
   <rule id="24700" level="4">
@@ -1042,6 +1189,7 @@
     <field name="osquery.pack">^windows-attacks$</field>
     <description>osquery: $(osquery.pack) query result</description>
     <group>windows_attacks,</group>
+    <options>no_full_log</options>
   </rule>
 
   <rule id="24701" level="4">
@@ -1049,6 +1197,7 @@
     <field name="osquery.name">CCleaner_Trojan.Floxif</field>
     <description>osquery: $(osquery.pack) $(osquery.subquery): CCleaner Trojan Floxif detected on registry path $(osquery.columns.path)</description>
     <group>windows_attacks,</group>
+    <options>no_full_log</options>
   </rule>
 
   <rule id="24702" level="4">
@@ -1056,6 +1205,7 @@
     <field name="osquery.name">CCleaner_Trojan_stage2.Floxif</field>
     <description>osquery: $(osquery.pack) $(osquery.subquery): CCleaner Trojan Floxif detected on service $(osquery.columns.name) for user $(osquery.columns.user_account)</description>
     <group>windows_attacks,</group>
+    <options>no_full_log</options>
   </rule>
 
   <rule id="24703" level="4">
@@ -1063,6 +1213,7 @@
     <field name="osquery.name">Winsecurity_info_1</field>
     <description>osquery: $(osquery.pack) $(osquery.subquery): Winsecurity.info Scam detected on path $(osquery.columns.install_location)</description>
     <group>windows_attacks,</group>
+    <options>no_full_log</options>
   </rule>
 
   <rule id="24704" level="4">
@@ -1070,6 +1221,7 @@
     <field name="osquery.name">Winsecurity_info_2</field>
     <description>osquery: $(osquery.pack) $(osquery.subquery): Winsecurity.info Scam detected on Chrome extension $(osquery.columns.name)</description>
     <group>windows_attacks,</group>
+    <options>no_full_log</options>
   </rule>
 
   <rule id="24705" level="4">
@@ -1077,6 +1229,7 @@
     <field name="osquery.name">unTabs_1</field>
     <description>osquery: $(osquery.pack) $(osquery.subquery): unTabs Browser extension malware detected on path $(osquery.columns.install_location)</description>
     <group>windows_attacks,</group>
+    <options>no_full_log</options>
   </rule>
 
   <rule id="24706" level="4">
@@ -1084,6 +1237,7 @@
     <field name="osquery.name">unTabs_2</field>
     <description>osquery: $(osquery.pack) $(osquery.subquery): unTabs Chrome extension malware detected $(osquery.columns.name)</description>
     <group>windows_attacks,</group>
+    <options>no_full_log</options>
   </rule>
 
   <rule id="24707" level="4">
@@ -1091,6 +1245,7 @@
     <field name="osquery.name">StickyKeys_File_Replace_Backdoor</field>
     <description>osquery: $(osquery.pack) $(osquery.subquery): Sticky file key backdoor detected for program $(osquery.columns.path)</description>
     <group>windows_attacks,</group>
+    <options>no_full_log</options>
   </rule>
 
   <rule id="24708" level="4">
@@ -1098,6 +1253,7 @@
     <field name="osquery.name">StickyKeys_Registry_Backdoor</field>
     <description>osquery: $(osquery.pack) $(osquery.subquery): Sticky registry key backdoor detected for key $(osquery.columns.path)</description>
     <group>windows_attacks,</group>
+    <options>no_full_log</options>
   </rule>
 
   <rule id="24709" level="4">
@@ -1105,6 +1261,7 @@
     <field name="osquery.name">conhost.exe_incorrect_path</field>
     <description>osquery: $(osquery.pack) $(osquery.subquery): conhost.exe process masquerading detected, path is $(osquery.columns.path)</description>
     <group>windows_attacks,</group>
+    <options>no_full_log</options>
   </rule>
 
   <rule id="24710" level="4">
@@ -1112,6 +1269,7 @@
     <field name="osquery.name">dllhost.exe_incorrect_path</field>
     <description>osquery: $(osquery.pack) $(osquery.subquery): dllhost.exe process masquerading detected, path is $(osquery.columns.path)</description>
     <group>windows_attacks,</group>
+    <options>no_full_log</options>
   </rule>
 
   <rule id="24711" level="4">
@@ -1119,6 +1277,7 @@
     <field name="osquery.name">lsass.exe_incorrect_path</field>
     <description>osquery: $(osquery.pack) $(osquery.subquery): lsass.exe process masquerading detected, path is $(osquery.columns.path)</description>
     <group>windows_attacks,</group>
+    <options>no_full_log</options>
   </rule>
 
   <rule id="24712" level="4">
@@ -1126,6 +1285,7 @@
     <field name="osquery.name">services.exe_incorrect_parent_process</field>
     <description>osquery: $(osquery.pack) $(osquery.subquery): services.exe process masquerading detected, the parent process is incorrect</description>
     <group>windows_attacks,</group>
+    <options>no_full_log</options>
   </rule>
 
   <rule id="24713" level="4">
@@ -1133,6 +1293,7 @@
     <field name="osquery.name">svchost.exe_incorrect_path</field>
     <description>osquery: $(osquery.pack) $(osquery.subquery): svchost.exe process masquerading detected, path $(osquery.columns.path) is incorrect</description>
     <group>windows_attacks,</group>
+    <options>no_full_log</options>
   </rule>
 
   <rule id="24714" level="4">
@@ -1140,12 +1301,14 @@
     <field name="osquery.name">svchost.exe_incorrect_parent_process</field>
     <description>osquery: $(osquery.pack) $(osquery.subquery): svchost.exe process masquerading detected, the parent process is incorrect</description>
     <group>windows_attacks,</group>
+    <options>no_full_log</options>
   </rule>
 
   <rule id="24800" level="4">
     <if_sid>24010</if_sid>
     <field name="osquery.pack">^unwanted-chrome-extensions$</field>
     <description>osquery: $(osquery.pack) query result</description>
+    <options>no_full_log</options>
   </rule>
 
   <rule id="24801" level="4">
@@ -1153,6 +1316,7 @@
     <field name="osquery.name">BetternetVPN</field>
     <description>osquery: $(osquery.pack) $(osquery.subquery): BetternetVPN Chrome extension malware detected</description>
     <group>unwanted_chrome,</group>
+    <options>no_full_log</options>
   </rule>
 
   <rule id="24802" level="4">
@@ -1160,6 +1324,7 @@
     <field name="osquery.name">Chrometana</field>
     <description>osquery: $(osquery.pack) $(osquery.subquery): Chrometana Chrome extension malware detected</description>
     <group>unwanted_chrome,</group>
+    <options>no_full_log</options>
   </rule>
 
   <rule id="24803" level="4">
@@ -1167,6 +1332,7 @@
     <field name="osquery.name">CopyFish</field>
     <description>osquery: $(osquery.pack) $(osquery.subquery): CopyFish Chrome extension malware detected</description>
     <group>unwanted_chrome,</group>
+    <options>no_full_log</options>
   </rule>
 
   <rule id="24804" level="4">
@@ -1174,6 +1340,7 @@
     <field name="osquery.name">Giphy</field>
     <description>osquery: $(osquery.pack) $(osquery.subquery): Giphy Chrome extension malware detected</description>
     <group>unwanted_chrome,</group>
+    <options>no_full_log</options>
   </rule>
 
   <rule id="24805" level="4">
@@ -1181,6 +1348,7 @@
     <field name="osquery.name">HolaVPN</field>
     <description>osquery: $(osquery.pack) $(osquery.subquery): HolaVPN Chrome extension malware detected</description>
     <group>unwanted_chrome,</group>
+    <options>no_full_log</options>
   </rule>
 
   <rule id="24806" level="4">
@@ -1188,6 +1356,7 @@
     <field name="osquery.name">InfinityNewTab</field>
     <description>osquery: $(osquery.pack) $(osquery.subquery): InfinityNewTab Chrome extension malware detected</description>
     <group>unwanted_chrome,</group>
+    <options>no_full_log</options>
   </rule>
 
   <rule id="24807" level="4">
@@ -1195,6 +1364,7 @@
     <field name="osquery.name">SocialFixer</field>
     <description>osquery: $(osquery.pack) $(osquery.subquery): SocialFixer Chrome extension malware detected</description>
     <group>unwanted_chrome,</group>
+    <options>no_full_log</options>
   </rule>
 
   <rule id="24808" level="4">
@@ -1202,6 +1372,7 @@
     <field name="osquery.name">TouchVPN</field>
     <description>osquery: $(osquery.pack) $(osquery.subquery): TouchVPN Chrome extension malware detected</description>
     <group>unwanted_chrome,</group>
+    <options>no_full_log</options>
   </rule>
 
   <rule id="24809" level="4">
@@ -1209,6 +1380,7 @@
     <field name="osquery.name">WebDeveloper</field>
     <description>osquery: $(osquery.pack) $(osquery.subquery): WebDeveloper Chrome extension malware detected</description>
     <group>unwanted_chrome,</group>
+    <options>no_full_log</options>
   </rule>
 
   <rule id="24810" level="4">
@@ -1216,6 +1388,7 @@
     <field name="osquery.name">WebPaint</field>
     <description>osquery: $(osquery.pack) $(osquery.subquery): WebPaint Chrome extension malware detected</description>
     <group>unwanted_chrome,</group>
+    <options>no_full_log</options>
   </rule>
 
   <rule id="24811" level="4">
@@ -1223,6 +1396,7 @@
     <field name="osquery.name">MacOSInstallCore</field>
     <description>osquery: $(osquery.pack) $(osquery.subquery): MacOSInstallCore Chrome extension malware detected</description>
     <group>unwanted_chrome,</group>
+    <options>no_full_log</options>
   </rule>
 
 </group>

--- a/rules/0555-azure_rules.xml
+++ b/rules/0555-azure_rules.xml
@@ -27,41 +27,48 @@ ID: 87800-87899
     <decoded_as>json</decoded_as>
     <field name="azure_tag">azure-log-analytics</field>
     <description>Azure: Log analytics</description>
+    <options>no_full_log</options>
   </rule>
 
   <rule id="87802" level="3">
     <decoded_as>json</decoded_as>
     <field name="azure_tag">azure-ad-graph</field>
     <description>Azure: AD $(activity)</description>
+    <options>no_full_log</options>
   </rule>
 
   <rule id="87803" level="3">
     <decoded_as>json</decoded_as>
     <field name="azure_tag">azure-storage</field>
     <description>Azure: Storage</description>
+    <options>no_full_log</options>
   </rule>
 
   <rule id="87804" level="3">
     <decoded_as>azure-storage</decoded_as>
     <description>Azure: Storage</description>
+    <options>no_full_log</options>
   </rule>
 
   <rule id="87810" level="3">
     <if_sid>87801</if_sid>
     <field name="Type">AzureActivity</field>
     <description>Azure: Log analytics activity</description>
+    <options>no_full_log</options>
   </rule>
 
   <rule id="87811" level="3">
     <if_sid>87810</if_sid>
     <field name="OperationName">\.+</field>
     <description>Azure: Log analytics: $(OperationName)</description>
+    <options>no_full_log</options>
   </rule>
 
   <rule id="87813" level="3">
     <if_sid>87803</if_sid>
     <field name="operationName">\.+</field>
     <description>Azure: Storage: $(OperationName)</description>
+    <options>no_full_log</options>
   </rule>
 
 </group>


### PR DESCRIPTION
Related issue https://github.com/wazuh/wazuh/issues/3513 

**Description**

- Added "no_full_log" for AWS rules
- Added "no_full_log" for Suricata rules
- Added "no_full_log" for Virustotal rules
- Added "no_full_log" for OwnCloud rules
- Added "no_full_log" for Vuls rules
- Added "no_full_log" for CIS-CAT rules
- Added "no_full_log" for Vulnerability rules
- Added "no_full_log" for MySQL audit rules
- Added "no_full_log" for OSQuery rules
- Added "no_full_log" for Azure rules

Those modules are expected to generate a JSON inside the `full_log` property which is in conflict with our `full_log` field in Elasticsearch.

**Example**

Here is an example AWS:

![image](https://user-images.githubusercontent.com/8860227/59591619-9bae0500-90ee-11e9-9c8a-df54654edb17.png)



