### PR TITLE
modify runtest

### DIFF
--- a/tools/rules-testing/rules/test_rules.xml
+++ b/tools/rules-testing/rules/test_rules.xml
@@ -35,7 +35,7 @@
 <!-- Dec 25 20:45:02 MyHost test_same_fields[12345]: User 'admin' logged from '192.168.1.100' 5 this is the not_same_fields test -->
 <!-- Dec 25 20:45:02 MyHost test_same_fields[12345]: User 'admin' logged from '192.168.1.100' 6 this is the not_same_fields test -->
 <!-- Dec 25 20:45:02 MyHost test_same_fields[12345]: User 'admin' logged from '192.168.1.100' 7 this is the not_same_fields test -->
-  <rule id="999207" level="3">
+<rule id="999207" level="3">
   <match>this is the not_same_fields test</match>
   <description>Testing not_same_fields</description>
 </rule>
@@ -46,5 +46,42 @@
   <description>Not Same fields works</description>
 </rule>
 
+<!--
+Dec 10 01:02:02 my_host my_progrma[1234]: ifsid test
+-->
+<rule id="999999" level="1">
+  <match>ifsid test</match>
+  <description>Parent rule</description>
+</rule>
+
+<!--
+Dec 10 01:02:02 my_host my_progrma[1234]: ifsid test r98 r96
+-->
+<rule id="999998" level="4">
+  <if_sid>999999</if_sid>
+  <match>r98</match>
+  <description>Child rule 98</description>
+</rule>
+
+<rule id="999997" level="4">
+  <if_sid>999999</if_sid>
+  <match>r97</match>
+  <description>Child rule 97</description>
+</rule>
+
+<rule id="999996" level="6">
+  <if_sid>999998</if_sid>
+  <match>r96</match>
+  <description>Child rule 98 96</description>
+</rule>
+
+<!--
+Dec 10 01:02:02 my_host my_progrma[1234]: ifsid test r97 r96
+-->
+<rule id="999996" level="4" overwrite="yes">
+  <if_sid>999997</if_sid>
+  <match>r96</match>
+  <description>Child overwrite rule 97 96</description>
+</rule>
 
 </group>

--- a/tools/rules-testing/runtests.py
+++ b/tools/rules-testing/runtests.py
@@ -55,6 +55,28 @@ def cleanDR(bdir):
         sys.exit(1)
 
 
+def provisionEC(bdir):
+    with open(bdir + '/etc/rules/local_rules.xml', 'a') as f:
+        f.write('<group name="windows,">')
+        f.write('<rule id="60000" level="0" overwrite="yes">')
+        f.write('<decoded_as>json</decoded_as>')
+        f.write('<field name="win.system.providerName">\.+</field>')
+        f.write('<options>no_full_log</options>')
+        f.write('<description>Overwrite succefuly</description>')
+        f.write('</rule>')
+        f.write('</group>')
+
+
+def cleanEC(bdir):
+    with open(bdir + '/etc/rules/local_rules.xml', 'r') as fread:
+        lines = fread.readlines()
+        with open(bdir + '/etc/rules/local_rules.xml', 'w') as fwrite:
+            for line in lines:
+                if '<group name="windows,">' not in line:
+                    fwrite.write(line)
+
+
+
 class OssecTester(object):
     def __init__(self, bdir):
         self._error = False
@@ -145,6 +167,8 @@ if __name__ == "__main__":
     initconfigpath = "/etc/ossec-init.conf"
     getOssecConfig(ossec_init, initconfigpath)
     provisionDR(ossec_init["DIRECTORY"])
+    provisionEC(ossec_init['DIRECTORY'])
     OT = OssecTester(ossec_init["DIRECTORY"])
     OT.run(selective_test)
     cleanDR(ossec_init["DIRECTORY"])
+    cleanEC(ossec_init['DIRECTORY'])

--- a/tools/rules-testing/runtests.py
+++ b/tools/rules-testing/runtests.py
@@ -65,6 +65,7 @@ def provisionEC(bdir):
         f.write('<description>Overwrite succefuly</description>')
         f.write('</rule>')
         f.write('</group>')
+    f.close()
 
 
 def cleanEC(bdir):
@@ -74,6 +75,8 @@ def cleanEC(bdir):
             for line in lines:
                 if '<group name="windows,">' not in line:
                     fwrite.write(line)
+        fwrite.close()
+    fread.close()
 
 
 

--- a/tools/rules-testing/runtests.py
+++ b/tools/rules-testing/runtests.py
@@ -14,12 +14,14 @@ import os.path
 from collections import OrderedDict
 import shutil
 
+
 class MultiOrderedDict(OrderedDict):
     def __setitem__(self, key, value):
         if isinstance(value, list) and key in self:
             self[key].extend(value)
         else:
             super(MultiOrderedDict, self).__setitem__(key, value)
+
 
 def getOssecConfig(initconf,path):
     if os.path.isfile(path):
@@ -34,6 +36,7 @@ def getOssecConfig(initconf,path):
         print "Seems like there is no Wazuh installation or ossec-init.conf is missing."
         sys.exit(1)
 
+
 def provisionDR(bdir):
     if os.path.isfile("./rules/test_rules.xml") and os.path.isfile("./decoders/test_decoders.xml"):
         shutil.copy2("./rules/test_rules.xml", ossec_init["DIRECTORY"] + "/etc/rules")
@@ -42,6 +45,7 @@ def provisionDR(bdir):
         print "Test files are missing."
         sys.exit(1)
 
+
 def cleanDR(bdir):
     if os.path.isfile(bdir + "/etc/rules/test_rules.xml") and os.path.isfile(bdir + "/etc/decoders/test_decoders.xml"):
         os.remove(bdir + "/etc/rules/test_rules.xml")
@@ -49,6 +53,7 @@ def cleanDR(bdir):
     else:
         print "Could not clean rules and decoders test files"
         sys.exit(1)
+
 
 class OssecTester(object):
     def __init__(self, bdir):
@@ -69,6 +74,7 @@ class OssecTester(object):
             cmd += ["-D", self._base_dir]
         cmd += ['-U', "%s:%s:%s" % (rule, alert, decoder)]
         return cmd
+
     def runTest(self, log, rule, alert, decoder, section, name, negate=False):
         p = subprocess.Popen(
                 self.buildCmd(rule, alert, decoder),
@@ -126,6 +132,7 @@ class OssecTester(object):
         if self._error:
             sys.exit(1)
 
+
 if __name__ == "__main__":
     if len(sys.argv) == 2:
         selective_test = sys.argv[1]
@@ -133,6 +140,7 @@ if __name__ == "__main__":
             selective_test += '.ini'
     else:
         selective_test = False
+
     ossec_init = {}
     initconfigpath = "/etc/ossec-init.conf"
     getOssecConfig(ossec_init, initconfigpath)

--- a/tools/rules-testing/runtests.py
+++ b/tools/rules-testing/runtests.py
@@ -133,10 +133,10 @@ if __name__ == "__main__":
             selective_test += '.ini'
     else:
         selective_test = False
-        ossec_init = {}
-        initconfigpath = "/etc/ossec-init.conf"
-        getOssecConfig(ossec_init, initconfigpath)
-        provisionDR(ossec_init["DIRECTORY"])
-        OT = OssecTester(ossec_init["DIRECTORY"])
-        OT.run(selective_test)
-        cleanDR(ossec_init["DIRECTORY"])
+    ossec_init = {}
+    initconfigpath = "/etc/ossec-init.conf"
+    getOssecConfig(ossec_init, initconfigpath)
+    provisionDR(ossec_init["DIRECTORY"])
+    OT = OssecTester(ossec_init["DIRECTORY"])
+    OT.run(selective_test)
+    cleanDR(ossec_init["DIRECTORY"])

--- a/tools/rules-testing/tests/features.ini
+++ b/tools/rules-testing/tests/features.ini
@@ -5,6 +5,20 @@ rule = 99900
 alert = 7
 decoder = ow_test
 
+[overwrite & if_sid I]
+log 1 pass = Dec 10 01:02:02 testUser ow_test[1234]: ifsid test r97 r96
+
+rule = 999996
+alert = 4
+decoder = ow_test
+
+[overwrite & if_sid II]
+log 1 pass = Dec 10 01:02:02 testUser ow_test[1234]: ifsid test r98 r96
+
+rule = 999998
+alert = 4
+decoder = ow_test
+
 [same fields]
 log 1 pass = Dec 25 20:45:02 MyHost test_same_fields[12345]: User 'admin' logged from '192.168.1.100' 5 this is the same_fields test
 log 1 pass = Dec 25 20:45:02 MyHost test_same_fields[12345]: User 'admin' logged from '192.168.1.100' 5 this is the same_fields test


### PR DESCRIPTION
The new modification allows only one test to be executed:
```
lopezziur@lopezziur:~/wazuh/wazuh-ruleset/tools/rules-testing$ sudo python runtests.py tests/apache.ini 
[sudo] contraseña para lopezziur: 
- [ File = ./tests/apache.ini ] ---------
............
```