### PR TITLE
Make Shellshock pattern more generic. Detect ShellShock attacks on all HTTP status code responses.

### DIFF
--- a/rules/0245-web_rules.xml
+++ b/rules/0245-web_rules.xml
@@ -218,7 +218,7 @@
 <!--
     Shellshock detected
     Pattern: "(){:;};" (with spaces)
-    Code: 2xx, 3xx, 4xx, 50x
+    Code: all
     Decoder: web-accesslog_decoders.xml
 
     Examples:
@@ -233,7 +233,7 @@
     -->
 
   <rule id="31166" level="15">
-    <if_sid>31101,31108,31120</if_sid>
+    <if_sid>31100</if_sid>
     <regex>"\(\)\s*{\s*\w*:;\s*}\s*;|"\(\)\s*{\s*\w*;\s*}\s*;</regex>
     <description>Shellshock attack attempt</description>
     <info type="cve">CVE-2014-6271</info>
@@ -242,7 +242,7 @@
   </rule>
 
   <rule id="31167" level="15">
-    <if_sid>31101,31108,31120</if_sid>
+    <if_sid>31100</if_sid>
     <regex>"\(\)\s*{\s*_;\.*}\s*>_[\$\(\$\(\)\)]\s*{</regex>
     <description>Shellshock attack attempt</description>
     <info type="cve">CVE-2014-6278</info>

--- a/rules/0245-web_rules.xml
+++ b/rules/0245-web_rules.xml
@@ -218,7 +218,7 @@
 <!--
     Shellshock detected
     Pattern: "(){:;};" (with spaces)
-    Code: 200, 404
+    Code: 200, 30x, 404
     Decoder: web-accesslog_decoders.xml
 
     Examples:

--- a/rules/0245-web_rules.xml
+++ b/rules/0245-web_rules.xml
@@ -218,7 +218,7 @@
 <!--
     Shellshock detected
     Pattern: "(){:;};" (with spaces)
-    Code: 200, 30x, 404
+    Code: 2xx, 3xx, 4xx, 50x
     Decoder: web-accesslog_decoders.xml
 
     Examples:
@@ -233,7 +233,7 @@
     -->
 
   <rule id="31166" level="15">
-    <if_sid>31101,31108</if_sid>
+    <if_sid>31101,31108,31120</if_sid>
     <regex>"\(\)\s*{\s*\w*:;\s*}\s*;|"\(\)\s*{\s*\w*;\s*}\s*;</regex>
     <description>Shellshock attack attempt</description>
     <info type="cve">CVE-2014-6271</info>
@@ -242,7 +242,7 @@
   </rule>
 
   <rule id="31167" level="15">
-    <if_sid>31101,31108</if_sid>
+    <if_sid>31101,31108,31120</if_sid>
     <regex>"\(\)\s*{\s*_;\.*}\s*>_[\$\(\$\(\)\)]\s*{</regex>
     <description>Shellshock attack attempt</description>
     <info type="cve">CVE-2014-6278</info>

--- a/rules/0245-web_rules.xml
+++ b/rules/0245-web_rules.xml
@@ -234,7 +234,7 @@
 
   <rule id="31166" level="15">
     <if_sid>31101,31108</if_sid>
-    <regex>"\(\)\s*{\s*:;\s*}\s*;|"\(\)\s*{\s*foo:;\s*}\s*;|"\(\)\s*{\s*ignored;\s*}\s*|"\(\)\s*{\s*gry;\s*}\s*;</regex>
+    <regex>"\(\)\s*{\s*\w*:;\s*}\s*;|"\(\)\s*{\s*\w*;\s*}\s*;</regex>
     <description>Shellshock attack attempt</description>
     <info type="cve">CVE-2014-6271</info>
     <info type="link">https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2014-6271</info>


### PR DESCRIPTION
The text pattern could be everything like e.g.:

```
192.168.2.100 - - [02/Nov/2015:01:35:55 +0100] "GET /cgi-bin/test.sh HTTP/1.1" 200 292 "-" "() { something:; };/usr/bin/perl ..."
```

or:

```
192.168.2.100 - - [02/Nov/2015:01:35:55 +0100] "GET /cgi-bin/test.sh HTTP/1.1" 200 292 "-" "() { something; };/usr/bin/perl ..."
```

This change should catch more of these variants.