### PR TITLE
Modified 0040-auditd_decoders file

### DIFF
--- a/decoders/0040-auditd_decoders.xml
+++ b/decoders/0040-auditd_decoders.xml
@@ -26,9 +26,24 @@ type=SYSCALL msg=audit(1479982525.380:50): arch=c000003e syscall=2 success=yes e
 <!-- SYSCALL -->
 <decoder name="auditd-syscall">
     <parent>auditd</parent>
-    <regex offset="after_regex">^arch=(\S+) syscall=(\d+) success=(\S+) exit=(\S+) a0=\S+ a1=\S+ a2=\S+ a3=\S+ items=\S+ ppid=(\S+) pid=(\S+) auid=(\S+) uid=(\S+) gid=(\S+) euid=(\S+) suid=(\S+) fsuid=(\S+) egid=(\S+) sgid=(\S+) fsgid=(\S+) tty=(\S+) ses=(\S+) comm=\p(\S+)\p exe=\p(\S+)\p</regex>
-    <order>audit.arch,audit.syscall,audit.success,audit.exit,audit.ppid,audit.pid,audit.auid,audit.uid,audit.gid,audit.euid,audit.suid,audit.fsuid,audit.egid,audit.sgid,audit.fsgid,audit.tty,audit.session,audit.command,audit.exe</order>
+    <regex offset="after_regex">^arch=(\S+) syscall=(\d+) success=(\S+) exit=(\S+) a0=\S+ a1=\S+ a2=\S+ a3=\S+ items=\S+ ppid=(\S+) pid=(\S+) auid=(\S+) uid=(\S+) gid=(\S+) euid=(\S+) suid=(\S+) fsuid=(\S+) egid=(\S+) sgid=(\S+) fsgid=(\S+) tty=(\S+) ses=(\S+)</regex>
+    <order>audit.arch,audit.syscall,audit.success,audit.exit,audit.ppid,audit.pid,audit.auid,audit.uid,audit.gid,audit.euid,audit.suid,audit.fsuid,audit.egid,audit.sgid,audit.fsgid,audit.tty,audit.session</order>
 </decoder>
+
+<!-- SYSCALL - command -->
+<decoder name="auditd-syscall">
+    <parent>auditd</parent>
+    <regex offset="after_regex">comm=\p*(\w+)\p*</regex>
+    <order>audit.command</order>
+</decoder>
+
+<!-- SYSCALL - exe -->
+<decoder name="auditd-syscall">
+    <parent>auditd</parent>
+    <regex offset="after_regex">exe=\p(\S+)\p</regex>
+    <order>audit.exe</order>
+</decoder>
+
 
 <!-- SYSCALL - key -->
 <decoder name="auditd-syscall">


### PR DESCRIPTION
Hello Team,

The value of the `comm` field present in "type=SYSCALL" logs can arrive both between double quotes or without them.

The XML code has been edited to cover those two options. The `\p*` expression has been included to consider that double quotes (or any other special character) match 0 or more times. It has been necessary to create two new child decoders, for `comm` field and `exe` field.

Regards,
Jose Miguel