### PR TITLE
Adding new sysmon rules 431

### DIFF
--- a/rules/0330-sysmon_rules.xml
+++ b/rules/0330-sysmon_rules.xml
@@ -10,148 +10,106 @@
     <rule id="184665" level="0">
         <if_sid>18100</if_sid>
         <match>Microsoft-Windows-Sysmon/Operational: INFORMATION(1)</match>
-        <description>Sysmon - Event 1: Process creation</description>
+        <description>Sysmon - Event 1</description>
         <group>sysmon_event1,</group>
     </rule>
 
     <rule id="185000" level="0">
         <if_sid>18100</if_sid>
         <match>Microsoft-Windows-Sysmon/Operational: INFORMATION(2)</match>
-        <description>Sysmon - Event 2: A process changed a file creation time</description>
+        <description>Sysmon - Event 2</description>
         <group>sysmon_event2,</group>
     </rule>
 
     <rule id="185001" level="0">
         <if_sid>18100</if_sid>
         <match>Microsoft-Windows-Sysmon/Operational: INFORMATION(3)</match>
-        <description>Sysmon - Event 3: Network connection</description>
+        <description>Sysmon - Event 3</description>
         <group>sysmon_event3,</group>
     </rule>
 
     <rule id="185002" level="0">
         <if_sid>18100</if_sid>
         <match>Microsoft-Windows-Sysmon/Operational: INFORMATION(4)</match>
-        <description>Sysmon - Event 4: Sysmon service state changed</description>
+        <description>Sysmon - Event 4</description>
         <group>sysmon_event4,</group>
     </rule>
 
     <rule id="185003" level="0">
         <if_sid>18100</if_sid>
         <match>Microsoft-Windows-Sysmon/Operational: INFORMATION(5)</match>
-        <description>Sysmon - Event 5: Process terminated</description>
+        <description>Sysmon - Event 5</description>
         <group>sysmon_event5,</group>
     </rule>
 
     <rule id="185004" level="0">
         <if_sid>18100</if_sid>
         <match>Microsoft-Windows-Sysmon/Operational: INFORMATION(6)</match>
-        <description>Sysmon - Event 6: Driver loaded</description>
+        <description>Sysmon - Event 6</description>
         <group>sysmon_event6,</group>
     </rule>
 
     <rule id="185005" level="0">
         <if_sid>18100</if_sid>
         <match>Microsoft-Windows-Sysmon/Operational: INFORMATION(7)</match>
-        <description>Sysmon - Event 7: Image loaded</description>
+        <description>Sysmon - Event 7</description>
         <group>sysmon_event7,</group>
     </rule>
 
     <rule id="185006" level="0">
         <if_sid>18100</if_sid>
         <match>Microsoft-Windows-Sysmon/Operational: INFORMATION(8)</match>
-        <description>Sysmon - Event 8: CreateRemoteThread</description>
+        <description>Sysmon - Event 8</description>
         <group>sysmon_event8,</group>
     </rule>
 
     <rule id="185007" level="0">
         <if_sid>18100</if_sid>
         <match>Microsoft-Windows-Sysmon/Operational: INFORMATION(9)</match>
-        <description>Sysmon - Event 9: RawAccessRead</description>
+        <description>Sysmon - Event 9</description>
         <group>sysmon_event9,</group>
     </rule>
 
     <rule id="185008" level="0">
         <if_sid>18101</if_sid>
         <match>Microsoft-Windows-Sysmon/Operational: INFORMATION(10)</match>
-        <description>Sysmon - Event 10: ProcessAccess</description>
+        <description>Sysmon - Event 10</description>
         <group>sysmon_event_10,</group>
     </rule>
 
     <rule id="185009" level="0">
         <if_sid>18100</if_sid>
         <match>Microsoft-Windows-Sysmon/Operational: INFORMATION(11)</match>
-        <description>Sysmon - Event 11: FileCreate</description>
+        <description>Sysmon - Event 11</description>
         <group>sysmon_event_11,</group>
     </rule>
 
     <rule id="185010" level="0">
         <if_sid>18101</if_sid>
         <match>Microsoft-Windows-Sysmon/Operational: INFORMATION(12)</match>
-        <description>Sysmon - Event 12: RegistryEven (Object create and delete)</description>
+        <description>Sysmon - Event 12</description>
         <group>sysmon_event_12,</group>
     </rule>
 
     <rule id="185011" level="0">
         <if_sid>18101</if_sid>
         <match>Microsoft-Windows-Sysmon/Operational: INFORMATION(13)</match>
-        <description>Sysmon - Event 13: RegistryEvent (Value Set)</description>
+        <description>Sysmon - Event 13</description>
         <group>sysmon_event_13,</group>
     </rule>
 
     <rule id="185012" level="0">
         <if_sid>18101</if_sid>
         <match>Microsoft-Windows-Sysmon/Operational: INFORMATION(14)</match>
-        <description>Sysmon - Event 14: RegistryEvent (Key and Value Rename)</description>
+        <description>Sysmon - Event 14</description>
         <group>sysmon_event_14,</group>
     </rule>
 
     <rule id="185013" level="0">
         <if_sid>18100</if_sid>
         <match>Microsoft-Windows-Sysmon/Operational: INFORMATION(15)</match>
-        <description>Sysmon - Event 15: FileCreateStreamHash</description>
+        <description>Sysmon - Event 15</description>
         <group>sysmon_event_15,</group>
-    </rule>
-
-    <rule id="185014" level="0">
-        <if_sid>18100</if_sid>
-        <match>Microsoft-Windows-Sysmon/Operational: INFORMATION(17)</match>
-        <description>Sysmon - Event 17: PipeEvent (Pipe Created)</description>
-        <group>sysmon_event_17,</group>
-    </rule>
-
-    <rule id="185016" level="0">
-        <if_sid>18100</if_sid>
-        <match>Microsoft-Windows-Sysmon/Operational: INFORMATION(18)</match>
-        <description>Sysmon - Event 18: PipeEvent (Pipe Connected)</description>
-        <group>sysmon_event_18,</group>
-    </rule>
-
-    <rule id="185017" level="0">
-        <if_sid>18100</if_sid>
-        <match>Microsoft-Windows-Sysmon/Operational: INFORMATION(19)</match>
-        <description>Sysmon - Event 19: WmiEvent (WmiEventFilter activity detected)</description>
-        <group>sysmon_event_19,</group>
-    </rule>
-
-    <rule id="185018" level="0">
-        <if_sid>18100</if_sid>
-        <match>Microsoft-Windows-Sysmon/Operational: INFORMATION(20)</match>
-        <description>Sysmon - Event 20: WmiEvent (WmiEventConsumer activity detected)</description>
-        <group>sysmon_event_20,</group>
-    </rule>
-
-    <rule id="185019" level="0">
-        <if_sid>18100</if_sid>
-        <match>Microsoft-Windows-Sysmon/Operational: INFORMATION(21)</match>
-        <description>Sysmon - Event 21: WmiEvent (WmiEventConsumerToFilter activity detected)</description>
-        <group>sysmon_event_21,</group>
-    </rule>
-
-    <rule id="185020" level="0">
-        <if_sid>18100</if_sid>
-        <match>Microsoft-Windows-Sysmon/Operational: INFORMATION(22)</match>
-        <description>Sysmon - Event 22: DNSEvent (DNS query)</description>
-        <group>sysmon_event_22,</group>
     </rule>
 
 </group>

--- a/rules/0330-sysmon_rules.xml
+++ b/rules/0330-sysmon_rules.xml
@@ -10,106 +10,148 @@
     <rule id="184665" level="0">
         <if_sid>18100</if_sid>
         <match>Microsoft-Windows-Sysmon/Operational: INFORMATION(1)</match>
-        <description>Sysmon - Event 1</description>
+        <description>Sysmon - Event 1: Process creation</description>
         <group>sysmon_event1,</group>
     </rule>
 
     <rule id="185000" level="0">
         <if_sid>18100</if_sid>
         <match>Microsoft-Windows-Sysmon/Operational: INFORMATION(2)</match>
-        <description>Sysmon - Event 2</description>
+        <description>Sysmon - Event 2: A process changed a file creation time</description>
         <group>sysmon_event2,</group>
     </rule>
 
     <rule id="185001" level="0">
         <if_sid>18100</if_sid>
         <match>Microsoft-Windows-Sysmon/Operational: INFORMATION(3)</match>
-        <description>Sysmon - Event 3</description>
+        <description>Sysmon - Event 3: Network connection</description>
         <group>sysmon_event3,</group>
     </rule>
 
     <rule id="185002" level="0">
         <if_sid>18100</if_sid>
         <match>Microsoft-Windows-Sysmon/Operational: INFORMATION(4)</match>
-        <description>Sysmon - Event 4</description>
+        <description>Sysmon - Event 4: Sysmon service state changed</description>
         <group>sysmon_event4,</group>
     </rule>
 
     <rule id="185003" level="0">
         <if_sid>18100</if_sid>
         <match>Microsoft-Windows-Sysmon/Operational: INFORMATION(5)</match>
-        <description>Sysmon - Event 5</description>
+        <description>Sysmon - Event 5: Process terminated</description>
         <group>sysmon_event5,</group>
     </rule>
 
     <rule id="185004" level="0">
         <if_sid>18100</if_sid>
         <match>Microsoft-Windows-Sysmon/Operational: INFORMATION(6)</match>
-        <description>Sysmon - Event 6</description>
+        <description>Sysmon - Event 6: Driver loaded</description>
         <group>sysmon_event6,</group>
     </rule>
 
     <rule id="185005" level="0">
         <if_sid>18100</if_sid>
         <match>Microsoft-Windows-Sysmon/Operational: INFORMATION(7)</match>
-        <description>Sysmon - Event 7</description>
+        <description>Sysmon - Event 7: Image loaded</description>
         <group>sysmon_event7,</group>
     </rule>
 
     <rule id="185006" level="0">
         <if_sid>18100</if_sid>
         <match>Microsoft-Windows-Sysmon/Operational: INFORMATION(8)</match>
-        <description>Sysmon - Event 8</description>
+        <description>Sysmon - Event 8: CreateRemoteThread</description>
         <group>sysmon_event8,</group>
     </rule>
 
     <rule id="185007" level="0">
         <if_sid>18100</if_sid>
         <match>Microsoft-Windows-Sysmon/Operational: INFORMATION(9)</match>
-        <description>Sysmon - Event 9</description>
+        <description>Sysmon - Event 9: RawAccessRead</description>
         <group>sysmon_event9,</group>
     </rule>
 
     <rule id="185008" level="0">
         <if_sid>18101</if_sid>
         <match>Microsoft-Windows-Sysmon/Operational: INFORMATION(10)</match>
-        <description>Sysmon - Event 10</description>
+        <description>Sysmon - Event 10: ProcessAccess</description>
         <group>sysmon_event_10,</group>
     </rule>
 
     <rule id="185009" level="0">
         <if_sid>18100</if_sid>
         <match>Microsoft-Windows-Sysmon/Operational: INFORMATION(11)</match>
-        <description>Sysmon - Event 11</description>
+        <description>Sysmon - Event 11: FileCreate</description>
         <group>sysmon_event_11,</group>
     </rule>
 
     <rule id="185010" level="0">
         <if_sid>18101</if_sid>
         <match>Microsoft-Windows-Sysmon/Operational: INFORMATION(12)</match>
-        <description>Sysmon - Event 12</description>
+        <description>Sysmon - Event 12: RegistryEven (Object create and delete)</description>
         <group>sysmon_event_12,</group>
     </rule>
 
     <rule id="185011" level="0">
         <if_sid>18101</if_sid>
         <match>Microsoft-Windows-Sysmon/Operational: INFORMATION(13)</match>
-        <description>Sysmon - Event 13</description>
+        <description>Sysmon - Event 13: RegistryEvent (Value Set)</description>
         <group>sysmon_event_13,</group>
     </rule>
 
     <rule id="185012" level="0">
         <if_sid>18101</if_sid>
         <match>Microsoft-Windows-Sysmon/Operational: INFORMATION(14)</match>
-        <description>Sysmon - Event 14</description>
+        <description>Sysmon - Event 14: RegistryEvent (Key and Value Rename)</description>
         <group>sysmon_event_14,</group>
     </rule>
 
     <rule id="185013" level="0">
         <if_sid>18100</if_sid>
         <match>Microsoft-Windows-Sysmon/Operational: INFORMATION(15)</match>
-        <description>Sysmon - Event 15</description>
+        <description>Sysmon - Event 15: FileCreateStreamHash</description>
         <group>sysmon_event_15,</group>
+    </rule>
+
+    <rule id="185014" level="0">
+        <if_sid>18100</if_sid>
+        <match>Microsoft-Windows-Sysmon/Operational: INFORMATION(17)</match>
+        <description>Sysmon - Event 17: PipeEvent (Pipe Created)</description>
+        <group>sysmon_event_17,</group>
+    </rule>
+
+    <rule id="185016" level="0">
+        <if_sid>18100</if_sid>
+        <match>Microsoft-Windows-Sysmon/Operational: INFORMATION(18)</match>
+        <description>Sysmon - Event 18: PipeEvent (Pipe Connected)</description>
+        <group>sysmon_event_18,</group>
+    </rule>
+
+    <rule id="185017" level="0">
+        <if_sid>18100</if_sid>
+        <match>Microsoft-Windows-Sysmon/Operational: INFORMATION(19)</match>
+        <description>Sysmon - Event 19: WmiEvent (WmiEventFilter activity detected)</description>
+        <group>sysmon_event_19,</group>
+    </rule>
+
+    <rule id="185018" level="0">
+        <if_sid>18100</if_sid>
+        <match>Microsoft-Windows-Sysmon/Operational: INFORMATION(20)</match>
+        <description>Sysmon - Event 20: WmiEvent (WmiEventConsumer activity detected)</description>
+        <group>sysmon_event_20,</group>
+    </rule>
+
+    <rule id="185019" level="0">
+        <if_sid>18100</if_sid>
+        <match>Microsoft-Windows-Sysmon/Operational: INFORMATION(21)</match>
+        <description>Sysmon - Event 21: WmiEvent (WmiEventConsumerToFilter activity detected)</description>
+        <group>sysmon_event_21,</group>
+    </rule>
+
+    <rule id="185020" level="0">
+        <if_sid>18100</if_sid>
+        <match>Microsoft-Windows-Sysmon/Operational: INFORMATION(22)</match>
+        <description>Sysmon - Event 22: DNSEvent (DNS query)</description>
+        <group>sysmon_event_22,</group>
     </rule>
 
 </group>

--- a/rules/0595-win-sysmon_rules.xml
+++ b/rules/0595-win-sysmon_rules.xml
@@ -151,6 +151,55 @@
     <options>no_full_log</options>
     <group>sysmon_event_15,</group>
   </rule>
+
+  <rule id="61644" level="0">
+    <if_sid>61600</if_sid>
+    <field name="win.system.eventID">^17$</field>
+    <description>Sysmon - Event 17: PipeEvent (Pipe Created) by $(win.eventdata.sourceImage)</description>
+    <options>no_full_log</options>
+    <group>sysmon_event_17,</group>
+  </rule>
+
+  <rule id="61645" level="0">
+    <if_sid>61600</if_sid>
+    <field name="win.system.eventID">^18$</field>
+    <description>Sysmon - Event 18: PipeEvent (Pipe Connected) by $(win.eventdata.sourceImage)</description>
+    <options>no_full_log</options>
+    <group>sysmon_event_18,</group>
+  </rule>
+
+  <rule id="61646" level="0">
+    <if_sid>61600</if_sid>
+    <field name="win.system.eventID">^19$</field>
+    <description>Sysmon - Event 19: WmiEvent (WmiEventFilter activity detected) by $(win.eventdata.sourceImage)</description>
+    <options>no_full_log</options>
+    <group>sysmon_event_19,</group>
+  </rule>
+
+  <rule id="61647" level="0">
+    <if_sid>61600</if_sid>
+    <field name="win.system.eventID">^20$</field>
+    <description>Sysmon - Event 20: WmiEvent (WmiEventConsumer activity detected) by $(win.eventdata.sourceImage)</description>
+    <options>no_full_log</options>
+    <group>sysmon_event_20,</group>
+  </rule>
+
+  <rule id="61648" level="0">
+    <if_sid>61600</if_sid>
+    <field name="win.system.eventID">^21$</field>
+    <description>Sysmon - Event 21: WmiEvent (WmiEventConsumerToFilter activity detected) by $(win.eventdata.sourceImage)</description>
+    <options>no_full_log</options>
+    <group>sysmon_event_21,</group>
+  </rule>
+
+  <rule id="61649" level="0">
+    <if_sid>61600</if_sid>
+    <field name="win.system.eventID">^22$</field>
+    <description>Sysmon - Event 22: DNSEvent (DNS query) by $(win.eventdata.sourceImage)</description>
+    <options>no_full_log</options>
+    <group>sysmon_event_22,</group>
+  </rule>
+
 </group>
 
 <group name="windows,sysmon,sysmon_process-anomalies,">


### PR DESCRIPTION
| Issue |
| --- |
| [431](https://github.com/wazuh/wazuh-ruleset/issues/431) |

Add new Sysmon rules for new eventchannel.

Some log examples:
>{"win":{"system":{"providerName":"Microsoft-Windows-Sysmon","providerGuid":"{5770385F-C22A-43E0-BF4C-06F5698FFBD9}","eventID":"22","version":"5","level":"4","task":"22","opcode":"0","keywords":"0x8000000000000000","systemTime":"2019-06-13T09:50:07.565921500Z","eventRecordID":"26","processID":"4896","threadID":"2060","channel":"Microsoft-Windows-Sysmon/Operational","computer":"WIN-S0GE7HFOP5K","severityValue":"INFORMATION","message":"Dns query:"},"eventdata":{"utcTime":"2019-06-13 09:50:07.862","processGuid":"{E6A6834E-48D5-5D02-0000-0010D5E80000}","processId":"668","queryName":"WIN-S0GE7HFOP5K","queryStatus":"1460","image":"C:\\Windows\\system32\\svchost.exe"}}}

**Testing**
Ossec-logtest output:
```
**Phase 2: Completed decoding.
       decoder: 'json'
       win.system.providerName: 'Microsoft-Windows-Sysmon'
       win.system.providerGuid: '{5770385F-C22A-43E0-BF4C-06F5698FFBD9}'
       win.system.eventID: '22'
       win.system.version: '5'
       win.system.level: '4'
       win.system.task: '22'
       win.system.opcode: '0'
       win.system.keywords: '0x8000000000000000'
       win.system.systemTime: '2019-06-13T09:50:07.565921500Z'
       win.system.eventRecordID: '26'
       win.system.processID: '4896'
       win.system.threadID: '2060'
       win.system.channel: 'Microsoft-Windows-Sysmon/Operational'
       win.system.computer: 'WIN-S0GE7HFOP5K'
       win.system.severityValue: 'INFORMATION'
       win.system.message: 'Dns query:'
       win.eventdata.utcTime: '2019-06-13 09:50:07.862'
       win.eventdata.processGuid: '{E6A6834E-48D5-5D02-0000-0010D5E80000}'
       win.eventdata.processId: '668'
       win.eventdata.queryName: 'WIN-S0GE7HFOP5K'
       win.eventdata.queryStatus: '1460'
       win.eventdata.image: 'C:\Windows\system32\svchost.exe'

**Phase 3: Completed filtering (rules).
       Rule id: '61649'
       Level: '0'
       Description: 'Sysmon - Event 22: DNSEvent (DNS query) by '
```