### PR TITLE
3.10 New rule for Windows 

### DIFF
--- a/rules/0590-win-system_rules.xml
+++ b/rules/0590-win-system_rules.xml
@@ -283,5 +283,13 @@
     <description>Some errors occur aproximately every three seconds</description>
     <options>no_full_log</options>
   </rule>
+  
+  <rule id="61138" level="5">
+    <if_sid>61100</if_sid>
+    <field name="win.system.eventID">^7045$</field>
+    <description>New Windows Service Created</description>
+    <options>no_full_log</options>
+    <options>no_email_alert</options>
+  </rule>
 
 </group>

--- a/tools/rules-testing/tests/new_windows_service.ini
+++ b/tools/rules-testing/tests/new_windows_service.ini
@@ -1,5 +1,0 @@
-[windows: new service alert message]
-log 1 pass = {"win":{"system":{"providerName":"Service Control Manager","providerGuid":"{555908d1-a6d7-4695-8e1e-26931d2012f4}","eventSourceName":"Service Control Manager","eventID":"7045","version":"0","level":"4","task":"0","opcode":"0","keywords":"0x8080000000000000","systemTime":"2019-07-30T14:34:57.458127900Z","eventRecordID":"1973","processID":"784","threadID":"7588","channel":"System","computer":"AAAA","severityValue":"INFORMATION","message":"Se instaló un servicio en el sistema."},"eventdata":{"serviceName":"AAAA","imagePath":"\"C:\\Program Files (x86)\\AAAA\\AAAA.exe\"","serviceType":"servicio de modo usuario","startType":"inicio automático","accountName":"LocalSystem"}}},"location":"EventChannel"}
-rule = 61138
-alert = 5
-decoder = json

--- a/tools/rules-testing/tests/new_windows_service.ini
+++ b/tools/rules-testing/tests/new_windows_service.ini
@@ -1,0 +1,5 @@
+[windows: new service alert message]
+log 1 pass = {"win":{"system":{"providerName":"Service Control Manager","providerGuid":"{555908d1-a6d7-4695-8e1e-26931d2012f4}","eventSourceName":"Service Control Manager","eventID":"7045","version":"0","level":"4","task":"0","opcode":"0","keywords":"0x8080000000000000","systemTime":"2019-07-30T14:34:57.458127900Z","eventRecordID":"1973","processID":"784","threadID":"7588","channel":"System","computer":"AAAA","severityValue":"INFORMATION","message":"Se instaló un servicio en el sistema."},"eventdata":{"serviceName":"AAAA","imagePath":"\"C:\\Program Files (x86)\\AAAA\\AAAA.exe\"","serviceType":"servicio de modo usuario","startType":"inicio automático","accountName":"LocalSystem"}}},"location":"EventChannel"}
+rule = 61138
+alert = 5
+decoder = json


### PR DESCRIPTION
The new rule is created to alert the installation of new services in a Windows system. It is made to trigger an alert when the Event ID 7045 is received. 

This is the new rule added at `/var/ossec/ruleset/rules/0590-win-system_rules.xml` :

```
<rule id="61138" level="5">
    <if_sid>61100</if_sid>
    <field name="win.system.eventID">^7045$</field>
    <description>New Windows Service Created</description>
    <options>no_full_log</options>
    <options>no_email_alert</options>
  </rule>
```

-  The field `<options>no_full_log</options>` is necessary because the full_log is in JSON format, so Elasticsearch can't process it correctly.


Event in JSON format received when a new system is installed, used to trigger this rule:

```
{"win":{"system":{"providerName":"Service Control Manager","providerGuid":"{555908d1-a6d7-4695-8e1e-26931d2012f4}","eventSourceName":"Service Control Manager","eventID":"7045","version":"0","level":"4","task":"0","opcode":"0","keywords":"0x8080000000000000","systemTime":"2019-07-30T14:34:57.458127900Z","eventRecordID":"1973","processID":"784","threadID":"7588","channel":"System","computer":"AAAA","severityValue":"INFORMATION","message":"Se instaló un servicio en el sistema."},"eventdata":{"serviceName":"AAAA","imagePath":"\"C:\\Program Files (x86)\\AAAA\\AAAA.exe\"","serviceType":"servicio de modo usuario","startType":"inicio automático","accountName":"LocalSystem"}}},"location":"EventChannel"}

```


- This rule was integrated with the collaboration of Gregory Bryant ( gregory.bryant@symplexity.com)