### PR TITLE
delete id 20049 from if_sid tag of rules 64101 and 18125

### DIFF
--- a/rules/0220-msauth_rules.xml
+++ b/rules/0220-msauth_rules.xml
@@ -162,7 +162,7 @@
 
   <rule id="18125" level="5">
     <if_sid>18102, 18103</if_sid>
-    <id>^20187$|^20014$|^20078$|^20050$|^20049$|^20189$</id>
+    <id>^20187$|^20014$|^20078$|^20050$|^20189$</id>
     <description>Windows: Remote access login failure.</description>
     <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_8.1.5,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,hipaa_164.312.a.1,nist_800_53_AU.14,nist_800_53_AC.7,nist_800_53_AC.2,</group>
   </rule>

--- a/rules/0620-win-generic_rules.xml
+++ b/rules/0620-win-generic_rules.xml
@@ -21,7 +21,7 @@
 
   <rule id="64101" level="5">
     <if_sid>64100</if_sid>
-    <field name="win.system.eventID">^20187$|^20014$|^20078$|^20050$|^20049$|^20189$</field>
+    <field name="win.system.eventID">^20187$|^20014$|^20078$|^20050$|^20189$</field>
     <description>Remote access login failure</description>
     <options>no_full_log</options>
     <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_8.1.5,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,hipaa_164.312.a.1,nist_800_53_AU.14,nist_800_53_AC.7,nist_800_53_AC.2,</group>


### PR DESCRIPTION
Hi team!

Rules `64101` and `18125` have value `20049` in its `if_sid` tags but this rule (`20049`) not exist now.
I remove this value from tags.

Regards, Eva