### PR TITLE
Sophos firewall XG series Decoders and Rules

### DIFF
--- a/decoders/0500-sophos_fw_decoders.xml
+++ b/decoders/0500-sophos_fw_decoders.xml
@@ -1,0 +1,321 @@
+<!--
+  -  Sophos XG210 Firewall decoders
+  -  Created by Wazuh, Inc.
+  -  Copyright (C) 2015-2019, Wazuh Inc.
+  -  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2.
+-->
+
+<!--
+device="SFW" date=2019-10-09 time=17:19:06 timezone="+08" device_name="XG210" device_id=AAAAAAAA1234567 log_id=010101010101 log_type="Firewall" log_component="Firewall Rule" log_subtype="Denied" status="Deny" priority=Information duration=0 fw_rule_id=14 policy_type=1 user_name="" user_gp="" iap=2 ips_policy_id=0 appfilter_policy_id=0 application="" application_risk=0 application_technology="" application_category="" in_interface="Port3" out_interface="Port2" src_mac=11:22:aa:bb:22:11 src_ip=11.22.33.44 src_country_code= dst_ip=44.33.22.11 dst_country_code= protocol="TCP" src_port=52667 dst_port=10051 sent_pkts=0  recv_pkts=0 sent_bytes=0 recv_bytes=0 tran_src_ip= tran_src_port=0 tran_dst_ip= tran_dst_port=0 srczonetype="" srczone="" dstzonetype="" dstzone="" dir_disp="" connid="" vconnid="" hb_health="No Heartbeat" message="" appresolvedby="Signature"th="No Heartbeat
+
+device="SFW" date=2019-10-09 time=17:19:06 timezone="+08" device_name="XG210" device_id=AAAAAAAA1234567 log_id=010101010101 log_type="Firewall" log_component="Firewall Rule" log_subtype="Allowed" status="Allow" priority=Information duration=0 fw_rule_id=22 policy_type=1 user_name="" user_gp="" iap=0 ips_policy_id=9 appfilter_policy_id=0 application="DNS" application_risk=1 application_technology="Network Protocol" application_category="Infrastructure" in_interface="Port3" out_interface="Port2" src_mac=11:22:aa:bb:22:11 src_ip=11.22.33.44 src_country_code=R1 dst_ip=8.8.8.8 dst_country_code=USA protocol="UDP" src_port=60778 dst_port=53 sent_pkts=0  recv_pkts=0 sent_bytes=0 recv_bytes=0 tran_src_ip=11.22.33.44 tran_src_port=0 tran_dst_ip= tran_dst_port=0 srczonetype="DMZ" srczone="DMZ" dstzonetype="WAN" dstzone="WAN" dir_disp="" connevent="Start" connid="17709984" vconnid="" hb_health="No Heartbeat" message="" appresolvedby="Signature"
+-->
+
+<decoder name="sophos-fw">
+  <prematch>^device="\w*"\s+date=\d+-\d+-\d+\s+time=</prematch>
+</decoder>
+
+<decoder name="sophos-fw">
+  <parent>sophos-fw</parent>
+  <regex>^device="(\w*)"\s+date=(\d+-\d+-\d+)\s+time=(\d+:\d+:\d+)\s+timezone="(\p*\d+)"</regex>
+  <order>device,date,time,timezone</order>
+</decoder>
+<decoder name="sophos-fw">
+  <parent>sophos-fw</parent>
+  <regex>device_name="(\.*)"\s+|(\.*)$</regex>
+  <order>device_name</order>
+</decoder>
+
+<decoder name="sophos-fw">
+  <parent>sophos-fw</parent>
+  <regex>device_id=(\w*)\s+|(\.*)$</regex>
+  <order>device_id</order>
+</decoder>
+
+<decoder name="sophos-fw">
+  <parent>sophos-fw</parent>
+  <regex>log_id=(\s*)\s+|(\.*)$</regex>
+  <order>log_id</order>
+</decoder>
+
+<decoder name="sophos-fw">
+  <parent>sophos-fw</parent>
+  <regex>log_type="(\w*)"\s+|(\.*)$</regex>
+  <order>log_type</order>
+</decoder>
+
+<decoder name="sophos-fw">
+  <parent>sophos-fw</parent>
+  <regex>log_component="(\.*)"\s+|(\.*)$</regex>
+  <order>log_component</order>
+</decoder>
+
+<decoder name="sophos-fw">
+  <parent>sophos-fw</parent>
+  <regex>log_subtype="(\w*)"\s+|(\.*)$</regex>
+  <order>log_subtype</order>
+</decoder>
+
+<decoder name="sophos-fw">
+  <parent>sophos-fw</parent>
+  <regex>status="(\.*)"\s+|(\.*)$</regex>
+  <order>sophos_fw_status_msg</order>
+</decoder>
+
+<decoder name="sophos-fw">
+  <parent>sophos-fw</parent>
+  <regex>priority=(\w*)\s+|(\.*)$</regex>
+  <order>priority</order>
+</decoder>
+
+<decoder name="sophos-fw">
+  <parent>sophos-fw</parent>
+  <regex>duration=(\d*)\s+|(\.*)$</regex>
+  <order>duration</order>
+</decoder>
+
+<decoder name="sophos-fw">
+  <parent>sophos-fw</parent>
+  <regex>fw_rule_id=(\d*)\s+|(\.*)$</regex>
+  <order>fw_rule_id</order>
+</decoder>
+
+<decoder name="sophos-fw">
+  <parent>sophos-fw</parent>
+  <regex>policy_type=(\d*)\s+|(\.*)$</regex>
+  <order>policy_type</order>
+</decoder>
+
+<decoder name="sophos-fw">
+  <parent>sophos-fw</parent>
+  <regex>user_name="(\w*)"\s+|(\.*)$</regex>
+  <order>user_name</order>
+</decoder>
+
+<decoder name="sophos-fw">
+  <parent>sophos-fw</parent>
+  <regex>user_gp="(\w*)"\s+|(\.*)$</regex>
+  <order>user_group</order>
+</decoder>
+
+<decoder name="sophos-fw">
+  <parent>sophos-fw</parent>
+  <regex>iap=(\d*)\s+|(\.*)$</regex>
+  <order>iap</order>
+</decoder>
+
+<decoder name="sophos-fw">
+  <parent>sophos-fw</parent>
+  <regex>ips_policy_id=(\d*)\s+|(\.*)$</regex>
+  <order>ips_policy_id</order>
+</decoder>
+
+<decoder name="sophos-fw">
+  <parent>sophos-fw</parent>
+  <regex>appfilter_policy_id=(\d*)\s+|(\.*)$</regex>
+  <order>appfilter_policy_id</order>
+</decoder>
+
+<decoder name="sophos-fw">
+  <parent>sophos-fw</parent>
+  <regex>application="(\w*)"\s+|(\.*)$</regex>
+  <order>application</order>
+</decoder>
+
+<decoder name="sophos-fw">
+  <parent>sophos-fw</parent>
+  <regex>application_risk=(\d*)\s+|(\.*)$</regex>
+  <order>application_risk</order>
+</decoder>
+
+<decoder name="sophos-fw">
+  <parent>sophos-fw</parent>
+  <regex>application_technology="(\w*)"\s+|(\.*)$</regex>
+  <order>application_technology</order>
+</decoder>
+
+<decoder name="sophos-fw">
+  <parent>sophos-fw</parent>
+  <regex>application_category="(\w*)"\s+|(\.*)$</regex>
+  <order>application_category</order>
+</decoder>
+
+<decoder name="sophos-fw">
+  <parent>sophos-fw</parent>
+  <regex>in_interface="(\w*)"\s+|(\.*)$</regex>
+  <order>in_interface</order>
+</decoder>
+
+<decoder name="sophos-fw">
+  <parent>sophos-fw</parent>
+  <regex>out_interface="(\w*)"\s+|(\.*)$</regex>
+  <order>out_interface</order>
+</decoder>
+
+<decoder name="sophos-fw">
+  <parent>sophos-fw</parent>
+  <regex>src_mac=(\.+:\.+:\.+:\.+:\.+:\.+)\s+|(\.*)$</regex>
+  <order>src_mac</order>
+</decoder>
+
+<decoder name="sophos-fw">
+  <parent>sophos-fw</parent>
+  <regex>src_ip=(\.*)\s+|(\.*)$</regex>
+  <order>src_ip</order>
+</decoder>
+
+<decoder name="sophos-fw">
+  <parent>sophos-fw</parent>
+  <regex>src_country_code=(\w*)\s+|(\.*)$</regex>
+  <order>src_country_code</order>
+</decoder>
+
+<decoder name="sophos-fw">
+  <parent>sophos-fw</parent>
+  <regex>dst_ip=(\.*)\s+|(\.*)$</regex>
+  <order>dst_ip</order>
+</decoder>
+
+<decoder name="sophos-fw">
+  <parent>sophos-fw</parent>
+  <regex>dst_country_code=(\w*)\s+|(\.*)$</regex>
+  <order>dst_country_code</order>
+</decoder>
+
+<decoder name="sophos-fw">
+  <parent>sophos-fw</parent>
+  <regex>protocol="(\w*)"\s+|(\.*)$</regex>
+  <order>protocol</order>
+</decoder>
+
+<decoder name="sophos-fw">
+  <parent>sophos-fw</parent>
+  <regex>src_port=(\d*)\s+|(\.*)$</regex>
+  <order>src_port</order>
+</decoder>
+
+<decoder name="sophos-fw">
+  <parent>sophos-fw</parent>
+  <regex>dst_port=(\d*)\s+|(\.*)$</regex>
+  <order>dst_port</order>
+</decoder>
+
+<decoder name="sophos-fw">
+  <parent>sophos-fw</parent>
+  <regex>sent_pkts=(\d*)\s+|(\.*)$</regex>
+  <order>sent_pkts</order>
+</decoder>
+
+<decoder name="sophos-fw">
+  <parent>sophos-fw</parent>
+  <regex>recv_pkts=(\d*)\s+|(\.*)$</regex>
+  <order>recv_pkts</order>
+</decoder>
+
+<decoder name="sophos-fw">
+  <parent>sophos-fw</parent>
+  <regex>sent_bytes=(\d*)\s+|(\.*)$</regex>
+  <order>sent_bytes</order>
+</decoder>
+
+<decoder name="sophos-fw">
+  <parent>sophos-fw</parent>
+  <regex>recv_bytes=(\d*)\s+|(\.*)$</regex>
+  <order>recv_bytes</order>
+</decoder>
+
+<decoder name="sophos-fw">
+  <parent>sophos-fw</parent>
+  <regex>tran_src_ip=(\.*)\s+|(\.*)$</regex>
+  <order>tran_src_ip</order>
+</decoder>
+
+<decoder name="sophos-fw">
+  <parent>sophos-fw</parent>
+  <regex>tran_src_port=(\d*)\s+|(\.*)$</regex>
+  <order>tran_src_port</order>
+</decoder>
+
+<decoder name="sophos-fw">
+  <parent>sophos-fw</parent>
+  <regex>tran_src_ip=(\.*)\s+|(\.*)$</regex>
+  <order>tran_src_ip</order>
+</decoder>
+
+<decoder name="sophos-fw">
+  <parent>sophos-fw</parent>
+  <regex>tran_dst_ip=(\.*)\s+|(\.*)$</regex>
+  <order>tran_dst_ip</order>
+</decoder>
+
+<decoder name="sophos-fw">
+  <parent>sophos-fw</parent>
+  <regex>srczonetype="(\.*)"\s+|(\.*)$</regex>
+  <order>srczonetype</order>
+</decoder>
+
+<decoder name="sophos-fw">
+  <parent>sophos-fw</parent>
+  <regex>srczone="(\.*)"\s+|(\.*)$</regex>
+  <order>srczone</order>
+</decoder>
+
+<decoder name="sophos-fw">
+  <parent>sophos-fw</parent>
+  <regex>dstzonetype="(\.*)"\s+|(\.*)$</regex>
+  <order>dstzonetype</order>
+</decoder>
+
+<decoder name="sophos-fw">
+  <parent>sophos-fw</parent>
+  <regex>dstzone="(\.*)"\s+|(\.*)$</regex>
+  <order>dstzone</order>
+</decoder>
+
+<decoder name="sophos-fw">
+  <parent>sophos-fw</parent>
+  <regex>dir_disp="(\.*)"\s+|(\.*)$</regex>
+  <order>dir_disp</order>
+</decoder>
+
+<decoder name="sophos-fw">
+  <parent>sophos-fw</parent>
+  <regex>connevent="(\.*)"\s+|(\.*)$</regex>
+  <order>connevent</order>
+</decoder>
+
+<decoder name="sophos-fw">
+  <parent>sophos-fw</parent>
+  <regex>connid="(\.*)"\s+|(\.*)$</regex>
+  <order>connid</order>
+</decoder>
+
+<decoder name="sophos-fw">
+  <parent>sophos-fw</parent>
+  <regex>vconnid="(\.*)"\s+|(\.*)$</regex>
+  <order>vconnid</order>
+</decoder>
+
+<decoder name="sophos-fw">
+  <parent>sophos-fw</parent>
+  <regex>hb_health="(\.*)"\s+|(\.*)$</regex>
+  <order>hb_health</order>
+</decoder>
+
+<decoder name="sophos-fw">
+  <parent>sophos-fw</parent>
+  <regex>message="(\.*)"\s+|(\.*)$</regex>
+  <order>message</order>
+</decoder>
+
+<decoder name="sophos-fw">
+  <parent>sophos-fw</parent>
+  <regex>appresolvedby="(\w*)"\s*|(\.*)$</regex>
+  <order>appresolvedby</order>
+</decoder>
+
+<decoder name="sophos-fw">
+  <parent>sophos-fw</parent>
+  <regex>th="(\.*)"\s*|(\.*)$</regex>
+  <order>th</order>
+</decoder>

--- a/rules/0690-sophos_fw_rules.xml
+++ b/rules/0690-sophos_fw_rules.xml
@@ -1,0 +1,74 @@
+<!--
+  -  Sophos XG210 Firewall rules
+  -  Created by Wazuh, Inc.
+  -  Copyright (C) 2015-2019, Wazuh Inc.
+  -  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2.
+-->
+
+<group name="sophos-fw,">
+  <rule id="70020" level="0">
+    <decoded_as>sophos-fw</decoded_as>
+    <description>Sophos XG210 Firewall event</description>
+  </rule>
+
+  <rule id="70021" level="5">
+    <if_sid>70020</if_sid>
+    <field name="sophos_fw_status_msg">Deny</field>
+    <description>Traffic Denied: from $(src_ip) to $(dst_ip)</description>
+  </rule>
+
+  <rule id="70022" level="3">
+    <if_sid>70020</if_sid>
+    <field name="sophos_fw_status_msg">Allow</field>
+    <description>Traffic Allowed: from $(src_ip) to $(dst_ip)</description>
+  </rule>
+
+  <rule id="70023" level="3">
+    <if_sid>70020</if_sid>
+    <field name="sophos_fw_status_msg">Detect</field>
+    <description>Traffic Detected: from $(src_ip) to $(dst_ip)</description>
+  </rule>
+
+  <rule id="70024" level="3">
+    <if_sid>70020</if_sid>
+    <field name="sophos_fw_status_msg">Drop</field>
+    <description>Traffic Dropped: from $(src_ip) to $(dst_ip)</description>
+  </rule>
+
+  <rule id="70025" level="3">
+    <if_sid>70020</if_sid>
+    <field name="sophos_fw_status_msg">Clean</field>
+    <description>Traffic Cleaned: from $(src_ip) to $(dst_ip)</description>
+  </rule>
+
+  <rule id="70026" level="7">
+    <if_sid>70020</if_sid>
+    <field name="sophos_fw_status_msg">Virus</field>
+    <description>Virus detected: source IP $(src_ip)</description>
+  </rule>
+
+  <rule id="70027" level="5">
+    <if_sid>70020</if_sid>
+    <field name="sophos_fw_status_msg">Spam</field>
+    <description>Spam: source IP $(src_ip)</description>
+  </rule>
+
+  <rule id="70028" level="3">
+    <if_sid>70020</if_sid>
+    <field name="sophos_fw_status_msg">Admin</field>
+    <description>Admin Traffic: from $(src_ip) to $(dst_ip)</description>
+  </rule>
+  
+  <rule id="70029" level="5">
+    <if_sid>70020</if_sid>
+    <field name="sophos_fw_status_msg">Authentication</field>
+    <description>Authentication Traffic: from $(src_ip) to $(dst_ip)</description>
+  </rule>
+  
+  <rule id="70030" level="3">
+    <if_sid>70020</if_sid>
+    <field name="sophos_fw_status_msg">System</field>
+    <description>System Traffic : from $(src_ip) to $(dst_ip)</description>
+  </rule>
+
+</group>

--- a/tools/rules-testing/tests/sophos_fw.ini
+++ b/tools/rules-testing/tests/sophos_fw.ini
@@ -1,0 +1,69 @@
+[sophos firewall: traffic denied]
+log 1 pass = device="SFW" date=2019-10-09 time=17:19:06 timezone="+08" device_name="XG210" device_id=AAAAAAAA1234567 log_id=010101010101 log_type="Firewall" log_component="Firewall Rule" log_subtype="Denied" status="Deny" priority=Information duration=0 fw_rule_id=14 policy_type=1 user_name="" user_gp="" iap=2 ips_policy_id=0 appfilter_policy_id=0 application="" application_risk=0 application_technology="" application_category="" in_interface="Port3" out_interface="Port2" src_mac=11:22:aa:bb:22:11 src_ip=11.22.33.44 src_country_code= dst_ip=44.33.22.11 dst_country_code= protocol="TCP" src_port=52667 dst_port=10051 sent_pkts=0  recv_pkts=0 sent_bytes=0 recv_bytes=0 tran_src_ip= tran_src_port=0 tran_dst_ip= tran_dst_port=0 srczonetype="" srczone="" dstzonetype="" dstzone="" dir_disp="" connid="" vconnid="" hb_health="No Heartbeat" message="" appresolvedby="Signature"th="No Heartbeat
+
+rule = 70021
+alert = 5
+decoder = sophos-fw
+
+[sophos firewall: traffic allowed]
+log 1 pass = device="SFW" date=2019-10-09 time=17:19:06 timezone="+08" device_name="XG210" device_id=AAAAAAAA1234567 log_id=010101010101 log_type="Firewall" log_component="Firewall Rule" log_subtype="Allowed" status="Allow" priority=Information duration=0 fw_rule_id=14 policy_type=1 user_name="" user_gp="" iap=2 ips_policy_id=0 appfilter_policy_id=0 application="" application_risk=0 application_technology="" application_category="" in_interface="Port3" out_interface="Port2" src_mac=11:22:aa:bb:22:11 src_ip=11.22.33.44 src_country_code= dst_ip=44.33.22.11 dst_country_code= protocol="TCP" src_port=52667 dst_port=10051 sent_pkts=0  recv_pkts=0 sent_bytes=0 recv_bytes=0 tran_src_ip= tran_src_port=0 tran_dst_ip= tran_dst_port=0 srczonetype="" srczone="" dstzonetype="" dstzone="" dir_disp="" connid="" vconnid="" hb_health="No Heartbeat" message="" appresolvedby="Signature"th="No Heartbeat
+
+rule = 70022
+alert = 3
+decoder = sophos-fw
+
+[sophos firewall: traffic detect]
+log 1 pass = device="SFW" date=2019-10-09 time=17:19:06 timezone="+08" device_name="XG210" device_id=AAAAAAAA1234567 log_id=010101010101 log_type="Firewall" log_component="Firewall Rule" log_subtype="Detected" status="Detect" priority=Information duration=0 fw_rule_id=14 policy_type=1 user_name="" user_gp="" iap=2 ips_policy_id=0 appfilter_policy_id=0 application="" application_risk=0 application_technology="" application_category="" in_interface="Port3" out_interface="Port2" src_mac=11:22:aa:bb:22:11 src_ip=11.22.33.44 src_country_code= dst_ip=44.33.22.11 dst_country_code= protocol="TCP" src_port=52667 dst_port=10051 sent_pkts=0  recv_pkts=0 sent_bytes=0 recv_bytes=0 tran_src_ip= tran_src_port=0 tran_dst_ip= tran_dst_port=0 srczonetype="" srczone="" dstzonetype="" dstzone="" dir_disp="" connid="" vconnid="" hb_health="No Heartbeat" message="" appresolvedby="Signature"th="No Heartbeat
+
+rule = 70023
+alert = 3
+decoder = sophos-fw
+
+[sophos firewall: traffic drop]
+log 1 pass = device="SFW" date=2019-10-09 time=17:19:06 timezone="+08" device_name="XG210" device_id=AAAAAAAA1234567 log_id=010101010101 log_type="Firewall" log_component="Firewall Rule" log_subtype="Dropped" status="Drop" priority=Information duration=0 fw_rule_id=14 policy_type=1 user_name="" user_gp="" iap=2 ips_policy_id=0 appfilter_policy_id=0 application="" application_risk=0 application_technology="" application_category="" in_interface="Port3" out_interface="Port2" src_mac=11:22:aa:bb:22:11 src_ip=11.22.33.44 src_country_code= dst_ip=44.33.22.11 dst_country_code= protocol="TCP" src_port=52667 dst_port=10051 sent_pkts=0  recv_pkts=0 sent_bytes=0 recv_bytes=0 tran_src_ip= tran_src_port=0 tran_dst_ip= tran_dst_port=0 srczonetype="" srczone="" dstzonetype="" dstzone="" dir_disp="" connid="" vconnid="" hb_health="No Heartbeat" message="" appresolvedby="Signature"th="No Heartbeat
+
+rule = 70024
+alert = 3
+decoder = sophos-fw
+
+[sophos firewall: traffic clean]
+log 1 pass = device="SFW" date=2019-10-09 time=17:19:06 timezone="+08" device_name="XG210" device_id=AAAAAAAA1234567 log_id=010101010101 log_type="Firewall" log_component="Firewall Rule" log_subtype="Cleaned" status="Clean" priority=Information duration=0 fw_rule_id=14 policy_type=1 user_name="" user_gp="" iap=2 ips_policy_id=0 appfilter_policy_id=0 application="" application_risk=0 application_technology="" application_category="" in_interface="Port3" out_interface="Port2" src_mac=11:22:aa:bb:22:11 src_ip=11.22.33.44 src_country_code= dst_ip=44.33.22.11 dst_country_code= protocol="TCP" src_port=52667 dst_port=10051 sent_pkts=0  recv_pkts=0 sent_bytes=0 recv_bytes=0 tran_src_ip= tran_src_port=0 tran_dst_ip= tran_dst_port=0 srczonetype="" srczone="" dstzonetype="" dstzone="" dir_disp="" connid="" vconnid="" hb_health="No Heartbeat" message="" appresolvedby="Signature"th="No Heartbeat
+
+rule = 70025
+alert = 3
+decoder = sophos-fw
+
+[sophos firewall: virus detected]
+log 1 pass = device="SFW" date=2019-10-09 time=17:19:06 timezone="+08" device_name="XG210" device_id=AAAAAAAA1234567 log_id=010101010101 log_type="Firewall" log_component="Firewall Rule" log_subtype="Virus" status="Virus" priority=Information duration=0 fw_rule_id=14 policy_type=1 user_name="" user_gp="" iap=2 ips_policy_id=0 appfilter_policy_id=0 application="" application_risk=0 application_technology="" application_category="" in_interface="Port3" out_interface="Port2" src_mac=11:22:aa:bb:22:11 src_ip=11.22.33.44 src_country_code= dst_ip=44.33.22.11 dst_country_code= protocol="TCP" src_port=52667 dst_port=10051 sent_pkts=0  recv_pkts=0 sent_bytes=0 recv_bytes=0 tran_src_ip= tran_src_port=0 tran_dst_ip= tran_dst_port=0 srczonetype="" srczone="" dstzonetype="" dstzone="" dir_disp="" connid="" vconnid="" hb_health="No Heartbeat" message="" appresolvedby="Signature"th="No Heartbeat
+
+rule = 70026
+alert = 7
+decoder = sophos-fw
+
+[sophos firewall: traffic spam]
+log 1 pass = device="SFW" date=2019-10-09 time=17:19:06 timezone="+08" device_name="XG210" device_id=AAAAAAAA1234567 log_id=010101010101 log_type="Firewall" log_component="Firewall Rule" log_subtype="Spam" status="Spam" priority=Information duration=0 fw_rule_id=14 policy_type=1 user_name="" user_gp="" iap=2 ips_policy_id=0 appfilter_policy_id=0 application="" application_risk=0 application_technology="" application_category="" in_interface="Port3" out_interface="Port2" src_mac=11:22:aa:bb:22:11 src_ip=11.22.33.44 src_country_code= dst_ip=44.33.22.11 dst_country_code= protocol="TCP" src_port=52667 dst_port=10051 sent_pkts=0  recv_pkts=0 sent_bytes=0 recv_bytes=0 tran_src_ip= tran_src_port=0 tran_dst_ip= tran_dst_port=0 srczonetype="" srczone="" dstzonetype="" dstzone="" dir_disp="" connid="" vconnid="" hb_health="No Heartbeat" message="" appresolvedby="Signature"th="No Heartbeat
+
+rule = 70027
+alert = 5
+decoder = sophos-fw
+
+[sophos firewall: traffic admin]
+log 1 pass = device="SFW" date=2019-10-09 time=17:19:06 timezone="+08" device_name="XG210" device_id=AAAAAAAA1234567 log_id=010101010101 log_type="Firewall" log_component="Firewall Rule" log_subtype="Admin" status="Admin" priority=Information duration=0 fw_rule_id=14 policy_type=1 user_name="" user_gp="" iap=2 ips_policy_id=0 appfilter_policy_id=0 application="" application_risk=0 application_technology="" application_category="" in_interface="Port3" out_interface="Port2" src_mac=11:22:aa:bb:22:11 src_ip=11.22.33.44 src_country_code= dst_ip=44.33.22.11 dst_country_code= protocol="TCP" src_port=52667 dst_port=10051 sent_pkts=0  recv_pkts=0 sent_bytes=0 recv_bytes=0 tran_src_ip= tran_src_port=0 tran_dst_ip= tran_dst_port=0 srczonetype="" srczone="" dstzonetype="" dstzone="" dir_disp="" connid="" vconnid="" hb_health="No Heartbeat" message="" appresolvedby="Signature"th="No Heartbeat
+
+rule = 70028
+alert = 3
+decoder = sophos-fw
+
+[sophos firewall: traffic authentication]
+log 1 pass = device="SFW" date=2019-10-09 time=17:19:06 timezone="+08" device_name="XG210" device_id=AAAAAAAA1234567 log_id=010101010101 log_type="Firewall" log_component="Firewall Rule" log_subtype="Authentication" status="Authentication" priority=Information duration=0 fw_rule_id=14 policy_type=1 user_name="" user_gp="" iap=2 ips_policy_id=0 appfilter_policy_id=0 application="" application_risk=0 application_technology="" application_category="" in_interface="Port3" out_interface="Port2" src_mac=11:22:aa:bb:22:11 src_ip=11.22.33.44 src_country_code= dst_ip=44.33.22.11 dst_country_code= protocol="TCP" src_port=52667 dst_port=10051 sent_pkts=0  recv_pkts=0 sent_bytes=0 recv_bytes=0 tran_src_ip= tran_src_port=0 tran_dst_ip= tran_dst_port=0 srczonetype="" srczone="" dstzonetype="" dstzone="" dir_disp="" connid="" vconnid="" hb_health="No Heartbeat" message="" appresolvedby="Signature"th="No Heartbeat
+
+rule = 70029
+alert = 5
+decoder = sophos-fw
+
+[sophos firewall: traffic system]
+log 1 pass = device="SFW" date=2019-10-09 time=17:19:06 timezone="+08" device_name="XG210" device_id=AAAAAAAA1234567 log_id=010101010101 log_type="Firewall" log_component="Firewall Rule" log_subtype="System" status="System" priority=Information duration=0 fw_rule_id=14 policy_type=1 user_name="" user_gp="" iap=2 ips_policy_id=0 appfilter_policy_id=0 application="" application_risk=0 application_technology="" application_category="" in_interface="Port3" out_interface="Port2" src_mac=11:22:aa:bb:22:11 src_ip=11.22.33.44 src_country_code= dst_ip=44.33.22.11 dst_country_code= protocol="TCP" src_port=52667 dst_port=10051 sent_pkts=0  recv_pkts=0 sent_bytes=0 recv_bytes=0 tran_src_ip= tran_src_port=0 tran_dst_ip= tran_dst_port=0 srczonetype="" srczone="" dstzonetype="" dstzone="" dir_disp="" connid="" vconnid="" hb_health="No Heartbeat" message="" appresolvedby="Signature"th="No Heartbeat
+
+rule = 70030
+alert = 3
+decoder = sophos-fw


### PR DESCRIPTION
I added new Decoder and Rules files to parse Sophos firewall XG210 logs.
Files:
- `decoders/0500-sophos_fw_decoders.xml` 
- `rules/0690-sophos_fw_rules.xml`
- `tools/rules-testing/tests/sophos_fw.ini`

Test result:
```
# python runtests.py
- [ File = ./tests/sophos_fw.ini ] ---------
..........
```

Regards.