### PR TITLE
Scope Rule 80200 to ^aws$

### DIFF
--- a/rules/0350-amazon_rules.xml
+++ b/rules/0350-amazon_rules.xml
@@ -15,7 +15,7 @@ ID: 80200 - 80499
     <!-- AWS wodle -->
     <rule id="80200" level="0">
         <decoded_as>json</decoded_as>
-        <field name="integration">aws</field>
+        <field name="integration">^aws$</field>
         <description>AWS alert.</description>
         <options>no_full_log</options>
     </rule>


### PR DESCRIPTION
The current rule for 80200 will match any integration that begins with aws. Would like to scope specific to just aws to support some additional integrations and rules off of them. My specific intent at the moment is to spin rules off of the integration value, aws.c7n.