### PR TITLE
Cisco switches - new Decoders and Rules

### DIFF
--- a/decoders/0066-cisco_switches_decoders.xml
+++ b/decoders/0066-cisco_switches_decoders.xml
@@ -1,0 +1,33 @@
+<!--
+  -  Cisco switches decoders
+  -  Created by Wazuh, Inc.
+  -  Copyright (C) 2015-2019, Wazuh Inc.
+  -  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2.
+-->
+
+<!--
+HOSTNAME-1: 2019 May 22 11:29:33.251 GMT: %DAEMON-3-SYSTEM_MSG: NTP: Peer 11.22.33.44 with stratum 1 selected - ntpd[29424] dst:"10.20.30.40
+-->
+<decoder name="cisco-sw-ntp">
+<prematch>\S+: \d+ \w+ \d+ \d+:\d+:\d+.\d+ \w+: %\S+: NTP: Peer \d+.\d+.\d+.\d+ \.+ - \w+[\d+]</prematch>
+<regex>(\S+): (\d+ \w+ \d+ \d+:\d+:\d+.\d+ \w+): %(\S+): (NTP): Peer (\d+.\d+.\d+.\d+) \.+ - \w+[(\d+)]</regex>
+<order>hostname, timestamp, program, protocol, srcip, pid</order>
+</decoder>
+
+<!--
+3387: HOSTNAME-2: May 22 19:04:20.424 GMT: %LINEPROTO-5-UPDOWN: Line protocol on Interface FastEthernet0/7, changed state to down-INT-TR Applicat
+-->
+<decoder name="cisco-sw-interface-change">
+<prematch>\d+: \S+: \w+ \d+ \d+:\d+:\d+.\d+ \w+: %\S+: \.*Interface \S+\p*\s*\.+</prematch>
+<regex>(\d+): (\S+): (\w+ \d+ \d+:\d+:\d+.\d+ \w+): %(\S+): \.*Interface (\S+)\p*\s*(\.+)</regex>
+<order>pid, hostname, timestamp, program, interface, data</order>
+</decoder>
+
+<!--
+HOSTNAME-3: 2019 May 22 12:33:09.614 GMT: %ETHPORT-5-IF_DOWN_LINK_FAILURE: Interface Ethernet1/17 is down (Link failure)1 2019-05-22T17:
+-->
+<decoder name="cisco-sw-interface-down">
+<prematch>\S+: \d+ \w+ \d+ \d+:\d+:\d+.\d+ \w+: %\S+:\.+Interface \S+\s*\.+</prematch>
+<regex>(\S+): (\d+ \w+ \d+ \d+:\d+:\d+.\d+ \w+): %(\S+):\.+Interface (\S+)\s*(\.+)</regex>
+<order>hostname, timestamp, program, interface, data</order>
+</decoder>

--- a/rules/0685-cisco_switches_rules.xml
+++ b/rules/0685-cisco_switches_rules.xml
@@ -1,0 +1,26 @@
+<!--
+  -  Cisco switches rules
+  -  Created by Wazuh, Inc.
+  -  Copyright (C) 2015-2019, Wazuh Inc.
+  -  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2.
+-->
+
+<group name="prosa-cisco-ntp,">
+
+    <rule id="64250" level="3">
+        <decoded_as>cisco-sw-ntp</decoded_as>
+        <description>Cisco devices NTP events: $(hostname)</description>
+    </rule>
+
+    <rule id="64251" level="3">
+        <decoded_as>cisco-sw-interface-change</decoded_as>
+        <description>Cisco device: $(hostname), interface: $(interface)</description>
+    </rule>
+
+    <rule id="64252" level="3">
+        <decoded_as>cisco-sw-interface-down</decoded_as>
+        <description>Cisco device: $(hostname), interface down: $(interface)</description>
+    </rule>	
+
+
+</group>

--- a/tools/rules-testing/tests/cisco_switches.ini
+++ b/tools/rules-testing/tests/cisco_switches.ini
@@ -1,0 +1,20 @@
+[cisco switches: Cisco devices NTP events]
+log 1 pass = HOSTNAME-1: 2019 May 22 11:29:33.251 GMT: %DAEMON-3-SYSTEM_MSG: NTP: Peer 11.22.33.44 with stratum 1 selected - ntpd[29424] dst:"10.20.30.40
+
+rule = 64250
+alert = 3
+decoder = cisco-sw-ntp
+
+[cisco switches: Cisco device interface changed]
+log 1 pass = 3387: HOSTNAME-2: May 22 19:04:20.424 GMT: %LINEPROTO-5-UPDOWN: Line protocol on Interface FastEthernet0/7, changed state to down-INT-TR Applicat
+
+rule = 64251
+alert = 3
+decoder = cisco-sw-interface-change
+
+[cisco switches: Cisco device interface down]
+log 1 pass = HOSTNAME-3: 2019 May 22 12:33:09.614 GMT: %ETHPORT-5-IF_DOWN_LINK_FAILURE: Interface Ethernet1/17 is down (Link failure)1 2019-05-22T17:
+
+rule = 64252
+alert = 3
+decoder = cisco-sw-interface-down


### PR DESCRIPTION
Hello,

I created new Decoders and Rules for **Cisco switches** related to NTP and network interfaces.

I assigned the Rules IDs **64250** to **64252**.

The script output doesn't show any "Failed" message:
```
# ./runtest.py
- [ File = ./tests/cisco_switches.ini ] ---------
........
```

I upload the following files:
- `decoders/0066-cisco_switches_decoders.xml`
- `rules/0685-cisco_switches_rules.xml`
- `tools/rules-testing/cisco_switches.ini`

Regards,
J. M. Mallorquín