### PR TITLE
Sophos antivirus - new Decoders and Rules

### DIFF
--- a/decoders/0299-sophos_decoders.xml
+++ b/decoders/0299-sophos_decoders.xml
@@ -1,0 +1,58 @@
+<!--
+  -  Sophos Antivirus decoders
+  -  Created by Wazuh, Inc.
+  -  Copyright (C) 2015-2019, Wazuh Inc.
+  -  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2.
+-->
+
+<!--
+<log><category>savscan.log</category><level>INFO</level><domain>savscan</domain><msg>SAVSCAN-DETAILS %s %s %s %s %s %s</msg><time>1558570140</time><arg>0</arg><arg>0</arg><arg>108267</arg><arg>131</arg><arg>0</arg><arg>0</arg></log>
+<log><category>update.check</category><level>INFO</level><domain>savupdate</domain><msg>NO_UPDATED_FROM %s</msg><time>1558572421</time><arg>http://10.11.12.13/SophosUpdate/CIDs/S000/EESAVUNIX/SUNOS_9_SPARC</arg></log>
+<log><category>savscan.log</category><level>INFO</level><domain>savscan</domain><msg>NOTIFY_ONDEMANDTHREAT_INFECTED %s</msg><time>1558572421</time><arg>path_file</arg></log>
+<log><category>savscan.log</category><level>INFO</level><domain>savscan</domain><msg>SCANNER_DIED_KILLED</msg><time>1558572421</time></log>  
+-->
+<decoder name="sophos-av">
+    <prematch>\<log>\.+\</log></prematch>
+</decoder>
+
+<decoder  name="sophos-av">
+    <parent>sophos-av</parent>
+    <regex>\<category>(\.+)\</category></regex>
+    <order>category</order>
+</decoder>
+
+<decoder name="sophos-av">
+    <parent>sophos-av</parent>
+    <regex>\<level>(\w+)\</level></regex>
+    <order>level</order>
+</decoder>
+
+<decoder name="sophos-av">
+    <parent>sophos-av</parent>
+    <regex>\<domain>(\.+)\</domain></regex>
+    <order>domain</order>
+</decoder>
+
+<decoder name="sophos-av">
+    <parent>sophos-av</parent>
+    <regex>\<msg>(\.+)\</msg></regex>
+    <order>msg</order>
+</decoder>
+
+<decoder name="sophos-av">
+    <parent>sophos-av</parent>
+    <regex>\<time>(\w+)\</time></regex>
+    <order>time</order>
+</decoder>
+
+<decoder name="sophos-av">
+    <parent>sophos-av</parent>
+    <regex>\<arg>(\w+)\</arg>\<arg>(\w+)\</arg>\<arg>(\w+)\</arg>\<arg>(\w+)\</arg>\<arg>(\w+)\</arg>\<arg>(\w+)\</arg></regex>
+    <order>mbootrecords,bootrecords,scanned_files,scan_errors,threads,infected_files</order>
+</decoder>
+
+<decoder name="sophos-av">
+    <parent>sophos-av</parent>
+    <regex>\<msg>NOTIFY_ONDEMANDTHREAT_INFECTED\.+\</msg>\.+\<arg>(\.+)\</arg></regex>
+    <order>infected_file_path</order>
+</decoder>

--- a/rules/0695-sophos_rules.xml
+++ b/rules/0695-sophos_rules.xml
@@ -1,0 +1,46 @@
+<!--
+  -  Sophos Antivirus rules
+  -  Created by Wazuh, Inc.
+  -  Copyright (C) 2015-2019, Wazuh Inc.
+  -  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2.
+-->
+
+<group name="sophos_rules">
+
+  <rule id="64270" level="0">
+	<decoded_as>sophos-av</decoded_as>
+    <field name="category">savscan.log</field>
+    <description>savscan category</description>
+  </rule>
+
+  <rule id="64271" level="3">
+    <if_sid>64270</if_sid>
+    <field name="msg">SAVSCAN-DETAILS</field>
+    <description>SAVSCAN-DETAILS alert</description>
+  </rule>
+
+  <rule id="64272" level="6">
+    <if_sid>64270</if_sid>
+    <field name="msg">NOTIFY_ONDEMANDTHREAT_INFECTED</field>
+    <description>NOTIFY_ONDEMANDTHREAT_INFECTED alert</description>
+  </rule>
+
+  <rule id="64273" level="6">
+    <if_sid>64270</if_sid>
+    <field name="msg">SCANNER_DIED_KILLED</field>
+    <description>SCANNER_DIED_KILLED alert</description>
+  </rule>
+
+  <rule id="64274" level="0">
+	<decoded_as>sophos-av</decoded_as>
+    <field name="category">update.check</field>
+    <description>Update category</description>
+  </rule>
+
+  <rule id="64275" level="3">
+    <if_sid>64274</if_sid>
+    <field name="msg">NO_UPDATED_FROM</field>
+    <description>NO_UPDATED_FROM alert</description>
+  </rule>
+
+</group>

--- a/tools/rules-testing/tests/sophos_av.ini
+++ b/tools/rules-testing/tests/sophos_av.ini
@@ -1,0 +1,27 @@
+[sophos av: Notice message detected]
+log 1 pass = <log><category>savscan.log</category><level>INFO</level><domain>savscan</domain><msg>SAVSCAN-DETAILS %s %s %s %s %s %s</msg><time>1558570140</time><arg>0</arg><arg>0</arg><arg>108267</arg><arg>131</arg><arg>0</arg><arg>0</arg></log>
+
+rule = 64271
+alert = 3
+decoder = sophos-av
+
+[sophos av: NOTIFY_ONDEMANDTHREAT_INFECTED alert]
+log 1 pass = <log><category>savscan.log</category><level>INFO</level><domain>savscan</domain><msg>NOTIFY_ONDEMANDTHREAT_INFECTED %s</msg><time>1558572421</time><arg>path_file</arg></log>
+
+rule = 64272
+alert = 6
+decoder = sophos-av
+
+[sophos av:  SCANNER_DIED_KILLED alert]
+log 1 pass = <log><category>savscan.log</category><level>INFO</level><domain>savscan</domain><msg>SCANNER_DIED_KILLED</msg><time>1558572421</time></log>
+rule = 64273
+alert = 6
+decoder = sophos-av
+
+[sophos av: NO_UPDATED_FROM alert]
+log 1 pass = <log><category>update.check</category><level>INFO</level><domain>savupdate</domain><msg>NO_UPDATED_FROM %s</msg><time>1558572421</time><arg>http://10.11.12.13/SophosUpdate/CIDs/S000/EESAVUNIX/SUNOS_9_SPARC</arg></log>
+ 
+
+rule = 64275
+alert = 3
+decoder = sophos-av


### PR DESCRIPTION
Hello,

We created new Decoders and Rules for **Sophos antivirus** Windows application.

We used Sibling Decoders to extract all of the dynamic fields the events.

For the Rules, we used both `<field name="category">` and `<field name="msg">` conditions to generate the corresponding alerts. I assigned IDs from **64270** to **64275**.

The script output doesn't show any "Failed" message:
```
# ./runtest.py
- [ File = ./tests/sophos_av.ini ] ---------
........
```

I upload the following files:
- `decoders/0299-sophos_decoders.xml `
- `rules/0695-sophos_rules.xml`
- `tools/rules-testing/sophos_av.ini`

Regards,
J. M. Mallorquín