### PR TITLE
Checkpoint Smart1 firewalls - new Decoders and Rules

### DIFF
--- a/decoders/0051-checkpoint-smart1_decoders.xml
+++ b/decoders/0051-checkpoint-smart1_decoders.xml
@@ -1,0 +1,330 @@
+<!--
+  -  CheckPoint Smart-1 Firewalls decoders
+  -  Created by Wazuh, Inc.
+  -  Copyright (C) 2015-2019, Wazuh Inc.
+  -  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2.
+-->
+
+<!--
+1 2019-05-15T16:27:07Z HOSTNAME CheckPoint 21111 - [action:"Accept"; flags:"411908"; ifdir:"inbound"; ifname:"eth2"; logid:"0"; loguid:"{0x5cdc3dda,0x10,0x3e3f70a,0xc0000001}"; origin:"11.22.33.44"; originsicname:"CN=TR-DC-FW-LAN-B-5600,O=LAN-QRO..y795qq"; sequencenum:"2"; time:"1557937627"; version:"5"; __policy_id_tag:"product=VPN-1 & FireWall-1[db_tag={8039F7DB-E715-C84E-8688-37607659BE12};mgmt=TR-DC-VCON-2-BATCH;date=1557834800;policy_name=FW-LAN-TR\]"; dst:"11.22.33.55"; inzone:"DMZ"; layer_name:"FW-LAN-TR Security"; layer_uuid:"c91c2266-fe52-43f3-bba3-42b0a105bd5c"; match_id:"178"; parent_rule:"0"; rule_action:"Accept"; rule_name:"SwitchOver Payware"; rul................
+1 2019-05-15T16:26:19Z HOSTNAME CheckPoint 19710 - [action:"Reject"; flags:"133376"; ifdir:"inbound"; ifname:"daemon"; loguid:"{0x0,0x0,0x0,0x0}"; origin:"11.22.33.44"; originsicname:"CN=TR-DC-FW-INT-B-5600,O=Internet-QRO..g7hgcu"; sequencenum:"7"; time:"1557937579"; version:"5"; community:"smartbt.cinetaca"; cookiei:"ec39c6c9c5d3669c"; dst:"11.22.33.55"; fw_subproduct:"VPN-1"; ike::"Main Mode Failed to match proposal: Transform: AES-256, SHA256, Pre-shared secret, Group 2 (1024 bit); Reason: Wrong value for: Hash Algorithm"; peer_gateway:"11.22.33.66"; reject_category:"IKE failure"; scheme::"IKE"; src:"11.22.33.77"; vpn_feature_name:"IKE"; ]
+1 2019-05-15T16:25:50Z HOSTNAME CheckPoint 19710 - [action:"Drop"; flags:"400644"; ifdir:"inbound"; ifname:"eth2"; logid:"0"; loguid:"{0x0,0x0,0x0,0x0}"; origin:"11.22.33.44"; originsicname:"CN=TR-DC-FW-INT-B-5600,O=Internet-QRO..g7hgcu"; sequencenum:"11"; time:"1557937550"; version:"5"; __policy_id_tag:"product=VPN-1 & FireWall-1[db_tag={C12F833B-77C9-3941-9B06-075E9D2A86A2};mgmt=TR-DC-VCON-2-INT;date=1557764162;policy_name=FW-INT-TR\]"; dst:"11.22.33.55"; inzone:"Internal"; layer_name:"FW-INT-TR Security"; layer_uuid:"75569106-7e80-4c4e-ab23-b0848f2cb41b"; match_id:"244"; parent_rule:"0"; rule_action:"Drop"; rule_name:"CleanUp Rule"; rule_uid:"b9d9605b-a71e-4664-a042-3fbd041b0b41"; outzone:"Internal"; product:"VPN-1 & FireWall-1"; proto:"17"; s_port:"55036"; service:"1514"; service_id:"ptos_avaya"; src:"11.22.33.77"; ]
+1 2019-05-15T16:26:39Z HOSTNAME CheckPoint 19710 - [action:"Encrypt"; conn_direction:"Outgoing"; contextnum:"1"; flags:"7232772"; ifdir:"inbound"; ifname:"eth1"; logid:"0"; loguid:"{0x5cdc3dbf,0x0,0x3dff70a,0xc0000000}"; origin:"11.22.33.44"; originsicname:"CN=TR-DC-FW-INT-B-5600,O=Internet-QRO..g7hgcu"; sequencenum:"12"; time:"1557937599"; version:"5"; __policy_id_tag:"product=VPN-1 & FireWall-1[db_tag={C12F833B-77C9-3941-9B06-075E9D2A86A2};mgmt=TR-DC-VCON-2-INT;date=1557764162;policy_name=FW-INT-TR\]"; community:"vpn.tr.csn"; context_num:"1"; dst:"11.22.33.66"; fw_subproduct:"VPN-1"; hll_key:"8249302006406138919"; inzone:"Internal"; layer_name:"FW-INT-TR Security"; layer_name:"FW-INT-TR Application"; layer_uuid:"75569106-7e80-4c4e-ab23-b0848f2cb41b"; layer_uuid:"70fed639-99d5-432c-9d1e-5473a66dff08"; match_id:"142"; match_id:"16777217"; parent_rule:"0"; parent_rule:"0"; rule_action:"Accept"; rule_action:"Accept"; rule_name:"CSN"; rule_uid:"d5d708fe-3315-................
+1 2019-05-15T16:26:40Z HOSTNAME CheckPoint 19710 - [action:"Decrypt"; flags:"417028"; ifdir:"inbound"; ifname:"eth4"; logid:"0"; loguid:"{0x5cdc3dc0,0x4,0x3dff70a,0xc0000002}"; origin:"11.22.33.44"; originsicname:"CN=TR-DC-FW-INT-B-5600,O=Internet-QRO..g7hgcu"; sequencenum:"22"; time:"1557937600"; version:"5"; __policy_id_tag:"product=VPN-1 & FireWall-1[db_tag={C12F833B-77C9-3941-9B06-075E9D2A86A2};mgmt=TR-DC-VCON-2-INT;date=1557764162;policy_name=FW-INT-TR\]"; community:"safecharge.hs.triara"; dst:"11.22.33.55"; fw_subproduct:"VPN-1"; inzone:"External"; layer_name:"FW-INT-TR Security"; layer_name:"FW-INT-TR Application"; layer_uuid:"75569106-7e80-4c4e-ab23-b0848f2cb41b"; layer_uuid:"70fed639-99d5-432c-9d1e-5473a66dff08"; match_id:"127"; match_id:"33554431"; parent_rule:"0"; parent_rule:"0"; rule_action:"Accept"; rule_action:"Accept"; rule_name:"SafeCharge SEC"; rule_name:"Implicit Cleanup"; rule_uid:"7a1447ad-3f4b-4397-89d7-3adb4b5c83a5"; methods::"ESP: AES-256 + SHA256"; nat_addtnl_rulenum:"1"; nat_rulenum:"61"; outzone:"Internal"; peer_gateway:"11.22.33.77"; product:"VPN-1 & FireWall-1"; proto:"6"; s_port:"55226"; scheme::"IKE"; service:"51262"; service_id:"port_51262"; src:"11.22.33.88"; vpn_feature_name:"VPN"; xlatedport:"0"; xlatedst:"11.22.33.99"; xlatesport:"0"; xlatesrc:"0.0.0.0";
+1 2019-05-15T16:27:08Z HOSTNAME CheckPoint 19710 - [action:"Key Install"; flags:"133376"; ifdir:"inbound"; ifname:"daemon"; loguid:"{0x0,0x0,0x0,0x0}"; origin:"11.22.33.44"; originsicname:"CN=TR-DC-FW-INT-B-5600,O=Internet-QRO..g7hgcu"; sequencenum:"5"; time:"1557937628"; version:"5"; cookiei:"891f38892b0e6bd6"; cookier:"d71409f32c496d13"; dst:"11.22.33.55"; fw_subproduct:"VPN-1"; ike::"Informational Exchange Received Delete IKE-SA from Peer: 11.22.33.66; Cookies: 891f38892b0e6bd6-d71409f32c496d13 "; msgid:"a4bd6724"; peer_gateway:"11.22.33.77"; scheme::"IKE"; src:"11.22.33.99"; vpn_feature_name:"IKE"; ]
+-->
+
+<decoder name="checkpoint-smart1">
+  <prematch>^\d* \d+-\d+-\d+T\d+:\d+:\w+ \.* \w+ \d+ - [</prematch>
+</decoder>
+
+<decoder name="checkpoint-smart1">
+  <parent>checkpoint-smart1</parent>
+  <regex>^\d* (\d+-\d+-\d+T\d+:\d+:\w+) (\w*) \w+ (\d+) - [</regex>
+  <order>timestamp,hostname,ProductVersion</order>
+</decoder>
+
+<decoder name="checkpoint-smart1">
+  <parent>checkpoint-smart1</parent>
+  <regex>action:"(\.*)";|(\.*)$</regex>
+  <order>fw_action</order>
+</decoder>
+
+<decoder name="checkpoint-smart1">
+  <parent>checkpoint-smart1</parent>
+  <regex>conn_direction:"(\w*)";|(\.*)$</regex>
+  <order>conn_direction</order>
+</decoder>
+
+<decoder name="checkpoint-smart1">
+  <parent>checkpoint-smart1</parent>
+  <regex>contextnum:"(\d*)";|(\.*)$</regex>
+  <order>contextnum</order>
+</decoder>
+
+<decoder name="checkpoint-smart1">
+  <parent>checkpoint-smart1</parent>
+  <regex>flags:"(\d*)";|(\.*)$</regex>
+  <order>flags</order>
+</decoder>
+
+<decoder name="checkpoint-smart1">
+  <parent>checkpoint-smart1</parent>
+  <regex>ifdir:"(\w*)";|(\.*)$</regex>
+  <order>ifdir</order>
+</decoder>
+
+<decoder name="checkpoint-smart1">
+  <parent>checkpoint-smart1</parent>
+  <regex>ifname:"(\w*)";|(\.*)$</regex>
+  <order>ifname</order>
+</decoder>
+
+<decoder name="checkpoint-smart1">
+  <parent>checkpoint-smart1</parent>
+  <regex>logid:"(\d*)";|(\.*)$</regex>
+  <order>logid</order>
+</decoder>
+
+<decoder name="checkpoint-smart1">
+  <parent>checkpoint-smart1</parent>
+  <regex>loguid:"{(\.*)}";|(\.*)$</regex>
+  <order>loguid</order>
+</decoder>
+
+<decoder name="checkpoint-smart1">
+  <parent>checkpoint-smart1</parent>
+  <regex>origin:"(\d*.\d*.\d*.\d*)";|(\.*)$</regex>
+  <order>origin</order>
+</decoder>
+
+<decoder name="checkpoint-smart1">
+  <parent>checkpoint-smart1</parent>
+  <regex>originsicname:"(\.*)";|(\.*)$</regex>
+  <order>originsicname</order>
+</decoder>
+
+<decoder name="checkpoint-smart1">
+  <parent>checkpoint-smart1</parent>
+  <regex>sequencenum:"(\d*)";|(\.*)$</regex>
+  <order>sequencenum</order>
+</decoder>
+
+<decoder name="checkpoint-smart1">
+  <parent>checkpoint-smart1</parent>
+  <regex>time:"(\d*)";|(\.*)$</regex>
+  <order>time</order>
+</decoder>
+
+<decoder name="checkpoint-smart1">
+  <parent>checkpoint-smart1</parent>
+  <regex>version:"(\d*)";|(\.*)$</regex>
+  <order>version</order>
+</decoder>
+
+<decoder name="checkpoint-smart1">
+  <parent>checkpoint-smart1</parent>
+  <regex>__policy_id_tag:"(\.*)";|(\.*)$</regex>
+  <order>policy_id_tag</order>
+</decoder>
+
+<decoder name="checkpoint-smart1">
+  <parent>checkpoint-smart1</parent>
+  <regex>community:"(\w*)";|(\.*)$</regex>
+  <order>community</order>
+</decoder>
+
+<decoder name="checkpoint-smart1">
+  <parent>checkpoint-smart1</parent>
+  <regex>cookiei:"(\w*)";|(\.*)$</regex>
+  <order>cookiei</order>
+</decoder>
+
+<decoder name="checkpoint-smart1">
+  <parent>checkpoint-smart1</parent>
+  <regex>cookier:"(\w*)";|(\.*)$</regex>
+  <order>cookier</order>
+</decoder>
+
+<decoder name="checkpoint-smart1">
+  <parent>checkpoint-smart1</parent>
+  <regex>context_num:"(\d*)";|(\.*)$</regex>
+  <order>context_num</order>
+</decoder>
+
+<decoder name="checkpoint-smart1">
+  <parent>checkpoint-smart1</parent>
+  <regex>dst:"(\d*.\d*.\d*.\d*)";|(\.*)$</regex>
+  <order>dst</order>
+</decoder>
+
+<decoder name="checkpoint-smart1">
+  <parent>checkpoint-smart1</parent>
+  <regex>fw_subproduct:"(\w*)";|(\.*)$</regex>
+  <order>fw_subproduct</order>
+</decoder>
+
+<decoder name="checkpoint-smart1">
+  <parent>checkpoint-smart1</parent>
+  <regex>hll_key:"(\d*)";|(\.*)$</regex>
+  <order>hll_key</order>
+</decoder>
+
+<decoder name="checkpoint-smart1">
+  <parent>checkpoint-smart1</parent>
+  <regex>ike::"(\.*)";|(\.*)$</regex>
+  <order>ike</order>
+</decoder>
+
+<decoder name="checkpoint-smart1">
+  <parent>checkpoint-smart1</parent>
+  <regex>Cookies:"(\w*)";|(\.*)$</regex>
+  <order>Cookies</order>
+</decoder>
+
+<decoder name="checkpoint-smart1">
+  <parent>checkpoint-smart1</parent>
+  <regex>msgid:"(\w*)";|(\.*)$</regex>
+  <order>msgid</order>
+</decoder>
+<decoder name="checkpoint-smart1">
+  <parent>checkpoint-smart1</parent>
+  <regex>Reason:"(\.*)";|(\.*)$</regex>
+  <order>Reason</order>
+</decoder>
+
+<decoder name="checkpoint-smart1">
+  <parent>checkpoint-smart1</parent>
+  <regex>inzone:"(\w*)";|(\.*)$</regex>
+  <order>inzone</order>
+</decoder>
+
+<decoder name="checkpoint-smart1">
+  <parent>checkpoint-smart1</parent>
+  <regex>layer_name:"(\.*)";|(\.*)$</regex>
+  <order>layer_name</order>
+</decoder>
+
+<decoder name="checkpoint-smart1">
+  <parent>checkpoint-smart1</parent>
+  <regex>layer_uuid:"(\w*)";|(\.*)$</regex>
+  <order>layer_uuid</order>
+</decoder>
+
+<decoder name="checkpoint-smart1">
+  <parent>checkpoint-smart1</parent>
+  <regex>match_id:"(\d*)";|(\.*)$</regex>
+  <order>match_id</order>
+</decoder>
+
+<decoder name="checkpoint-smart1">
+  <parent>checkpoint-smart1</parent>
+  <regex>parent_rule:"(\d*)";|(\.*)$</regex>
+  <order>parent_rule</order>
+</decoder>
+
+<decoder name="checkpoint-smart1">
+  <parent>checkpoint-smart1</parent>
+  <regex>rule_action:"(\w*)";|(\.*)$</regex>
+  <order>rule_action</order>
+</decoder>
+
+<decoder name="checkpoint-smart1">
+  <parent>checkpoint-smart1</parent>
+  <regex>rule_name:"(\.*)";|(\.*)$</regex>
+  <order>rule_name</order>
+</decoder>
+
+<decoder name="checkpoint-smart1">
+  <parent>checkpoint-smart1</parent>
+  <regex>rule_uid:"(\w*)";|(\.*)$</regex>
+  <order>rule_uid</order>
+</decoder>
+
+<decoder name="checkpoint-smart1">
+  <parent>checkpoint-smart1</parent>
+  <regex>methods:"(\.*)";|(\.*)$</regex>
+  <order>methods</order>
+</decoder>
+
+<decoder name="checkpoint-smart1">
+  <parent>checkpoint-smart1</parent>
+  <regex>nat_addtnl_rulenum:"(\d*)";|(\.*)$</regex>
+  <order>nat_addtnl_rulenum</order>
+</decoder>
+
+<decoder name="checkpoint-smart1">
+  <parent>checkpoint-smart1</parent>
+  <regex>nat_rulenum:"(\d*)";|(\.*)$</regex>
+  <order>nat_rulenum</order>
+</decoder>
+
+<decoder name="checkpoint-smart1">
+  <parent>checkpoint-smart1</parent>
+  <regex>outzone:"(\w*)";|(\.*)$</regex>
+  <order>outzone</order>
+</decoder>
+
+<decoder name="checkpoint-smart1">
+  <parent>checkpoint-smart1</parent>
+  <regex>product:"(\.*)";|(\.*)$</regex>
+  <order>product</order>
+</decoder>
+ 
+<decoder name="checkpoint-smart1">
+  <parent>checkpoint-smart1</parent>
+  <regex>peer_gateway:"(\d*.\d*.\d*.\d*)";|(\.*)$</regex>
+  <order>peer_gateway</order>
+</decoder>
+
+<decoder name="checkpoint-smart1">
+  <parent>checkpoint-smart1</parent>
+  <regex>reject_category:"(\.*)";|(\.*)$</regex>
+  <order>reject_category</order>
+</decoder>
+
+<decoder name="checkpoint-smart1">
+  <parent>checkpoint-smart1</parent>
+  <regex>scheme::"(\w*)";|(\.*)$</regex>
+  <order>scheme</order>
+</decoder>
+
+<decoder name="checkpoint-smart1">
+  <parent>checkpoint-smart1</parent>
+  <regex>proto:"(\d*)";|(\.*)$</regex>
+  <order>proto</order>
+</decoder>
+
+<decoder name="checkpoint-smart1">
+  <parent>checkpoint-smart1</parent>
+  <regex>s_port:"(\d*)";|(\.*)$</regex>
+  <order>s_port</order>
+</decoder>
+
+<decoder name="checkpoint-smart1">
+  <parent>checkpoint-smart1</parent>
+  <regex>service:"(\d*)";|(\.*)$</regex>
+  <order>service</order>
+</decoder>
+
+<decoder name="checkpoint-smart1">
+  <parent>checkpoint-smart1</parent>
+  <regex>service_id:"(\w*)";|(\.*)$</regex>
+  <order>service_id</order>
+</decoder>
+
+<decoder name="checkpoint-smart1">
+  <parent>checkpoint-smart1</parent>
+  <regex>src:"(\d*.\d*.\d*.\d*)";|(\.*)$</regex>
+  <order>src</order>
+</decoder>
+
+<decoder name="checkpoint-smart1">
+  <parent>checkpoint-smart1</parent>
+  <regex>vpn_feature_name:"(\w*)";|(\.*)$</regex>
+  <order>vpn_feature_name</order>
+</decoder>
+
+<decoder name="checkpoint-smart1">
+  <parent>checkpoint-smart1</parent>
+  <regex>xlatedport:"(\d*)";|(\.*)$</regex>
+  <order>xlatedport</order>
+</decoder>
+
+<decoder name="checkpoint-smart1">
+  <parent>checkpoint-smart1</parent>
+  <regex>xlateds:"(\d*.\d*.\d*.\d*)";|(\.*)$</regex>
+  <order>xlateds</order>
+</decoder>
+
+<decoder name="checkpoint-smart1">
+  <parent>checkpoint-smart1</parent>
+  <regex>xlatesport:"(\d*)";|(\.*)$</regex>
+  <order>xlatesport</order>
+</decoder>
+
+<decoder name="checkpoint-smart1">
+  <parent>checkpoint-smart1</parent>
+  <regex>xlatesrc:"(\d*.\d*.\d*.\d*)";|(\.*)$</regex>
+  <order>xlatesrc</order>
+</decoder>

--- a/rules/0680-checkpoint-smart1_rules.xml
+++ b/rules/0680-checkpoint-smart1_rules.xml
@@ -1,0 +1,129 @@
+<!--
+  -  CheckPoint Smart-1 Firewalls rules
+  -  Created by Wazuh, Inc.
+  -  Copyright (C) 2015-2019, Wazuh Inc.
+  -  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2.
+-->
+
+<group name="checkpoint-smart1,">
+
+    <rule id="64220" level="0">
+        <decoded_as>checkpoint-smart1</decoded_as>
+        <description>Checkpoint events.</description>
+    </rule>
+
+    <rule id="64221" level="0">
+        <if_sid>64220</if_sid>
+        <field name="fw_action">Accept</field>
+        <description>Accept: Connection Accepted.</description>
+    </rule>
+	
+    <rule id="64222" level="4">
+        <if_sid>64220</if_sid>
+        <field name="fw_action">Drop</field>
+        <description>Drop: Prohibit a packet from passing. Send no response.</description>
+    </rule>
+
+    <rule id="64223" level="9">
+        <if_sid>64220</if_sid>
+        <field name="fw_action">Reject</field>
+        <description>Reject: Prohibit a packet from passing. Send an ICMP destination-unreachable back to the source host.</description>
+    </rule>
+
+    <rule id="64224" level="2">
+        <if_sid>64220</if_sid>
+        <field name="fw_action">Encrypt</field>
+        <description>Encrypt: Connection Encrypted</description>
+    </rule>
+	
+	<rule id="64225" level="2">
+        <if_sid>64220</if_sid>
+        <field name="fw_action">Decrypt</field>
+        <description>Decrypt: Connection Decrypted</description>
+    </rule>
+
+	<rule id="64226" level="2">
+        <if_sid>64220</if_sid>
+        <match>Key Install</match>
+        <description>Key Install: Encryption keys were created.</description>
+    </rule>	
+
+	<rule id="64227" level="4">
+        <if_sid>64220</if_sid>
+        <field name="fw_action">Monitored</field>
+        <description>Monitored: A security event was monitored; however, it was not blocked, due to the current configuration.</description>
+    </rule>
+	
+	<rule id="64228" level="3">
+        <if_sid>64220</if_sid>
+        <field name="fw_action">Bypass</field>
+        <description>Bypass: The connection passed transparently through InterSpect.</description>
+    </rule>
+
+	<rule id="64229" level="0">
+        <if_sid>64220</if_sid>
+        <field name="fw_action">Flag</field>
+        <description>Flag: Flags the connection.</description>
+    </rule>
+
+	<rule id="64230" level="3">
+        <if_sid>64220</if_sid>
+        <field name="fw_action">Login</field>
+        <description>Login: A user logged into the system.</description>
+    </rule>
+
+	<rule id="64231" level="3">
+        <if_sid>64220</if_sid>
+        <match>VPN routing</match>
+        <description>VPN routing: The connection was routed through the gateway acting as a central hub.</description>
+    </rule>
+	
+	<rule id="64232" level="3">
+        <if_sid>64220</if_sid>
+        <field name="fw_action">Deauthorize</field>
+        <description>Deauthorize: Client Authentication logoff.</description>
+    </rule>
+
+	<rule id="64233" level="3">
+        <if_sid>64220</if_sid>
+        <field name="fw_action">Authorize</field>
+        <description>Authorize: Client Authentication logon.</description>
+    </rule>
+
+	<rule id="64234" level="7">
+        <if_sid>64220</if_sid>
+        <field name="fw_action">Block</field>
+        <description>Block: Connection blocked by Interspect.</description>
+    </rule>	
+	
+	<rule id="64235" level="3">
+        <if_sid>64220</if_sid>
+        <field name="fw_action">Detect</field>
+        <description>Detect: Connection was detected by Interspect.</description>
+    </rule>	
+	
+	<rule id="64236" level="4">
+        <if_sid>64220</if_sid>
+        <field name="fw_action">Inspect</field>
+        <description>Inspect: Connection was subject to a configured protections.</description>
+    </rule>	
+	
+	<rule id="64237" level="7">
+        <if_sid>64220</if_sid>
+        <field name="fw_action">Quarantine</field>
+        <description>Quarantine: The IP source address of the connection was quarantined.</description>
+    </rule>	
+	
+	<rule id="64238" level="7">
+        <if_sid>64220</if_sid>
+        <match>Replace Malicious code</match>
+        <description>Replace Malicious code: Malicious code in the connection was replaced.</description>
+    </rule>	
+		
+	<rule id="64239" level="3">
+        <if_sid>64220</if_sid>
+        <field name="fw_action">Allow</field>
+        <description>Allow: The firewall allowed a URL.</description>
+    </rule>	
+	
+</group>

--- a/tools/rules-testing/tests/checkpoint_smart1.ini
+++ b/tools/rules-testing/tests/checkpoint_smart1.ini
@@ -1,0 +1,126 @@
+[checkpoint smart1: Drop: Prohibit a packet from passing. Send no response.]
+log 1 pass = 1 2019-05-15T16:25:50Z HOSTNAME CheckPoint 19710 - [action:"Drop"; flags:"400644"; ifdir:"inbound"; ifname:"eth2"; logid:"0"; loguid:"{0x0,0x0,0x0,0x0}"; origin:"11.22.33.44"; originsicname:"CN=TR-DC-FW-INT-B-5600,O=Internet-QRO..g7hgcu"; sequencenum:"11"; time:"1557937550"; version:"5"; __policy_id_tag:"product=VPN-1 & FireWall-1[db_tag={C12F833B-77C9-3941-9B06-075E9D2A86A2};mgmt=TR-DC-VCON-2-INT;date=1557764162;policy_name=FW-INT-TR\]"; dst:"11.22.33.55"; inzone:"Internal"; layer_name:"FW-INT-TR Security"; layer_uuid:"75569106-7e80-4c4e-ab23-b0848f2cb41b"; match_id:"244"; parent_rule:"0"; rule_action:"Drop"; rule_name:"CleanUp Rule"; rule_uid:"b9d9605b-a71e-4664-a042-3fbd041b0b41"; outzone:"Internal"; product:"VPN-1 & FireWall-1"; proto:"17"; s_port:"55036"; service:"1514"; service_id:"ptos_avaya"; src:"11.22.33.77"; ]
+
+rule = 64222
+alert = 4
+decoder = checkpoint-smart1
+
+[checkpoint smart1: Reject: Prohibit a packet from passing. Send an ICMP destination-unreachable back to the source host.]
+log 1 pass = 1 2019-05-15T16:26:19Z HOSTNAME CheckPoint 19710 - [action:"Reject"; flags:"133376"; ifdir:"inbound"; ifname:"daemon"; loguid:"{0x0,0x0,0x0,0x0}"; origin:"11.22.33.44"; originsicname:"CN=TR-DC-FW-INT-B-5600,O=Internet-QRO..g7hgcu"; sequencenum:"7"; time:"1557937579"; version:"5"; community:"smartbt.cinetaca"; cookiei:"ec39c6c9c5d3669c"; dst:"11.22.33.55"; fw_subproduct:"VPN-1"; ike::"Main Mode Failed to match proposal: Transform: AES-256, SHA256, Pre-shared secret, Group 2 (1024 bit); Reason: Wrong value for: Hash Algorithm"; peer_gateway:"11.22.33.66"; reject_category:"IKE failure"; scheme::"IKE"; src:"11.22.33.77"; vpn_feature_name:"IKE"; ]
+
+rule = 64223
+alert = 9
+decoder = checkpoint-smart1
+
+[checkpoint smart1: Encrypt: Connection Encrypted]
+log 1 pass = 1 2019-05-15T16:26:39Z HOSTNAME CheckPoint 19710 - [action:"Encrypt"; conn_direction:"Outgoing"; contextnum:"1"; flags:"7232772"; ifdir:"inbound"; ifname:"eth1"; logid:"0"; loguid:"{0x5cdc3dbf,0x0,0x3dff70a,0xc0000000}"; origin:"11.22.33.44"; originsicname:"CN=TR-DC-FW-INT-B-5600,O=Internet-QRO..g7hgcu"; sequencenum:"12"; time:"1557937599"; version:"5"; __policy_id_tag:"product=VPN-1 & FireWall-1[db_tag={C12F833B-77C9-3941-9B06-075E9D2A86A2};mgmt=TR-DC-VCON-2-INT;date=1557764162;policy_name=FW-INT-TR\]"; community:"vpn.tr.csn"; context_num:"1"; dst:"11.22.33.66"; fw_subproduct:"VPN-1"; hll_key:"8249302006406138919"; inzone:"Internal"; layer_name:"FW-INT-TR Security"; layer_name:"FW-INT-TR Application"; layer_uuid:"75569106-7e80-4c4e-ab23-b0848f2cb41b"; layer_uuid:"70fed639-99d5-432c-9d1e-5473a66dff08"; match_id:"142"; match_id:"16777217"; parent_rule:"0"; parent_rule:"0"; rule_action:"Accept"; rule_action:"Accept"; rule_name:"CSN"; rule_uid:"d5d708fe-3315-................
+
+rule = 64224
+alert = 2
+decoder = checkpoint-smart1
+
+[checkpoint smart1: Decrypt: Connection Decrypted]
+log 1 pass = 1 2019-05-15T16:26:40Z HOSTNAME CheckPoint 19710 - [action:"Decrypt"; flags:"417028"; ifdir:"inbound"; ifname:"eth4"; logid:"0"; loguid:"{0x5cdc3dc0,0x4,0x3dff70a,0xc0000002}"; origin:"11.22.33.44"; originsicname:"CN=TR-DC-FW-INT-B-5600,O=Internet-QRO..g7hgcu"; sequencenum:"22"; time:"1557937600"; version:"5"; __policy_id_tag:"product=VPN-1 & FireWall-1[db_tag={C12F833B-77C9-3941-9B06-075E9D2A86A2};mgmt=TR-DC-VCON-2-INT;date=1557764162;policy_name=FW-INT-TR\]"; community:"safecharge.hs.triara"; dst:"11.22.33.55"; fw_subproduct:"VPN-1"; inzone:"External"; layer_name:"FW-INT-TR Security"; layer_name:"FW-INT-TR Application"; layer_uuid:"75569106-7e80-4c4e-ab23-b0848f2cb41b"; layer_uuid:"70fed639-99d5-432c-9d1e-5473a66dff08"; match_id:"127"; match_id:"33554431"; parent_rule:"0"; parent_rule:"0"; rule_action:"Accept"; rule_action:"Accept"; rule_name:"SafeCharge SEC"; rule_name:"Implicit Cleanup"; rule_uid:"7a1447ad-3f4b-4397-89d7-3adb4b5c83a5"; methods::"ESP: AES-256 + SHA256"; nat_addtnl_rulenum:"1"; nat_rulenum:"61"; outzone:"Internal"; peer_gateway:"11.22.33.77"; product:"VPN-1 & FireWall-1"; proto:"6"; s_port:"55226"; scheme::"IKE"; service:"51262"; service_id:"port_51262"; src:"11.22.33.88"; vpn_feature_name:"VPN"; xlatedport:"0"; xlatedst:"11.22.33.99"; xlatesport:"0"; xlatesrc:"0.0.0.0";
+
+rule = 64225
+alert = 2
+decoder = checkpoint-smart1
+
+[checkpoint smart1: Key Install: Encryption keys were created.]
+log 1 pass = 1 2019-05-15T16:27:08Z HOSTNAME CheckPoint 19710 - [action:"Key Install"; flags:"133376"; ifdir:"inbound"; ifname:"daemon"; loguid:"{0x0,0x0,0x0,0x0}"; origin:"11.22.33.44"; originsicname:"CN=TR-DC-FW-INT-B-5600,O=Internet-QRO..g7hgcu"; sequencenum:"5"; time:"1557937628"; version:"5"; cookiei:"891f38892b0e6bd6"; cookier:"d71409f32c496d13"; dst:"11.22.33.55"; fw_subproduct:"VPN-1"; ike::"Informational Exchange Received Delete IKE-SA from Peer: 11.22.33.66; Cookies: 891f38892b0e6bd6-d71409f32c496d13 "; msgid:"a4bd6724"; peer_gateway:"11.22.33.77"; scheme::"IKE"; src:"11.22.33.99"; vpn_feature_name:"IKE"; ]
+
+rule = 64226
+alert = 2
+decoder = checkpoint-smart1
+
+[checkpoint smart1: Monitored: A security event was monitored; however, it was not blocked, due to the current configuration.]
+log 1 pass = 1 2019-05-15T16:27:08Z HOSTNAME CheckPoint 19710 - [action:"Monitored";...
+
+rule = 64227
+alert = 4
+decoder = checkpoint-smart1
+
+[checkpoint smart1: Bypass: The connection passed transparently through InterSpect.]
+log 1 pass = 1 2019-05-15T16:27:08Z HOSTNAME CheckPoint 19710 - [action:"Bypass";...
+
+rule = 64228
+alert = 3
+decoder = checkpoint-smart1
+
+[checkpoint smart1: Flag: Flags the connection.]
+log 1 pass =  1 2019-05-15T16:27:08Z HOSTNAME CheckPoint 19710 - [action:"Flag";...
+
+rule = 64229
+alert = 0
+decoder = checkpoint-smart1
+
+[checkpoint smart1: Login: A user logged into the system.]
+log 1 pass = 1 2019-05-15T16:27:08Z HOSTNAME CheckPoint 19710 - [action:"Login";...
+
+rule = 64230
+alert = 3
+decoder = checkpoint-smart1
+
+[checkpoint smart1: VPN routing: The connection was routed through the gateway acting as a central hub.]
+log 1 pass = 1 2019-05-15T16:27:08Z HOSTNAME CheckPoint 19710 - [action:""; VPN routing...
+
+rule = 64231
+alert = 3
+decoder = checkpoint-smart1
+
+[checkpoint smart1: Deauthorize: Client Authentication logoff.]
+log 1 pass = 1 2019-05-15T16:27:08Z HOSTNAME CheckPoint 19710 - [action:"Deauthorize";...
+
+rule = 64232
+alert = 3
+decoder = checkpoint-smart1
+
+[checkpoint smart1: Authorize: Client Authentication logon]
+log 1 pass = 1 2019-05-15T16:27:08Z HOSTNAME CheckPoint 19710 - [action:"Authorize";...
+
+rule = 64233
+alert = 3
+decoder = checkpoint-smart1
+
+[checkpoint smart1: Block: Connection blocked by Interspect.]
+log 1 pass = 1 2019-05-15T16:27:08Z HOSTNAME CheckPoint 19710 - [action:"Block";...
+
+rule = 64234
+alert = 7
+decoder = checkpoint-smart1
+
+[checkpoint smart1: Detect: Connection was detected by Interspect.]
+log 1 pass = 1 2019-05-15T16:27:08Z HOSTNAME CheckPoint 19710 - [action:"Detect";...
+
+rule = 64235
+alert = 3
+decoder = checkpoint-smart1
+
+[checkpoint smart1: Inspect: Connection was subject to a configured protections.]
+log 1 pass = 1 2019-05-15T16:27:08Z HOSTNAME CheckPoint 19710 - [action:"Inspect";...
+
+rule = 64236
+alert = 4
+decoder = checkpoint-smart1
+
+[checkpoint smart1: Quarantine: The IP source address of the connection was quarantined.]
+log 1 pass = 1 2019-05-15T16:27:08Z HOSTNAME CheckPoint 19710 - [action:"Quarantine";...
+
+rule = 64237
+alert = 7
+decoder = checkpoint-smart1
+
+[checkpoint smart1: Replace Malicious code: Malicious code in the connection was replaced.]
+log 1 pass = 1 2019-05-15T16:27:08Z HOSTNAME CheckPoint 19710 - [action:""; Replace Malicious code ...
+
+rule = 64238
+alert = 7
+decoder = checkpoint-smart1
+
+[checkpoint smart1: The firewall allowed a URL]
+log 1 pass = 1 2019-05-15T16:27:08Z HOSTNAME CheckPoint 19710 - [action:"Allow"; flags:"133376"; ifdir:"inbound"; ifname:"daemon"; loguid:"{0x0,0x0,0x0,0x0}"; origin:"11.22.33.44"; originsicname:"CN=TR-DC-FW-INT-B-5600,O=Internet-QRO..g7hgcu"; sequencenum:"5"; time:"1557937628"; version:"5"; cookiei:"891f38892b0e6bd6"; cookier:"d71409f32c496d13"; dst:"11.22.33.55"; fw_subproduct:"VPN-1"; ike::"Informational Exchange Received Delete IKE-SA from Peer: 11.22.33.66; Cookies: 891f38892b0e6bd6-d71409f32c496d13 "; msgid:"a4bd6724"; peer_gateway:"11.22.33.77"; scheme::"IKE"; src:"11.22.33.99"; vpn_feature_name:"IKE"; ]
+
+rule = 64239
+alert = 3
+decoder = checkpoint-smart1
+


### PR DESCRIPTION
Hello,

I created new Decoders and Rules for **Checkpoint Smart1** firewalls series.

I used Sibling Decoders to extract all of the dynamic fields from the syslog event.

For the Rules, I used both `<match>` and `<field name="fw_action">` conditions to generate the corresponding alerts. I assigned IDs from **64220** to **64239**.

The script output doesn't show any "Failed" message:
```
[root@wazuh-manager-3-9-ip9 ~]# ./runtest.py
- [ File = ./tests/checkpoint_smart1.ini ] ---------
..................
```

I add the following files:
- decoders/0051-checkpoint-smart1_decoders.xml
- rules/0680-checkpoint-smart1_rules.xml
- tools/rules-testing/checkpoint_smart1.ini

Regards,
J. M. Mallorquín