### PR TITLE
Change macOS rules to be consistent and non intrusive

### DIFF
--- a/sca/darwin/15/cis_apple_macOS_10.11.yml
+++ b/sca/darwin/15/cis_apple_macOS_10.11.yml
@@ -256,7 +256,7 @@ checks:
       - cis: ["2.11"]
     condition: none
     rules:
-      - 'c:java -version -> r:1.6.0'
+      - 'c:/usr/libexec/java_home -> r:1.6.0'
 
 # 3.2 Enable security auditing (Scored)
   - id: 7518

--- a/sca/darwin/16/cis_apple_macOS_10.12.yml
+++ b/sca/darwin/16/cis_apple_macOS_10.12.yml
@@ -242,7 +242,7 @@ checks:
       - cis: ["2.11"]
     condition: none
     rules:
-      - 'c:java -version -> r:1.6.0'
+      - 'c:/usr/libexec/java_home -> r:1.6.0'
 
 # 3.1 Enable security auditing (Scored)
   - id: 8017

--- a/sca/darwin/17/cis_apple_macOS_10.13.yml
+++ b/sca/darwin/17/cis_apple_macOS_10.13.yml
@@ -19,13 +19,13 @@ policy:
     - https://www.cisecurity.org/cis-benchmarks/
 
 requirements:
-  title: "Check MacOS version (is 10.13 or higher?)"
+  title: "Check MacOS version"
   description: "Requirements for running the SCA scan against MacOS 10.13 (High Sierra)."
   condition: any
   rules:
-    - 'c:sw_vers -> r:^ProductVersion:\t*\s*10\p\d+'
-    - 'c:system_profiler SPSoftwareDataType -> r:System Version:\.*10\p\d+'
-    - 'c:defaults read loginwindow SystemVersionStampAsString -> r:^\t*\s*10\p\d+'
+    - 'c:sw_vers -> r:^ProductVersion:\t*\s*10\p13'
+    - 'c:system_profiler SPSoftwareDataType -> r:System Version:\.*10\p13'
+    - 'c:defaults read loginwindow SystemVersionStampAsString -> r:^\t*\s*10\p13'
 
 checks:
 # 1.1 Verify all Apple provided software is current (Scored)

--- a/sca/darwin/17/cis_apple_macOS_10.13.yml
+++ b/sca/darwin/17/cis_apple_macOS_10.13.yml
@@ -243,7 +243,7 @@ checks:
       - cis: ["2.11"]
     condition: none
     rules:
-      - 'c:java -version -> r:1.6.0'
+      - 'c:/usr/libexec/java_home -> r:1.6.0'
 
 # 2.13 Ensure EFI version is valid and being regularly checked (Scored)
   - id: 8517


### PR DESCRIPTION
Referenced issue: https://github.com/wazuh/wazuh/issues/3935

The macOS rules were triggering a pop up if java wasn't installed in the OS.
Also, the policy for macOS 10.13 was being installed in every macOS that wasn't 10.11 or 10.12. Now the policy is only installed in 10.13.

This PR has an equivalent PR in Wazuh repository: https://github.com/wazuh/wazuh/pull/3936