### PR TITLE
Changing CIS-CAT rules according to JSON decode fields refactor

### DIFF
--- a/rules/0015-ossec_rules.xml
+++ b/rules/0015-ossec_rules.xml
@@ -244,7 +244,7 @@
   </rule>
 
 
-  <!-- File rotation/reducded rules -->
+  <!-- File rotation/truncation rules -->
   <rule id="591" level="3">
     <if_sid>500</if_sid>
     <match>^ossec: File rotated </match>

--- a/rules/0510-ciscat_rules.xml
+++ b/rules/0510-ciscat_rules.xml
@@ -44,198 +44,198 @@
   </rule>
 
   <rule id="87404" level="3">
-    <if_sid>87401, 87402</if_sid>
-    <field name="type">^scan_info$</field>
+    <if_sid>87401, 87402, 87403</if_sid>
+    <field name="cis.type">^scan_info$</field>
     <description>CIS-CAT: assessment information for scan $(scan_id)</description>
     <group></group>
     <options>no_full_log</options>
   </rule>
 
   <!-- Rule to support CIS-CAT rules of Wazuh 3.1 -->
-  <rule id="87405" level="3">
+  <!-- <rule id="87405" level="3">
     <if_sid>87403</if_sid>
-    <field name="type">^scan_info$</field>
+    <field name="cis.type">^scan_info$</field>
     <description>CIS-CAT: assessment information for scan $(scan_id)</description>
     <group></group>
     <options>no_full_log</options>
-  </rule>
+  </rule> -->
 
   <rule id="87406" level="0">
-    <if_sid>87401, 87402</if_sid>
-    <field name="type">^scan_result$</field>
+    <if_sid>87401, 87402, 87403</if_sid>
+    <field name="cis.type">^scan_result$</field>
     <field name="cis.result">^pass$</field>
     <description>CIS-CAT: $(cis.rule_title) (passed)</description>
     <options>no_full_log</options>
   </rule>
 
-  <rule id="87407" level="0">
+  <!-- <rule id="87407" level="0">
     <if_sid>87403</if_sid>
     <field name="type">^scan_result$</field>
     <field name="cis-data.result">^pass$</field>
     <description>CIS-CAT: $(cis-data.rule_title) (passed)</description>
     <options>no_full_log</options>
-  </rule>
+  </rule> -->
 
   <rule id="87408" level="0">
-    <if_sid>87401, 87402</if_sid>
-    <field name="type">^scan_result$</field>
+    <if_sid>87401, 87402, 87403</if_sid>
+    <field name="cis.type">^scan_result$</field>
     <field name="cis.result">^notchecked$</field>
     <description>CIS-CAT: $(cis.rule_title) (not checked)</description>
     <options>no_full_log</options>
   </rule>
 
-  <rule id="87409" level="0">
+  <!-- <rule id="87409" level="0">
     <if_sid>87403</if_sid>
     <field name="type">^scan_result$</field>
     <field name="cis-data.result">^notchecked$</field>
     <description>CIS-CAT: $(cis-data.rule_title) (not checked)</description>
     <options>no_full_log</options>
-  </rule>
+  </rule> -->
 
   <rule id="87410" level="0">
-    <if_sid>87401, 87402</if_sid>
-    <field name="type">^scan_result$</field>
+    <if_sid>87401, 87402, 87403</if_sid>
+    <field name="cis.type">^scan_result$</field>
     <field name="cis.result">^notselected$</field>
     <description>CIS-CAT: $(cis.rule_title) (not selected)</description>
     <options>no_full_log</options>
   </rule>
 
-  <rule id="87411" level="0">
+  <!-- <rule id="87411" level="0">
     <if_sid>87403</if_sid>
     <field name="type">^scan_result$</field>
     <field name="cis-data.result">^notselected$</field>
     <description>CIS-CAT: $(cis-data.rule_title) (not selected)</description>
     <options>no_full_log</options>
-  </rule>
+  </rule> -->
 
   <rule id="87412" level="3">
-    <if_sid>87401, 87402</if_sid>
-    <field name="type">^scan_result$</field>
+    <if_sid>87401, 87402, 87403</if_sid>
+    <field name="cis.type">^scan_result$</field>
     <field name="cis.result">^error$</field>
     <description>CIS-CAT: $(cis.rule_title) (error)</description>
     <options>no_full_log</options>
   </rule>
 
-  <rule id="87413" level="3">
+  <!-- <rule id="87413" level="3">
     <if_sid>87403</if_sid>
     <field name="type">^scan_result$</field>
     <field name="cis-data.result">^error$</field>
     <description>CIS-CAT: $(cis-data.rule_title) (error)</description>
     <options>no_full_log</options>
-  </rule>
+  </rule> -->
 
   <rule id="87414" level="3">
-    <if_sid>87401, 87402</if_sid>
-    <field name="type">^scan_result$</field>
+    <if_sid>87401, 87402, 87403</if_sid>
+    <field name="cis.type">^scan_result$</field>
     <field name="cis.result">^unknown$</field>
     <description>CIS-CAT: $(cis.rule_title) (unknown)</description>
     <options>no_full_log</options>
   </rule>
 
-  <rule id="87415" level="3">
+  <!-- <rule id="87415" level="3">
     <if_sid>87403</if_sid>
     <field name="type">^scan_result$</field>
     <field name="cis-data.result">^unknown$</field>
     <description>CIS-CAT: $(cis-data.rule_title) (unknown)</description>
     <options>no_full_log</options>
-  </rule>
+  </rule> -->
 
   <rule id="87416" level="1">
-    <if_sid>87401, 87402</if_sid>
-    <field name="type">^scan_result$</field>
+    <if_sid>87401, 87402, 87403</if_sid>
+    <field name="cis.type">^scan_result$</field>
     <field name="cis.result">^informational$</field>
     <description>CIS-CAT: $(cis.rule_title) (informational)</description>
     <options>no_full_log</options>
   </rule>
 
-  <rule id="87417" level="1">
+  <!-- <rule id="87417" level="1">
     <if_sid>87403</if_sid>
     <field name="type">^scan_result$</field>
     <field name="cis-data.result">^informational$</field>
     <description>CIS-CAT: $(cis-data.rule_title) (informational)</description>
     <options>no_full_log</options>
-  </rule>
+  </rule> -->
 
   <rule id="87418" level="7">
-    <if_sid>87401, 87402</if_sid>
-    <field name="type">^scan_result$</field>
+    <if_sid>87401, 87402, 87403</if_sid>
+    <field name="cis.type">^scan_result$</field>
     <field name="cis.result">^fail$</field>
     <description>CIS-CAT: $(cis.rule_title) (failed)</description>
     <group>gdpr_IV_35.7.d,</group>
     <options>no_full_log</options>
   </rule>
 
-  <rule id="87419" level="7">
+  <!-- <rule id="87419" level="7">
     <if_sid>87403</if_sid>
     <field name="type">^scan_result$</field>
     <field name="cis-data.result">^fail$</field>
     <description>CIS-CAT: $(cis-data.rule_title) (failed)</description>
     <group>gdpr_IV_35.7.d,</group>
     <options>no_full_log</options>
-  </rule>
+  </rule> -->
 
 <!-- Example JSON event
 {"type":"scan_info","scan_id":75459013,"cis":{"benchmark":"CIS Ubuntu Linux 16.04 LTS Benchmark","hostname":"ubuntu","timestamp":"2017-12-21T03:16:54.431-08:00","score":76}}
 -->
 
   <rule id="87420" level="4">
-    <if_sid>87401, 87402</if_sid>
+    <if_sid>87401, 87402, 87403</if_sid>
     <field name="cis.score">^8\d</field>
     <description>CIS-CAT Report overview: Score less than 90% ($(cis.score))</description>
     <options>no_full_log</options>
   </rule>
 
-  <rule id="87421" level="4">
+  <!-- <rule id="87421" level="4">
     <if_sid>87403</if_sid>
     <field name="cis-data.score">^8\d</field>
     <description>CIS-CAT Report overview: Score less than 90% ($(cis-data.score) %)</description>
     <options>no_full_log</options>
-  </rule>
+  </rule> -->
 
   <rule id="87422" level="5">
-    <if_sid>87401, 87402</if_sid>
+    <if_sid>87401, 87402, 87403</if_sid>
     <field name="cis.score">^7\d|^6\d|^5\d</field>
     <description>CIS-CAT Report overview: Score less than 80% ($(cis.score))</description>
     <options>no_full_log</options>
   </rule>
 
-  <rule id="87423" level="5">
+  <!-- <rule id="87423" level="5">
     <if_sid>87403</if_sid>
     <field name="cis-data.score">^7\d|^6\d|^5\d</field>
     <description>CIS-CAT Report overview: Score less than 80% ($(cis-data.score) %)</description>
     <options>no_full_log</options>
-  </rule>
+  </rule> -->
 
   <rule id="87424" level="7">
-    <if_sid>87401, 87402</if_sid>
+    <if_sid>87401, 87402, 87403</if_sid>
     <field name="cis.score">^4\d|^3\d</field>
     <description>CIS-CAT Report overview: Score less than 50% ($(cis.score))</description>
     <group>gdpr_IV_35.7.d,</group>
     <options>no_full_log</options>
   </rule>
 
-  <rule id="87425" level="7">
+  <!-- <rule id="87425" level="7">
     <if_sid>87403</if_sid>
     <field name="cis-data.score">^4\d|^3\d</field>
     <description>CIS-CAT Report overview: Score less than 50% ($(cis-data.score) %)</description>
     <group>gdpr_IV_35.7.d,</group>
     <options>no_full_log</options>
-  </rule>
+  </rule> -->
 
   <rule id="87426" level="9">
-    <if_sid>87401, 87402</if_sid>
+    <if_sid>87401, 87402, 87403</if_sid>
     <field name="cis.score">^2\d|^1\d|^\d$</field>
     <description>CIS-CAT Report overview: Score less than 30% ($(cis.score))</description>
     <group>gdpr_IV_35.7.d,</group>
     <options>no_full_log</options>
   </rule>
 
-  <rule id="87427" level="9">
+  <!-- <rule id="87427" level="9">
     <if_sid>87403</if_sid>
     <field name="cis-data.score">^2\d|^1\d|^\d$</field>
     <description>CIS-CAT Report overview: Score less than 30% ($(cis-data.score) %)</description>
     <group>gdpr_IV_35.7.d,</group>
     <options>no_full_log</options>
-  </rule>
+  </rule> -->
 
 </group>


### PR DESCRIPTION
|Related issue|
|---|
|#452|

## Description

This PR aims to adjust the CIS-CAT rules `0510-ciscat_rules.xml` according to changes performed at the mentioned issue.

* The field names have been updated by adding the `cis` prefix. For example :
  `field name="result"` ---> `field name="cis.result"`
* Both `cis:` and `cis-data` events have been unified under the same fields. It is mean the fields such as `cis-data.X` have been replaced by `cis.X`

## Tests

- [x] Generating CIS-CAT alerts such as `rule id = 87418`
- [x] Getting the appropriate JSON alert.

```
{
  "timestamp": "2019-07-18T16:00:07.521+0000",
  "rule": {
    "level": 7,
    "description": "CIS-CAT: Ensure users own their home directories (failed)",
    "id": "87418",
    "firedtimes": 66,
    "mail": false,
    "groups": [
      "ciscat"
    ],
    "gdpr": [
      "IV_35.7.d"
    ]
  },
  "agent": {
    "id": "001",
    "name": "centOS7-Agent",
    "ip": "10.0.2.15"
  },
  "manager": {
    "name": "wazuhManager"
  },
  "id": "1563465607.905311",
  "decoder": {
    "name": "ciscat"
  },
  "data": {
    "cis": {
      "type": "scan_result",
      "scan_id": "29230194",
      "rule_id": "6.2.9",
      "rule_title": "Ensure users own their home directories",
      "group": "System Maintenance",
      "description": "The user home directory is space defined for the particular user to set local environment variables and to store personal files.",
      "rationale": "Since the user is accountable for files stored in the user home directory, the user must be the owner of the directory.",
      "remediation": "Change the ownership of any home directories that are not owned by the defined user to the correct user.",
      "result": "fail"
    }
  },
  "location": "wodle_cis-cat"
}
``` 

The ciscat rules file modified : 
```
<rule id="87402" level="0">
    <decoded_as>json</decoded_as>
    <field name="type">\.+</field>
    <field name="scan_id">\.+</field>
    <match>"cis":{</match>
    <description>CIS-CAT events.</description>
    <options>no_full_log</options>
  </rule>

  <rule id="87403" level="0">
    <decoded_as>json</decoded_as>
    <field name="type">\.+</field>
    <field name="scan_id">\.+</field>
    <match>"cis-data":{</match>
    <description>Old CIS-CAT events.</description>
    <options>no_full_log</options>
  </rule>

...
<rule id="87418" level="7">
    <if_sid>87401, 87402, 87403</if_sid>
    <field name="cis.type">^scan_result$</field>
    <field name="cis.result">^fail$</field>
    <description>CIS-CAT: $(cis.rule_title) (failed)</description>
    <group>gdpr_IV_35.7.d,</group>
    <options>no_full_log</options>
  </rule>
...
```