### PR TITLE
Fix SonicWall decoder prematch

### DIFF
--- a/decoders/0295-sonicwall_decoders.xml
+++ b/decoders/0295-sonicwall_decoders.xml
@@ -21,7 +21,7 @@
   -->
 
 <decoder name="sonicwall">
-   <prematch>^\s*id=\w+\s+sn=\w+\s+time="\.+"\s+fw=\S+ </prematch>
+   <prematch>^\<\d+>\s*id=\w+\s+sn=\w+\s+time="\.+"\s+fw=\S+ |^\s*id=\w+\s+sn=\w+\s+time="\.+"\s+fw=\S+ </prematch>
    <plugin_decoder>SonicWall_Decoder</plugin_decoder>
 </decoder>
 

--- a/decoders/0295-sonicwall_decoders.xml
+++ b/decoders/0295-sonicwall_decoders.xml
@@ -21,7 +21,7 @@
   -->
 
 <decoder name="sonicwall">
-   <prematch>^id=\w+\s+sn=\w+\s+time="\.+"\s+fw=\S+ </prematch>
+   <prematch>^\s*id=\w+\s+sn=\w+\s+time="\.+"\s+fw=\S+ </prematch>
    <plugin_decoder>SonicWall_Decoder</plugin_decoder>
 </decoder>
 


### PR DESCRIPTION
Hi team,

This PR fixes https://github.com/wazuh/wazuh/issues/2757.

We have seen several cases where the SonicWall events include whitespaces at the beginning, causing the events not to be decoded.

This issue has also been reported in our mailing list: https://groups.google.com/forum/?utm_medium=email&utm_source=footer#!msg/wazuh/9N_sDFkfEts/0RqdZoMdCAAJ

Adding `\s*` at the beginning of the parent prematch would do the trick.

Best regards,
Miguel