### PR TITLE
Fix rules about shellshock attack

### DIFF
--- a/rules/0245-web_rules.xml
+++ b/rules/0245-web_rules.xml
@@ -232,7 +232,7 @@
     192.168.2.100 - - [02/Nov/2015:01:35:55 +0100] "GET /cgi-bin/test.sh HTTP/1.1" 200 292 "-" "() { _; foo; } >_[$($())] { /usr/bin/perl ... }"
     -->
 
-    <rule id="31166" level="15">
+  <rule id="31166" level="15">
     <if_sid>31101,31108</if_sid>
     <regex>"\(\)\s*{\s*:;\s*}\s*;|"\(\)\s*{\s*foo:;\s*}\s*;|"\(\)\s*{\s*ignored;\s*}\s*|"\(\)\s*{\s*gry;\s*}\s*;</regex>
     <description>Shellshock attack attempt</description>

--- a/rules/0245-web_rules.xml
+++ b/rules/0245-web_rules.xml
@@ -18,13 +18,13 @@
     <id>^2|^3</id>
     <compiled_rule>is_simple_http_request</compiled_rule>
     <description>Ignored URLs (simple queries).</description>
-   </rule>
+  </rule>
 
   <rule id="31101" level="5">
     <if_sid>31100</if_sid>
     <id>^4</id>
     <description>Web server 400 error code.</description>
-	<group>attack,pci_dss_6.5,pci_dss_11.4,gdpr_IV_35.7.d,nist_800_53_SA.11,nist_800_53_SI.4,</group>
+    <group>attack,pci_dss_6.5,pci_dss_11.4,gdpr_IV_35.7.d,nist_800_53_SA.11,nist_800_53_SI.4,</group>
   </rule>
 
   <rule id="31102" level="0">
@@ -218,10 +218,11 @@
 <!--
     Shellshock detected
     Pattern: "(){:;};" (with spaces)
-    Code: 200
+    Code: 200, 404
     Decoder: web-accesslog_decoders.xml
 
     Examples:
+    192.168.2.100 - - [02/Nov/2015:01:35:55 +0100] "GET /cgi-bin/test.sh HTTP/1.1" 404 292 "-" "() { :;};/usr/bin/perl ..."
     192.168.2.100 - - [02/Nov/2015:01:35:55 +0100] "GET /cgi-bin/test.sh HTTP/1.1" 200 292 "-" "() { :;};/usr/bin/perl ..."
     192.168.2.100 - - [02/Nov/2015:01:35:55 +0100] "GET /cgi-bin/test.sh HTTP/1.1" 200 292 "-" "() { foo:; };/usr/bin/perl ..."
     192.168.2.100 - - [02/Nov/2015:01:35:55 +0100] "GET /cgi-bin/test.sh HTTP/1.1" 200 292 "-" "() { ignored; };/usr/bin/perl ..."
@@ -230,24 +231,23 @@
     192.168.2.100 - - [02/Nov/2015:01:35:55 +0100] "GET /cgi-bin/test.sh HTTP/1.1" 200 292 "-" "() { _; } >_[$($())] { /usr/bin/perl ... }"
     192.168.2.100 - - [02/Nov/2015:01:35:55 +0100] "GET /cgi-bin/test.sh HTTP/1.1" 200 292 "-" "() { _; foo; } >_[$($())] { /usr/bin/perl ... }"
     -->
+
     <rule id="31166" level="15">
-        <if_sid>31108</if_sid>
-	<regex>"\(\)\s*{\s*:;\s*}\s*;|"\(\)\s*{\s*foo:;\s*}\s*;|"\(\)\s*{\s*ignored;\s*}\s*|"\(\)\s*{\s*gry;\s*}\s*;</regex>
-        <description>Shellshock attack detected</description>
-	<info type="cve">CVE-2014-6271</info>
-	<info type="link">https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2014-6271</info>
-        <group>attack,pci_dss_11.4,gdpr_IV_35.7.d,nist_800_53_SI.4,</group>
-    </rule>
+    <if_sid>31101,31108</if_sid>
+    <regex>"\(\)\s*{\s*:;\s*}\s*;|"\(\)\s*{\s*foo:;\s*}\s*;|"\(\)\s*{\s*ignored;\s*}\s*|"\(\)\s*{\s*gry;\s*}\s*;</regex>
+    <description>Shellshock attack attempt</description>
+    <info type="cve">CVE-2014-6271</info>
+    <info type="link">https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2014-6271</info>
+    <group>attack,pci_dss_11.4,gdpr_IV_35.7.d,nist_800_53_SI.4,</group>
+  </rule>
 
-
-        <rule id="31167" level="15">
-        <if_sid>31108</if_sid>
-        <regex>"\(\)\s*{\s*_;\.*}\s*>_[\$\(\$\(\)\)]\s*{</regex>
-        <description>Shellshock attack detected</description>
-	<info type="cve">CVE-2014-6278</info>
-	<info type="link">https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2014-6278</info>
-        <group>attack,pci_dss_11.4,nist_800_53_SI.4,</group>
-    </rule>
-
+  <rule id="31167" level="15">
+    <if_sid>31101,31108</if_sid>
+    <regex>"\(\)\s*{\s*_;\.*}\s*>_[\$\(\$\(\)\)]\s*{</regex>
+    <description>Shellshock attack attempt</description>
+    <info type="cve">CVE-2014-6278</info>
+    <info type="link">https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2014-6278</info>
+    <group>attack,pci_dss_11.4,gdpr_IV_35.7.d,nist_800_53_SI.4,</group>
+  </rule>
 
 </group>

--- a/rules/0250-apache_rules.xml
+++ b/rules/0250-apache_rules.xml
@@ -295,37 +295,4 @@
     <group>modsecurity,gpg13_10.1,</group>
   </rule>
 
-    <!--
-    Shellshock detected
-    Pattern: "(){:;};" (with spaces)
-    Code: 400
-    Decoder: web-accesslog_decoders.xml
-
-    Examples:
-    192.168.2.100 - - [02/Nov/2015:01:35:55 +0100] "GET /cgi-bin/test.sh HTTP/1.1" 404 292 "-" "() { :;};/usr/bin/perl ..."
-    192.168.2.100 - - [02/Nov/2015:01:35:55 +0100] "GET /cgi-bin/test.sh HTTP/1.1" 200 292 "-" "() { foo:; };/usr/bin/perl ..."
-    192.168.2.100 - - [02/Nov/2015:01:35:55 +0100] "GET /cgi-bin/test.sh HTTP/1.1" 200 292 "-" "() { ignored; };/usr/bin/perl ..."
-    192.168.2.100 - - [02/Nov/2015:01:35:55 +0100] "GET /cgi-bin/test.sh HTTP/1.1" 200 292 "-" "() { gry; };/usr/bin/perl ..."
-
-    192.168.2.100 - - [02/Nov/2015:01:35:55 +0100] "GET /cgi-bin/test.sh HTTP/1.1" 200 292 "-" "() { _; } >_[$($())] { /usr/bin/perl ... }"
-    192.168.2.100 - - [02/Nov/2015:01:35:55 +0100] "GET /cgi-bin/test.sh HTTP/1.1" 200 292 "-" "() { _; foo; } >_[$($())] { /usr/bin/perl ... }"
-    -->
-    <rule id="30412" level="6">
-        <if_sid>31101</if_sid>
-	<regex>"\(\)\s*{\s*:;\s*}\s*;|"\(\)\s*{\s*foo:;\s*}\s*;|"\(\)\s*{\s*ignored;\s*}\s*|"\(\)\s*{\s*gry;\s*}\s*;</regex>
-        <description>Apache: Shellshock attack attempt</description>
-	<info type="cve">CVE-2014-6271</info>
-	<info type="link">https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2014-6271</info>
-        <group>attack,pci_dss_11.4,gdpr_IV_35.7.d,nist_800_53_SI.4,</group>
-    </rule>
-
-    <rule id="30413" level="6">
-        <if_sid>31101</if_sid>
-        <regex>"\(\)\s*{\s*_;\.*}\s*>_[\$\(\$\(\)\)]\s*{</regex>
-        <description>Apache: Shellshock attack attempt</description>
-	<info type="cve">CVE-2014-6278</info>
-	<info type="link">https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2014-6278</info>
-        <group>attack,pci_dss_11.4,nist_800_53_SI.4,</group>
-    </rule>
-
 </group>


### PR DESCRIPTION
Hi team,

The shellshock rules were duplicated in the Apache rules file, looking for the same events, with a rule level of 6 which is too low for a shellshock attack, and with the GDPR mapping missing.

This pull request fixes the following issues:

- Merged the shellshock rules in the file `0245-web_rules.xml`.
- As the web code for a shellshock attack can be 200 or 404, the parent rules should be 31101 and 31108.
- Added the GDPR mapping to rule 31167.
- Fixed format of some rules.

**Logtest output**

*Rule 31166*

```
192.168.2.100 - - [02/Nov/2015:01:35:55 +0100] "GET /cgi-bin/test.sh HTTP/1.1" 404 292 "-" "() { :;};/usr/bin/perl ..."


**Phase 1: Completed pre-decoding.
       full event: '192.168.2.100 - - [02/Nov/2015:01:35:55 +0100] "GET /cgi-bin/test.sh HTTP/1.1" 404 292 "-" "() { :;};/usr/bin/perl ..."'
       timestamp: '(null)'
       hostname: 'ubuntu'
       program_name: '(null)'
       log: '192.168.2.100 - - [02/Nov/2015:01:35:55 +0100] "GET /cgi-bin/test.sh HTTP/1.1" 404 292 "-" "() { :;};/usr/bin/perl ..."'

**Phase 2: Completed decoding.
       decoder: 'web-accesslog'
       srcip: '192.168.2.100'
       protocol: 'GET'
       url: '/cgi-bin/test.sh'
       id: '404'

**Phase 3: Completed filtering (rules).
       Rule id: '31166'
       Level: '15'
       Description: 'Shellshock attack attempt'
       Info - CVE: 'CVE-2014-6271'
       Info - Link: 'https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2014-6271'
**Alert to be generated.
```

*Rule 31167*

```
**Phase 1: Completed pre-decoding.
       full event: '192.168.2.100 - - [02/Nov/2015:01:35:55 +0100] "GET /cgi-bin/test.sh HTTP/1.1" 200 292 "-" "() { _; } >_[$($())] { /usr/bin/perl ... }"'
       timestamp: '(null)'
       hostname: 'ubuntu'
       program_name: '(null)'
       log: '192.168.2.100 - - [02/Nov/2015:01:35:55 +0100] "GET /cgi-bin/test.sh HTTP/1.1" 200 292 "-" "() { _; } >_[$($())] { /usr/bin/perl ... }"'

**Phase 2: Completed decoding.
       decoder: 'web-accesslog'
       srcip: '192.168.2.100'
       protocol: 'GET'
       url: '/cgi-bin/test.sh'
       id: '200'

**Phase 3: Completed filtering (rules).
       Rule id: '31167'
       Level: '15'
       Description: 'Shellshock attack attempt'
       Info - CVE: 'CVE-2014-6278'
       Info - Link: 'https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2014-6278'
**Alert to be generated.
```