### PR TITLE
Improved Windows Defender ruleset with new rules

### DIFF
--- a/rules/0600-win-wdefender_rules.xml
+++ b/rules/0600-win-wdefender_rules.xml
@@ -33,36 +33,1032 @@
     <group>system_error,gpg13_4.3,gdpr_IV_35.7.d,</group>
   </rule>
 
-  <!-- {"win":{"system":{"providerName":"Microsoft-Windows-Windows Defender","providerGuid":"{555908d1-a6d7-4695-8e1e-26931d2012f4}","eventSourceName":"Microsoft-Windows-Eventlog","eventID":"1116","version":"0","level":"4","task":"0","opcode":"0","keywords":"0x8080000000000000","systemTime":"2018-11-27T13:03:51.594213100Z","eventRecordID":"8453","correlation":"","processID":"608","threadID":"1296","channel":"Microsoft-Windows-Windows Defender/Operational","computer":"hffg","message":"Windows Defender has detected malware or other potentially unwanted software.","severityValue":"WARNING"},"eventdata":{"subjectUserSid":"S-1-5-21-571","subjectUserName":"HFFG$","subjectDomainName":"WORKGROUP","subjectLogonId":"0x3e7","transactionId":"{D2399FF4-F177-11E8-82BA-08002750D7C5}","newState":"52","resourceManager":"{7D5F0E1F-ABCB-11E8-A2E2-D5514FE2B72B}","processId":"0x3f8","processName":"C:\\Windows\\System32\\svchost.exe"}}}    -->
-  
-  <rule id="62103" level="12">
-    <if_sid>62101</if_sid>
-    <field name="win.system.eventID">^1116$</field>
-    <description>Windows Defender: detected potentially unwanted software $(win.eventdata.process Name)</description>
-    <options>no_full_log</options>
-    <group>gdpr_IV_35.7.d,</group>
-  </rule>
 
-  <!-- {"win":{"system":{"providerName":"Microsoft-Windows-Windows Defender","providerGuid":"{555908d1-a6d7-4695-8e1e-26931d2012f4}","eventSourceName":"Microsoft-Windows-Eventlog","eventID":"1117","version":"0","level":"4","task":"0","opcode":"0","keywords":"0x8080000000000000","systemTime":"2018-11-27T13:03:51.594213100Z","eventRecordID":"8453","correlation":"","processID":"608","threadID":"1296","channel":"Microsoft-Windows-Windows Defender/Operational","computer":"hffg","message":"Windows Defender has taken action to protect this machine from malware or other potentially unwanted software.   For more information please see the following:  http://go.microsoft.com/fwlink/?linkid=37020&name=Virus:DOS/EICAR_Test_File&threatid=2147519003&enterprise=0         Name: Virus:DOS/EICAR_Test_File         ID: 2147519003          Severity: Severe        Category: Virus         Path: file:_C:\Users\spiderman\Downloads\eicar.com.txt;webfile:_C:\Users\spiderman\Downloads\eicar.com.txt|http://www.eicar.org/download/eicar.com.txt|chrome.exe    Detection Origin: Internet      Detection Type: Concrete        Detection Source: Real-Time Protection          User: NT AUTHORITY\SYSTEM       Process Name: C:\Windows\System32\SearchProtocolHost.exe     Action: Quarantine      Action Status:  No additional actions required          Error Code: 0x80508023          Error description: The program could not find the malware and other potentially unwanted software on this computer.","severityValue":"INFORMATION"},"eventdata":{"subjectUserSid":"S-1-5-21-571","subjectUserName":"HFFG$","subjectDomainName":"WORKGROUP","subjectLogonId":"0x3e7","transactionId":"{D2399FF4-F177-11E8-82BA-08002750D7C5}","newState":"52","resourceManager":"{7D5F0E1F-ABCB-11E8-A2E2-D5514FE2B72B}","processId":"0x3f8","processName":"C:\\Windows\\System32\\svchost.exe"}}}    -->
   
-  <rule id="62104" level="7">
-    <if_sid>62100</if_sid>
-    <field name="win.system.eventID">^1117$</field>
-    <description>Windows Defender: taken action to protect machine from unwanted software $(win.eventdata.process Name)</description>
-    <options>no_full_log</options>
-    <group>gdpr_IV_35.7.d,</group>
-  </rule>
 
-  <rule id="62105" level="10" frequency="$MS_FREQ" timeframe="240">
+  <rule id="62103" level="10" frequency="$MS_FREQ" timeframe="240">
     <if_matched_sid>62102</if_matched_sid>
     <description>Multiple Windows Defender error events</description>
     <options>no_full_log</options>
   </rule>
 
-  <rule id="62106" level="10" frequency="$MS_FREQ" timeframe="120">
+  <rule id="62104" level="10" frequency="$MS_FREQ" timeframe="120">
     <if_matched_sid>62101</if_matched_sid>
     <description>Multiple Windows Defender warning events</description>
     <options>no_full_log</options>
   </rule>
+  
+  <rule id="62105" level="14" frequency="$MS_FREQ" timeframe="60">
+    <if_matched_sid>62101</if_matched_sid>
+    <description>Short-time multiple Windows Defender error events</description>
+    <options>no_full_log</options>
+  </rule>
 
+  <rule id="62106" level="14" frequency="$MS_FREQ" timeframe="30">
+    <if_matched_sid>62102</if_matched_sid>
+    <description>Short-time multiple Windows Defender warning events</description>
+    <options>no_full_log</options>
+  </rule>
+  
+  
+  <!-- Event ID 1000 -->
+  <rule id="62107" level="3">
+    <if_sid>62100</if_sid>
+    <field name="win.system.eventID">^1000$</field>
+    <description>Windows Defender: Antimalware scan started</description>
+    <options>no_full_log</options>
+    <group>gdpr_IV_35.7.d,</group>
+  </rule>
+
+
+  <!-- Event ID 1001 -->
+  <rule id="62108" level="3">
+    <if_sid>62100</if_sid>
+    <field name="win.system.eventID">^1001$</field>
+    <description>Windows Defender: Antimalware scan finished</description>
+    <options>no_full_log</options>
+    <group>gdpr_IV_35.7.d,</group>
+  </rule>
+
+
+  <!-- Event ID 1002 -->
+  <rule id="62109" level="5">
+    <if_sid>62101</if_sid>
+    <field name="win.system.eventID">^1002$</field>
+    <description>Windows Defender: Antimalware scan was stopped before it finished</description>
+    <options>no_full_log</options>
+    <group>gdpr_IV_35.7.d,</group>
+  </rule>
+
+
+  <!-- Event ID 1003 -->
+  <rule id="62110" level="3">
+    <if_sid>62100</if_sid>
+    <field name="win.system.eventID">^1003$</field>
+    <description>Windows Defender: Antimalware scan paused</description>
+    <options>no_full_log</options>
+    <group>gdpr_IV_35.7.d,</group>
+  </rule>
+
+
+  <!-- Event ID 1004 -->
+  <rule id="62111" level="3">
+    <if_sid>62100</if_sid>
+    <field name="win.system.eventID">^1004$</field>
+    <description>Windows Defender: Antimalware scan resumed</description>
+    <options>no_full_log</options>
+    <group>gdpr_IV_35.7.d,</group>
+  </rule>
+
+
+  <!-- Event ID 1005 -->
+  <rule id="62112" level="5">
+    <if_sid>62101</if_sid>
+    <field name="win.system.eventID">^1005$</field>
+    <description>Windows Defender: Antimalware scan failed</description>
+    <options>no_full_log</options>
+    <group>gdpr_IV_35.7.d,</group>
+  </rule>
+
+
+  <!-- Event ID 1006 -->
+  <rule id="62113" level="14">
+    <if_sid>62101</if_sid>
+    <field name="win.system.eventID">^1006$</field>
+    <description>Windows Defender: Antimalware engine found $(win.eventdata.severityName) malware or other potentially unwanted software</description>
+    <options>no_full_log</options>
+    <group>gdpr_IV_35.7.d,gdpr_II_5.1.f,</group>
+  </rule>
+
+
+  <!-- Event ID 1007 -->
+  <rule id="62114" level="3">
+    <if_sid>62100</if_sid>
+    <field name="win.system.eventID">^1007$</field>
+    <description>Windows Defender: Antimalware platform performed an action to protect your system from malware or other potentially unwanted software</description>
+    <options>no_full_log</options>
+    <group>gdpr_IV_35.7.d,gdpr_II_5.1.f,</group>
+  </rule>
+
+
+  <!-- Event ID 1008 -->
+  <rule id="62115" level="5">
+    <if_sid>62101</if_sid>
+    <field name="win.system.eventID">^1008$</field>
+    <description>Windows Defender: Antimalware platform failed to perform an action to protect your system from malware or other potentially unwanted software</description>
+    <options>no_full_log</options>
+    <group>gdpr_IV_35.7.d,gdpr_II_5.1.f,</group>
+  </rule>
+
+
+  <!-- Event ID 1009 -->
+  <rule id="62116" level="3">
+    <if_sid>62100</if_sid>
+    <field name="win.system.eventID">^1009$</field>
+    <description>Windows Defender: Antimalware platform restored an item from quarantine at $(win.eventdata.path)</description>
+    <options>no_full_log</options>
+    <group>gdpr_IV_35.7.d,gdpr_II_5.1.f,</group>
+  </rule>
+
+
+  <!-- Event ID 1010 -->
+  <rule id="62117" level="5">
+    <if_sid>62101</if_sid>
+    <field name="win.system.eventID">^1010$</field>
+    <description>Windows Defender: Antimalware platform could not restore an item from quarantine at $(win.eventdata.path)</description>
+    <options>no_full_log</options>
+    <group>gdpr_IV_35.7.d,gdpr_II_5.1.f,</group>
+  </rule>
+
+
+  <!-- Event ID 1011 -->
+  <rule id="62118" level="3">
+    <if_sid>62100</if_sid>
+    <field name="win.system.eventID">^1011$</field>
+    <description>Windows Defender: Antimalware platform deleted an item from quarantine at $(win.eventdata.path)</description>
+    <options>no_full_log</options>
+    <group>gdpr_IV_35.7.d,gdpr_II_5.1.f,</group>
+  </rule>
+
+
+  <!-- Event ID 1012 -->
+  <rule id="62119" level="5">
+    <if_sid>62101</if_sid>
+    <field name="win.system.eventID">^1012$</field>
+    <description>Windows Defender: Antimalware platform could not delete an item from quarantine at $(win.eventdata.path)</description>
+    <options>no_full_log</options>
+    <group>gdpr_IV_35.7.d,gdpr_II_5.1.f,</group>
+  </rule>
+
+
+  <!-- Event ID 1013 -->
+  <rule id="62120" level="3">
+    <if_sid>62100</if_sid>
+    <field name="win.system.eventID">^1013$</field>
+    <description>Windows Defender: Antimalware platform deleted history of malware and other potentially unwanted software</description>
+    <options>no_full_log</options>
+    <group>gdpr_IV_35.7.d,gdpr_II_5.1.f,</group>
+  </rule>
+
+
+  <!-- Event ID 1014 -->
+  <rule id="62121" level="5">
+    <if_sid>62101</if_sid>
+    <field name="win.system.eventID">^1014$</field>
+    <description>Windows Defender: Antimalware platform could not delete history of malware and other potentially unwanted software</description>
+    <options>no_full_log</options>
+    <group>gdpr_IV_35.7.d,gdpr_II_5.1.f,</group>
+  </rule>
+
+
+  <!-- Event ID 1015 -->
+  <rule id="62122" level="12">
+    <if_sid>62101</if_sid>
+    <field name="win.system.eventID">^1015$</field>
+    <description>Windows Defender: Antimalware platform detected suspicious $(win.eventdata.detectionType) behaviour ($(win.eventdata.processName))</description>
+    <options>no_full_log</options>
+    <group>gdpr_IV_35.7.d,</group>
+  </rule>
+
+
+  <!-- Event ID 1116 -->
+  <rule id="62123" level="12">
+      <if_sid>62101</if_sid>
+      <field name="win.system.eventID">^1116$</field>
+      <description>Windows Defender: Antimalware platform detected $(win.eventdata.severityName) potentially unwanted software ($(win.eventdata.processName))</description>
+      <options>no_full_log</options>
+      <group>gdpr_IV_35.7.d,</group>
+  </rule>
+
+
+  <!-- Event ID 1117 -->
+  <rule id="62124" level="3">
+      <if_sid>62100</if_sid>
+      <field name="win.system.eventID">^1117$</field>
+      <description>Windows Defender: Antimalware platform performed an action to protect you from potentially unwanted software ($(win.eventdata.processName))</description>
+      <options>no_full_log</options>
+      <group>gdpr_IV_35.7.d,gdpr_II_5.1.f,</group>
+  </rule>
+
+
+  <!-- Event ID 1118 -->
+  <rule id="62125" level="8">
+    <if_sid>62101</if_sid>
+    <field name="win.system.eventID">^1118$</field>
+    <description>Windows Defender: Antimalware platform failed performing an action to protect you from potentially unwanted software ($(win.eventdata.processName))</description>
+    <options>no_full_log</options>
+    <group>gdpr_IV_35.7.d,gdpr_II_5.1.f,</group>
+  </rule>
+
+
+  <!-- Event ID 1119 -->
+  <rule id="62126" level="14">
+    <if_sid>62101</if_sid>
+    <field name="win.system.eventID">^1119$</field>
+    <description>Windows Defender: Antimalware platform encountered a critical error when attempting to perform an action over the  potentially unwanted software</description>
+    <options>no_full_log</options>
+    <group>gdpr_IV_35.7.d,gdpr_II_5.1.f,</group>
+  </rule>
+
+
+  <!-- Event ID 1120 -->
+  <rule id="62127" level="3">
+    <if_sid>62100</if_sid>
+    <field name="win.system.eventID">^1120$</field>
+    <description>Windows Defender: Antimalware platform has deduced the hashes for a threat resource</description>
+    <options>no_full_log</options>
+    <group>gdpr_IV_35.7.d,</group>
+  </rule>
+
+
+  <!-- Event ID 1150 -->
+  <rule id="62128" level="3">
+    <if_sid>62100</if_sid>
+    <field name="win.system.eventID">^1150$</field>
+    <description>Windows Defender: Antimalware platform is running and in a healthy state</description>
+    <options>no_full_log</options>
+    <group>gdpr_IV_35.7.d,</group>
+  </rule>
+
+
+  <!-- Event ID 1151 -->
+  <rule id="62129" level="2">
+    <if_sid>62100</if_sid>
+    <field name="win.system.eventID">^1151$</field>
+    <description>Windows Defender: Endpoint Protection client health report</description>
+    <options>no_full_log</options>
+    <group>gdpr_IV_35.7.d,gdpr_IV_30.1.g</group>
+  </rule>
+
+
+  <!-- Event ID 2000 -->
+  <rule id="62130" level="3">
+    <if_sid>62100</if_sid>
+    <field name="win.system.eventID">^2000$</field>
+    <description>Windows Defender: Antimalware definitions updated successfully</description>
+    <options>no_full_log</options>
+  </rule>
+
+
+  <!-- Event ID 2001 -->
+  <rule id="62131" level="5">
+    <if_sid>62101</if_sid>
+    <field name="win.system.eventID">^2001$</field>
+    <description>Windows Defender: Antimalware definition update failed</description>
+    <options>no_full_log</options>
+  </rule>
+
+
+  <!-- Event ID 2002 -->
+  <rule id="62132" level="3">
+    <if_sid>62100</if_sid>
+    <field name="win.system.eventID">^2002$</field>
+    <description>Windows Defender: Antimalware engine updated successfully</description>
+    <options>no_full_log</options>
+  </rule>
+
+
+  <!-- Event ID 2003 -->
+  <rule id="62133" level="5">
+    <if_sid>62101</if_sid>
+    <field name="win.system.eventID">^2003$</field>
+    <description>Windows Defender: Antimalware engine update failed</description>
+    <options>no_full_log</options>
+  </rule>
+
+
+  <!-- Event ID 2004 -->
+  <rule id="62134" level="8">
+    <if_sid>62101</if_sid>
+    <field name="win.system.eventID">^2004$</field>
+    <description>Windows Defender: Error while attempting to load antimalware definitions</description>
+    <options>no_full_log</options>
+  </rule>
+
+
+  <!-- Event ID 2005 -->
+  <rule id="62135" level="8">
+    <if_sid>62101</if_sid>
+    <field name="win.system.eventID">^2005$</field>
+    <description>Windows Defender: Error while attempting to load antimalware engine because the antimalware platform is outdated</description>
+    <options>no_full_log</options>
+  </rule>
+
+
+  <!-- Event ID 2006 -->
+  <rule id="62136" level="8">
+    <if_sid>62101</if_sid>
+    <field name="win.system.eventID">^2006$</field>
+    <description>Windows Defender: Error while attempting to update antimalware platform</description>
+    <options>no_full_log</options>
+  </rule>
+
+
+  <!-- Event ID 2007 -->
+  <rule id="62137" level="2">
+    <if_sid>62100</if_sid>
+    <field name="win.system.eventID">^2007$</field>
+    <description>Windows Defender: Antimalware platform will soon be updated</description>
+    <options>no_full_log</options>
+    <group>gdpr_IV_35.7.d,</group>
+  </rule>
+
+
+  <!-- Event ID 2010 -->
+  <rule id="62138" level="3">
+    <if_sid>62100</if_sid>
+    <field name="win.system.eventID">^2010$</field>
+    <description>Windows Defender: Antimalware engine used Dynamic Signature Service to get additional definitions</description>
+    <options>no_full_log</options>
+    <group>gdpr_IV_35.7.d,</group>
+  </rule>
+
+
+  <!-- Event ID 2011 -->
+  <rule id="62139" level="3">
+    <if_sid>62100</if_sid>
+    <field name="win.system.eventID">^2011$</field>
+    <description>Windows Defender: DSS deleted the outdated dynamic definitions</description>
+    <options>no_full_log</options>
+    <group>gdpr_IV_35.7.d,</group>
+  </rule>
+
+
+  <!-- Event ID 2012 -->
+  <rule id="62140" level="8">
+    <if_sid>62101</if_sid>
+    <field name="win.system.eventID">^2012$</field>
+    <description>Windows Defender: Error while attempting to use Dynamic Signature Service</description>
+    <options>no_full_log</options>
+    <group>gdpr_IV_35.7.d,</group>
+  </rule>
+
+
+  <!-- Event ID 2013 -->
+  <rule id="62141" level="3">
+    <if_sid>62100</if_sid>
+    <field name="win.system.eventID">^2013$</field>
+    <description>Windows Defender: Dynamic Signature Service deleted all dynamic definitions</description>
+    <options>no_full_log</options>
+    <group>gdpr_IV_35.7.d,</group>
+  </rule>
+
+
+  <!-- Event ID 2020 -->
+  <rule id="62142" level="2">
+    <if_sid>62100</if_sid>
+    <field name="win.system.eventID">^2020$</field>
+    <description>Windows Defender: Antimalware engine downloaded a clean file</description>
+    <options>no_full_log</options>
+    <group>gdpr_IV_35.7.d,</group>
+  </rule>
+
+
+  <!-- Event ID 2021 -->
+  <rule id="62143" level="5">
+    <if_sid>62101</if_sid>
+    <field name="win.system.eventID">^2021$</field>
+    <description>Windows Defender: Antimalware engine failed to download a clean file</description>
+    <options>no_full_log</options>
+    <group>gdpr_IV_35.7.d,</group>
+  </rule>
+
+
+  <!-- Event ID 2030 -->
+  <rule id="62144" level="2">
+    <if_sid>62100</if_sid>
+    <field name="win.system.eventID">^2030$</field>
+    <description>Windows Defender: Antimalware engine was downloaded and is configured to run offline on the next system restart</description>
+    <options>no_full_log</options>
+    <group>gdpr_IV_35.7.d,</group>
+  </rule>
+
+
+  <!-- Event ID 2031 -->
+  <rule id="62145" level="5">
+    <if_sid>62101</if_sid>
+    <field name="win.system.eventID">^2031$</field>
+    <description>Windows Defender: Antimalware engine was unable to download and configure an offline scan</description>
+    <options>no_full_log</options>
+    <group>gdpr_IV_35.7.d,</group>
+  </rule>
+
+
+  <!-- Event ID 2040 -->
+  <rule id="62146" level="5">
+    <if_sid>62101</if_sid>
+    <field name="win.system.eventID">^2040$</field>
+    <description>Windows Defender: Antimalware support for this Operating System will soon end</description>
+    <options>no_full_log</options>
+    <group>gdpr_IV_35.7.d,</group>
+  </rule>
+
+
+  <!-- Event ID 2041 -->
+  <rule id="62147" level="8">
+    <if_sid>62101</if_sid>
+    <field name="win.system.eventID">^2041$</field>
+    <description>Windows Defender: Antimalware support for this Operating System has ended</description>
+    <options>no_full_log</options>
+    <group>gdpr_IV_35.7.d,</group>
+  </rule>
+
+
+  <!-- Event ID 2042 -->
+  <rule id="62148" level="8">
+    <if_sid>62101</if_sid>
+    <field name="win.system.eventID">^2042$</field>
+    <description>Windows Defender: Antimalware engine no longer supports this Operating System</description>
+    <options>no_full_log</options>
+    <group>gdpr_IV_35.7.d,</group>
+  </rule>
+
+
+  <!-- Event ID 3002 -->
+  <rule id="62149" level="10">
+    <if_sid>62101</if_sid>
+    <field name="win.system.eventID">^3002$</field>
+    <description>Windows Defender: $(win.eventdata.feature) real-time protection encountered an error and failed</description>
+    <options>no_full_log</options>
+    <group>gdpr_IV_35.7.d,</group>
+  </rule>
+
+
+  <!-- Event ID 3007 -->
+  <rule id="62150" level="5">
+    <if_sid>62100</if_sid>
+    <field name="win.system.eventID">^3007$</field>
+    <description>Windows Defender: $(win.eventdata.feature) real-time protection recovered from a failure</description>
+    <options>no_full_log</options>
+    <group>gdpr_IV_35.7.d,</group>
+  </rule>
+
+
+  <!-- Event ID 5000 -->
+  <rule id="62151" level="3">
+    <if_sid>62100</if_sid>
+    <field name="win.system.eventID">^5000$</field>
+    <description>Windows Defender: Antivirus real-time protection is enabled</description>
+    <options>no_full_log</options>
+    <group>gdpr_IV_35.7.d,</group>
+  </rule>
+
+
+  <!-- Event ID 5001 -->
+  <rule id="62152" level="5">
+    <if_sid>62100</if_sid>
+    <field name="win.system.eventID">^5001$</field>
+    <description>Windows Defender: Antivirus real-time protection is disabled</description>
+    <options>no_full_log</options>
+    <group>gdpr_IV_35.7.d,</group>
+  </rule>
+
+
+  <!-- Event ID 5004 -->
+  <rule id="62153" level="3">
+    <if_sid>62100</if_sid>
+    <field name="win.system.eventID">^5004$</field>
+    <description>Windows Defender: Antivirus real-time protection feature configuration has changed</description>
+    <options>no_full_log</options>
+    <group>gdpr_IV_35.7.d,gdpr_II_5.1.f,</group>
+  </rule>
+
+
+  <!-- Event ID 5007 -->
+  <rule id="62154" level="5">
+    <if_sid>62100</if_sid>
+    <field name="win.system.eventID">^5007$</field>
+    <description>Windows Defender: Antimalware platform feature configuration changed</description>
+    <options>no_full_log</options>
+    <group>gdpr_IV_35.7.d,gdpr_II_5.1.f,</group>
+  </rule>
+
+
+  <!-- Event ID 5008 -->
+  <rule id="62155" level="12">
+    <if_sid>62101</if_sid>
+    <field name="win.system.eventID">^5008$</field>
+    <description>Windows Defender: Antimalware engine encountered an error and failed because of $(win.eventdata.failureType) at $(win.eventdata.resource)</description>
+    <options>no_full_log</options>
+    <group>gdpr_IV_35.7.d,gdpr_II_5.1.f,</group>
+  </rule>
+
+
+  <!-- Event ID 5009 -->
+  <rule id="62156" level="3">
+    <if_sid>62100</if_sid>
+    <field name="win.system.eventID">^5009$</field>
+    <description>Windows Defender: Antivirus scanning for malware and other potentially unwanted software is enabled</description>
+    <options>no_full_log</options>
+    <group>gdpr_IV_35.7.d,</group>
+  </rule>
+
+
+  <!-- Event ID 5010 -->
+  <rule id="62157" level="10">
+    <if_sid>62100</if_sid>
+    <field name="win.system.eventID">^5010$</field>
+    <description>Windows Defender: Antivirus scanning for malware and other potentially unwanted software is disabled</description>
+    <options>no_full_log</options>
+    <group>gdpr_IV_35.7.d,</group>
+  </rule>
+
+
+  <!-- Event ID 5011 -->
+  <rule id="62158" level="3">
+    <if_sid>62100</if_sid>
+    <field name="win.system.eventID">^5011$</field>
+    <description>Windows Defender: Antivirus scanning for viruses is enabled</description>
+    <options>no_full_log</options>
+    <group>gdpr_IV_35.7.d,</group>
+  </rule>
+
+
+  <!-- Event ID 5012 -->
+  <rule id="62159" level="10">
+    <if_sid>62100</if_sid>
+    <field name="win.system.eventID">^5012$</field>
+    <description>Windows Defender: Antivirus scanning for viruses is disabled</description>
+    <options>no_full_log</options>
+    <group>gdpr_IV_35.7.d,</group>
+  </rule>
+
+
+  <!-- Event ID 5100 -->
+  <rule id="62160" level="5">
+    <if_sid>62101</if_sid>
+    <field name="win.system.eventID">^5100$</field>
+    <description>Windows Defender: Antimalware platform will expire soon</description>
+    <options>no_full_log</options>
+    <group>gdpr_IV_35.7.d,</group>
+  </rule>
+
+
+  <!-- Event ID 5101 -->
+  <rule id="62161" level="8">
+    <if_sid>62101</if_sid>
+    <field name="win.system.eventID">^5101$</field>
+    <description>Windows Defender: Antimalware platform is expired due to error $(win.eventdata.errorCode)</description>
+    <options>no_full_log</options>
+    <group>gdpr_IV_35.7.d,</group>
+  </rule>
+
+
+  <!-- ERROR 0x80508007 -->
+  <rule id="62162" level="12">
+    <if_sid>62102</if_sid>
+    <field name="win.eventdata.errorCode">^0x80508007$</field>
+    <description>Windows Defender: ERROR: NO MEMORY</description>
+    <options>no_full_log</options>
+  </rule>
+
+
+  <!-- ERROR 0x8050800C -->
+  <rule id="62163" level="12">
+    <if_sid>62102</if_sid>
+    <field name="win.eventdata.errorCode">^0x8050800C$</field>
+    <description>Windows Defender: ERROR: BAD INPUT DATA</description>
+    <options>no_full_log</options>
+  </rule>
+
+
+  <!-- ERROR 0x80508020 -->
+  <rule id="62164" level="12">
+    <if_sid>62102</if_sid>
+    <field name="win.eventdata.errorCode">^0x80508020$</field>
+    <description>Windows Defender: ERROR: BAD CONFIGURATION</description>
+    <options>no_full_log</options>
+  </rule>
+
+
+  <!-- ERROR 0x805080211 -->
+  <rule id="62165" level="12">
+    <if_sid>62102</if_sid>
+    <field name="win.eventdata.errorCode">^0x805080211$</field>
+    <description>Windows Defender: ERROR: QUARANTINE FAILED</description>
+    <options>no_full_log</options>
+  </rule>
+
+
+  <!-- ERROR 0x80508022 -->
+  <rule id="62166" level="12">
+    <if_sid>62102</if_sid>
+    <field name="win.eventdata.errorCode">^0x80508022$</field>
+    <description>Windows Defender: ERROR: REBOOT REQUIRED</description>
+    <options>no_full_log</options>
+  </rule>
+
+
+  <!-- ERROR 0x80508023 -->
+  <rule id="62167" level="12">
+    <if_sid>62102</if_sid>
+    <field name="win.eventdata.errorCode">^0x80508023$</field>
+    <description>Windows Defender: ERROR: THREAT NOT FOUND</description>
+    <options>no_full_log</options>
+  </rule>
+
+
+  <!-- ERROR 0x80508024 -->
+  <rule id="62168" level="12">
+    <if_sid>62102</if_sid>
+    <field name="win.eventdata.errorCode">^0x80508024$</field>
+    <description>Windows Defender: ERROR: FULL SCAN REQUIRED</description>
+    <options>no_full_log</options>
+  </rule>
+
+
+  <!-- ERROR 0x80508025 -->
+  <rule id="62169" level="12">
+    <if_sid>62102</if_sid>
+    <field name="win.eventdata.errorCode">^0x80508025$</field>
+    <description>Windows Defender: ERROR: MANUAL STEPS REQUIRED</description>
+    <options>no_full_log</options>
+  </rule>
+
+
+  <!-- ERROR 0x80508026 -->
+  <rule id="62170" level="12">
+    <if_sid>62102</if_sid>
+    <field name="win.eventdata.errorCode">^0x80508026$</field>
+    <description>Windows Defender: ERROR: REMOVE NOT SUPPORTED</description>
+    <options>no_full_log</options>
+  </rule>
+
+
+  <!-- ERROR 0x80508027 -->
+  <rule id="62171" level="12">
+    <if_sid>62102</if_sid>
+    <field name="win.eventdata.errorCode">^0x80508027$</field>
+    <description>Windows Defender: ERROR: REMOVE LOW MEDIUM DISABLED</description>
+    <options>no_full_log</options>
+  </rule>
+
+
+  <!-- ERROR 0x80508029 -->
+  <rule id="62172" level="12">
+    <if_sid>62102</if_sid>
+    <field name="win.eventdata.errorCode">^0x80508029$</field>
+    <description>Windows Defender: ERROR: RESCAN REQUIRED</description>
+    <options>no_full_log</options>
+  </rule>
+
+
+  <!-- ERROR 0x80508030 -->
+  <rule id="62173" level="12">
+    <if_sid>62102</if_sid>
+    <field name="win.eventdata.errorCode">^0x80508030$</field>
+    <description>Windows Defender: ERROR: CALLISTO REQUIRED</description>
+    <options>no_full_log</options>
+  </rule>
+
+
+  <!-- ERROR 0x80508031 -->
+  <rule id="62174" level="12">
+    <if_sid>62102</if_sid>
+    <field name="win.eventdata.errorCode">^0x80508031$</field>
+    <description>Windows Defender: ERROR: PLATFORM OUTDATED</description>
+    <options>no_full_log</options>
+  </rule>
+
+
+  <!-- ERROR 0x80501000 -->
+  <rule id="62175" level="12">
+    <if_sid>62102</if_sid>
+    <field name="win.eventdata.errorCode">^0x80501000$</field>
+    <description>Windows Defender: ERROR: UI CONSOLIDATION BASE</description>
+    <options>no_full_log</options>
+  </rule>
+
+
+  <!-- ERROR 0x80501001 -->
+  <rule id="62176" level="12">
+    <if_sid>62102</if_sid>
+    <field name="win.eventdata.errorCode">^0x80501001$</field>
+    <description>Windows Defender: ERROR: ACTIONS FAILED</description>
+    <options>no_full_log</options>
+  </rule>
+
+
+  <!-- ERROR 0x80501002 -->
+  <rule id="62177" level="12">
+    <if_sid>62102</if_sid>
+    <field name="win.eventdata.errorCode">^0x80501002$</field>
+    <description>Windows Defender: ERROR: NO ENGINE</description>
+    <options>no_full_log</options>
+  </rule>
+
+
+  <!-- ERROR 0x80501003 -->
+  <rule id="62178" level="12">
+    <if_sid>62102</if_sid>
+    <field name="win.eventdata.errorCode">^0x80501003$</field>
+    <description>Windows Defender: ERROR: ACTIVE THREATS</description>
+    <options>no_full_log</options>
+  </rule>
+
+
+  <!-- ERROR 0x80501004 -->
+  <rule id="62179" level="12">
+    <if_sid>62102</if_sid>
+    <field name="win.eventdata.errorCode">^0x80501004$</field>
+    <description>Windows Defender: ERROR: NO INTERNET CONNECTION</description>
+    <options>no_full_log</options>
+  </rule>
+
+
+  <!-- ERROR 0x80501101 -->
+  <rule id="62180" level="12">
+    <if_sid>62102</if_sid>
+    <field name="win.eventdata.errorCode">^0x80501101$</field>
+    <description>Windows Defender: ERROR: LUA CANCELLATION</description>
+    <options>no_full_log</options>
+  </rule>
+
+
+  <!-- ERROR 0x805011011 -->
+  <rule id="62181" level="12">
+    <if_sid>62102</if_sid>
+    <field name="win.eventdata.errorCode">^0x805011011$</field>
+    <description>Windows Defender: ERROR: CODE LUA CANCELLED</description>
+    <options>no_full_log</options>
+  </rule>
+
+
+  <!-- ERROR 0x80501102 -->
+  <rule id="62182" level="12">
+    <if_sid>62102</if_sid>
+    <field name="win.eventdata.errorCode">^0x80501102$</field>
+    <description>Windows Defender: ERROR: CODE ALREADY SHUTDOWN</description>
+    <options>no_full_log</options>
+  </rule>
+
+
+  <!-- ERROR 0x80501103 -->
+  <rule id="62183" level="12">
+    <if_sid>62102</if_sid>
+    <field name="win.eventdata.errorCode">^0x80501103$</field>
+    <description>Windows Defender: ERROR: CODE ASYNC CALL PENDING</description>
+    <options>no_full_log</options>
+  </rule>
+
+
+  <!-- ERROR 0x80501104 -->
+  <rule id="62184" level="12">
+    <if_sid>62102</if_sid>
+    <field name="win.eventdata.errorCode">^0x80501104$</field>
+    <description>Windows Defender: ERROR: CODE CANCELLED</description>
+    <options>no_full_log</options>
+  </rule>
+
+
+  <!-- ERROR 0x80501105 -->
+  <rule id="62185" level="12">
+    <if_sid>62102</if_sid>
+    <field name="win.eventdata.errorCode">^0x80501105$</field>
+    <description>Windows Defender: ERROR: CODE NO TARGETOS</description>
+    <options>no_full_log</options>
+  </rule>
+
+
+  <!-- ERROR 0x80501106 -->
+  <rule id="62186" level="12">
+    <if_sid>62102</if_sid>
+    <field name="win.eventdata.errorCode">^0x80501106$</field>
+    <description>Windows Defender: ERROR: CODE BAD REGEXP</description>
+    <options>no_full_log</options>
+  </rule>
+
+
+  <!-- ERROR 0x80501107 -->
+  <rule id="62187" level="12">
+    <if_sid>62102</if_sid>
+    <field name="win.eventdata.errorCode">^0x80501107$</field>
+    <description>Windows Defender: ERROR: TEST INDUCED ERROR</description>
+    <options>no_full_log</options>
+  </rule>
+
+
+  <!-- ERROR 0x80501108 -->
+  <rule id="62188" level="12">
+    <if_sid>62102</if_sid>
+    <field name="win.eventdata.errorCode">^0x80501108$</field>
+    <description>Windows Defender: ERROR: SIG BACKUP DISABLED</description>
+    <options>no_full_log</options>
+  </rule>
+
+
+  <!-- ERROR 0x80508001 -->
+  <rule id="62189" level="12">
+    <if_sid>62102</if_sid>
+    <field name="win.eventdata.errorCode">^0x80508001$</field>
+    <description>Windows Defender: ERROR: BAD INIT MODULES</description>
+    <options>no_full_log</options>
+  </rule>
+
+
+  <!-- ERROR 0x80508002 -->
+  <rule id="62190" level="12">
+    <if_sid>62102</if_sid>
+    <field name="win.eventdata.errorCode">^0x80508002$</field>
+    <description>Windows Defender: ERROR: BAD DATABASE</description>
+    <options>no_full_log</options>
+  </rule>
+
+
+  <!-- ERROR 0x80508004 -->
+  <rule id="62191" level="12">
+    <if_sid>62102</if_sid>
+    <field name="win.eventdata.errorCode">^0x80508004$</field>
+    <description>Windows Defender: ERROR: BAD UFS</description>
+    <options>no_full_log</options>
+  </rule>
+
+
+  <!-- ERROR 0x8050800C -->
+  <rule id="62192" level="12">
+    <if_sid>62102</if_sid>
+    <field name="win.eventdata.errorCode">^0x8050800C$</field>
+    <description>Windows Defender: ERROR: BAD INPUT DATA</description>
+    <options>no_full_log</options>
+  </rule>
+
+
+  <!-- ERROR 0x8050800D -->
+  <rule id="62193" level="12">
+    <if_sid>62102</if_sid>
+    <field name="win.eventdata.errorCode">^0x8050800D$</field>
+    <description>Windows Defender: ERROR: BAD GLOBAL STORAGE</description>
+    <options>no_full_log</options>
+  </rule>
+
+
+  <!-- ERROR 0x8050800E -->
+  <rule id="62194" level="12">
+    <if_sid>62102</if_sid>
+    <field name="win.eventdata.errorCode">^0x8050800E$</field>
+    <description>Windows Defender: ERROR: OBSOLETE</description>
+    <options>no_full_log</options>
+  </rule>
+
+
+  <!-- ERROR 0x8050800F -->
+  <rule id="62195" level="12">
+    <if_sid>62102</if_sid>
+    <field name="win.eventdata.errorCode">^0x8050800F$</field>
+    <description>Windows Defender: ERROR: NOT SUPPORTED</description>
+    <options>no_full_log</options>
+  </rule>
+
+
+  <!-- ERROR 0x80508010 -->
+  <rule id="62196" level="12">
+    <if_sid>62102</if_sid>
+    <field name="win.eventdata.errorCode">^0x80508010$</field>
+    <description>Windows Defender: ERROR: NO MORE ITEMS</description>
+    <options>no_full_log</options>
+  </rule>
+
+
+  <!-- ERROR 0x80508011 -->
+  <rule id="62197" level="12">
+    <if_sid>62102</if_sid>
+    <field name="win.eventdata.errorCode">^0x80508011$</field>
+    <description>Windows Defender: ERROR: DUPLICATE SCAN ID</description>
+    <options>no_full_log</options>
+  </rule>
+
+
+  <!-- ERROR 0x80508012 -->
+  <rule id="62198" level="12">
+    <if_sid>62102</if_sid>
+    <field name="win.eventdata.errorCode">^0x80508012$</field>
+    <description>Windows Defender: ERROR: BAD SCAN ID</description>
+    <options>no_full_log</options>
+  </rule>
+
+
+  <!-- ERROR 0x80508013 -->
+  <rule id="62199" level="12">
+    <if_sid>62102</if_sid>
+    <field name="win.eventdata.errorCode">^0x80508013$</field>
+    <description>Windows Defender: ERROR: BAD USER DB VERSION</description>
+    <options>no_full_log</options>
+  </rule>
+
+
+  <!-- ERROR 0x80508014 -->
+  <rule id="62200" level="12">
+    <if_sid>62102</if_sid>
+    <field name="win.eventdata.errorCode">^0x80508014$</field>
+    <description>Windows Defender: ERROR: RESTORE FAILED</description>
+    <options>no_full_log</options>
+  </rule>
+
+
+  <!-- ERROR 0x80508016 -->
+  <rule id="62201" level="12">
+    <if_sid>62102</if_sid>
+    <field name="win.eventdata.errorCode">^0x80508016$</field>
+    <description>Windows Defender: ERROR: BAD ACTION</description>
+    <options>no_full_log</options>
+  </rule>
+
+
+  <!-- ERROR 0x80508019 -->
+  <rule id="62202" level="12">
+    <if_sid>62102</if_sid>
+    <field name="win.eventdata.errorCode">^0x80508019$</field>
+    <description>Windows Defender: ERROR: NOT FOUND</description>
+    <options>no_full_log</options>
+  </rule>
+
+
+  <!-- ERROR 0x80509001 -->
+  <rule id="62203" level="12">
+    <if_sid>62102</if_sid>
+    <field name="win.eventdata.errorCode">^0x80509001$</field>
+    <description>Windows Defender: ERROR: BAD EHANDLE</description>
+    <options>no_full_log</options>
+  </rule>
+
+
+  <!-- ERROR 0x80509003 -->
+  <rule id="62204" level="12">
+    <if_sid>62102</if_sid>
+    <field name="win.eventdata.errorCode">^0x80509003$</field>
+    <description>Windows Defender: ERROR: RELO KERNEL NOT LOADED</description>
+    <options>no_full_log</options>
+  </rule>
+
+
+  <!-- ERROR 0x8050A001 -->
+  <rule id="62205" level="12">
+    <if_sid>62102</if_sid>
+    <field name="win.eventdata.errorCode">^0x8050A001$</field>
+    <description>Windows Defender: ERROR: BAD DB: OPEN</description>
+    <options>no_full_log</options>
+  </rule>
+
+
+  <!-- ERROR 0x8050A002 -->
+  <rule id="62206" level="12">
+    <if_sid>62102</if_sid>
+    <field name="win.eventdata.errorCode">^0x8050A002$</field>
+    <description>Windows Defender: ERROR: BAD DB: HEADER</description>
+    <options>no_full_log</options>
+  </rule>
+
+
+  <!-- ERROR 0x8050A003 -->
+  <rule id="62207" level="12">
+    <if_sid>62102</if_sid>
+    <field name="win.eventdata.errorCode">^0x8050A003$</field>
+    <description>Windows Defender: ERROR: BAD DB: OLD ENGINE</description>
+    <options>no_full_log</options>
+  </rule>
+
+  
+  <!-- ERROR 0x8050A004 -->
+  <rule id="62208" level="12">
+    <if_sid>62102</if_sid>
+    <field name="win.eventdata.errorCode">^0x8050A004$</field>
+    <description>Windows Defender: ERROR: BAD DB: CONTENT</description>
+    <options>no_full_log</options>
+  </rule>
+
+
+  <!-- ERROR 0x8050A005 -->
+  <rule id="62209" level="12">
+    <if_sid>62102</if_sid>
+    <field name="win.eventdata.errorCode">^0x8050A005$</field>
+    <description>Windows Defender: ERROR: BAD DB: NOT SIGNED</description>
+    <options>no_full_log</options>
+  </rule>
+
+  
+  <!-- ERROR 0x8050A002 -->
+  <rule id="62210" level="12">
+    <if_sid>62102</if_sid>
+    <field name="win.eventdata.errorCode">^0x8050A002$</field>
+    <description>Windows Defender: ERROR: BAD DB: HEADER</description>
+    <options>no_full_log</options>
+  </rule>
+
+
+  <!-- ERROR 0x8050801 -->
+  <rule id="62211" level="12">
+    <if_sid>62102</if_sid>
+    <field name="win.eventdata.errorCode">^0x8050801$</field>
+    <description>Windows Defender: ERROR: REMOVE FAILED</description>
+    <options>no_full_log</options>
+  </rule>
+
+
+  <!-- ERROR 0x80508018 -->
+  <rule id="62212" level="12">
+    <if_sid>62102</if_sid>
+    <field name="win.eventdata.errorCode">^0x80508018$</field>
+    <description>Windows Defender: ERROR: SCAN ABORTED</description>
+    <options>no_full_log</options>
+  </rule>
 </group>


### PR DESCRIPTION
Hello Team,
this PR closes #389 

## Description
The **Windows Defender** ruleset [0600-win-wdefender_rules.xml](https://github.com/wazuh/wazuh-ruleset/blob/3.9/rules/0600-win-wdefender_rules.xml) needed to be extended.

The newly added rules are organized into 3 groups:

- 62100 -> Information
- 62101 -> Warning 
- 62102 -> Error

The groups above are created based on Windows Event ID documentation on: https://docs.microsoft.com/en-us/windows/security/threat-protection/windows-defender-antivirus/troubleshoot-windows-defender-antivirus

All the best,
Pablo