### PR TITLE
F5 BigIP GTM - new Decoders and Rules

### DIFF
--- a/decoders/0099-f5_bigip_decoders.xml
+++ b/decoders/0099-f5_bigip_decoders.xml
@@ -1,0 +1,29 @@
+<!--
+  -  F5 Networks BIG-IP GTM (Global Traffic Manager) decoders
+  -  Created by Wazuh, Inc.
+  -  Copyright (C) 2015-2019, Wazuh Inc.
+  -  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2.
+-->
+
+<!--
+Log fields: 
+<time stamp> <host name> <level> <service[pid]> <message code> <message text>
+
+Log samples:
+
+May 24 11:15:01 HOSTNAME notice logrotate[3582]: ALERT exited abnormally with [1]
+May 24 11:15:25 HOSTNAME warning tmm1[18463]: 01260013:4: SSL Handshake failed for TCP 192.168.1.15:50932 -> 11.22.33.44:443
+May 17 11:28:20 HOSTNAME alert gtmd[13220]: 011ae0f2:1: Monitor instance /Common/Monitor_1.1.1.1 192.168.1.1:1526 UP -> DOWN from /Common/F5-LAN-SF (no reply from big3d: timed out)
+May 17 11:28:21 HOSTNAME alert gtmd[13202]: 011a4003:1: SNMP_TRAP: Pool /Common/hostname member pmtdbaf5-SF (ip:port=10.1.1.1:5443) state change green -> red ( Monitor /Common/Monitor_1.1.1.1 from /Common/F5-LAN-SF : no reply from big3d: timed out)
+May 17 11:28:22 HOSTNAME alert gtmd[13202]: 011a6006:1: SNMP_TRAP: VS virtual_server_name (ip:port=192.168.1.2:1526) (Server /Common/virtual_server_name) state change green -> red ( Monitor /Common/Monitor_1.1.1.1 from /Common/F5-LAN-SF : no reply from big3d: timed out)
+-->
+
+<decoder name="f5_bigip_decoder">
+	<prematch>\w+ \w+[\d+]: \S+ \.+</prematch>
+</decoder>
+
+<decoder name="f5_bigip_decoder_fields">
+   <parent>f5_bigip_decoder</parent>
+   <regex>(\w+) (\w+)[(\d+)]: (\S+) (\.+)</regex>
+   <order>level,service,pid,message_code,message_text</order>
+</decoder>

--- a/rules/0690-f5_bigip_rules.xml
+++ b/rules/0690-f5_bigip_rules.xml
@@ -1,0 +1,33 @@
+<!--
+  -  F5 Networks BIG-IP GTM (Global Traffic Manager) rules
+  -  Created by Wazuh, Inc.
+  -  Copyright (C) 2015-2019, Wazuh Inc.
+  -  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2.
+-->
+
+<group name="f5_bigip,">
+
+    <rule id="64260" level="0">
+        <decoded_as>f5_bigip_decoder</decoded_as>
+        <description>F5 Networks BigIP GTM events.</description>
+    </rule>
+	
+	<rule id="64261" level="3">
+        <if_sid>64260</if_sid>
+        <field name="level">notice</field>
+        <description>F5 BigIP GTM: Notice message detected.</description>
+    </rule>
+	
+    <rule id="64262" level="7">
+        <if_sid>64260</if_sid>
+        <field name="level">warning</field>
+        <description>F5 BigIP GTM: Warning message detected.</description>
+    </rule>
+	
+    <rule id="64263" level="7">
+        <if_sid>64260</if_sid>
+        <field name="level">alert</field>
+        <description>F5 BigIP GTM: Alert message detected.</description>
+    </rule>
+
+</group>

--- a/tools/rules-testing/tests/f5_bigip.ini
+++ b/tools/rules-testing/tests/f5_bigip.ini
@@ -1,0 +1,22 @@
+[f5 bigip gtm: Notice message detected]
+log 1 pass = May 24 11:15:01 HOSTNAME notice logrotate[3582]: ALERT exited abnormally with [1]
+
+rule = 64261
+alert = 3
+decoder = f5_bigip_decoder
+
+[f5 bigip gtm: Warning message detected]
+log 1 pass = May 24 11:15:25 HOSTNAME warning tmm1[18463]: 01260013:4: SSL Handshake failed for TCP 192.168.1.15:50932 -> 11.22.33.44:443
+
+rule = 64262
+alert = 7
+decoder = f5_bigip_decoder
+
+[f5 bigip gtm:  Alert message detected]
+log 1 pass = May 17 11:28:20 HOSTNAME alert gtmd[13220]: 011ae0f2:1: Monitor instance /Common/Monitor_1.1.1.1 192.168.1.1:1526 UP -> DOWN from /Common/F5-LAN-SF (no reply from big3d: timed out)
+log 2 pass = May 17 11:28:21 HOSTNAME alert gtmd[13202]: 011a4003:1: SNMP_TRAP: Pool /Common/hostname member pmtdbaf5-SF (ip:port=10.1.1.1:5443) state change green -> red ( Monitor /Common/Monitor_1.1.1.1 from /Common/F5-LAN-SF : no reply from big3d: timed out)
+log 3 pass = May 17 11:28:22 HOSTNAME alert gtmd[13202]: 011a6006:1: SNMP_TRAP: VS virtual_server_name (ip:port=192.168.1.2:1526) (Server /Common/virtual_server_name) state change green -> red ( Monitor /Common/Monitor_1.1.1.1 from /Common/F5-LAN-SF : no reply from big3d: timed out) 
+
+rule = 64263
+alert = 7
+decoder = f5_bigip_decoder


### PR DESCRIPTION
Hello,

I created new Decoders and Rules for **F5 Big-IP GTM (Global Traffic Manager)** devices.

For the Rules, I used `<field name="level">` conditions to generate the corresponding alerts. I assigned IDs from **64260** to **64263**.

The script output doesn't show any "Failed" message:
```
# ./runtest.py
- [ File = ./tests/f5_bigip.ini ] ---------
........
```

I upload the following files:
- `decoders/0099-f5_bigip_decoders.xml`
- `rules/0690-f5_bigip_rules.xml`
- `tools/rules-testing/f5_bigip.ini`

Regards,
J. M. Mallorquín