### PR TITLE
Changed the level of rule 51556 (doas was run as root.) from 2 to 3

### DIFF
--- a/rules/0310-openbsd_rules.xml
+++ b/rules/0310-openbsd_rules.xml
@@ -286,7 +286,7 @@
     <description>A command was run using doas.</description>
   </rule>
 
-  <rule id="51556" level="2">
+  <rule id="51556" level="3">
     <if_sid>51555</if_sid>
     <match> as root </match>
     <description>A doas command was run as root.</description>


### PR DESCRIPTION
The reasoning behind this being that the corresponding sudo-rule uses level 3, and
that wazuh in recent versions comes configured to only log alerts on rules 3 and up, hence
this rule would not generate an event under normal circumstances.