### PR TITLE
Add missing 'r:' to rule 3084 from CIS Debian 9 policy

### DIFF
--- a/sca/debian/cis_debian7_L1.yml
+++ b/sca/debian/cis_debian7_L1.yml
@@ -439,7 +439,7 @@ checks:
       - http://www.openldap.org
     condition: none
     rules:
-      - 'c:dpkg -s slapd -> install ok installed'
+      - 'c:dpkg -s slapd -> r:install ok installed'
 
   - id: 1034
     title: "Ensure NFS and RPC are not enabled"
@@ -550,7 +550,7 @@ checks:
       - cis: ["6.16"]
     condition: none
     rules:
-      - 'c:dpkg -s rsync -> install ok installed'
+      - 'c:dpkg -s rsync -> r:install ok installed'
       - 'not f:/etc/default/rsync -> !r:^# && r:RSYNC_ENABLE\s*\t*=\s*\t*false'
 
 # 7 Network Configuration and Firewall
@@ -870,7 +870,7 @@ checks:
       - cis: ["9.2.1"]
     condition: all
     rules:
-      - 'c:dpkg -s libpam-cracklib -> install ok installed'
+      - 'c:dpkg -s libpam-cracklib -> r:install ok installed'
       - 'f:/etc/pam.d/common-password -> !r:^# && r:password\s*\t*required\s*\t*pam_cracklib.so && r:retry=\d && n:minlen=(\d+) compare >= 14 && r:dcredit=-\d+ && r:ucredit=-\d+ && r:ocredit=-\d+ && r:lcredit=-\d+'
 
   - id: 1070

--- a/sca/debian/cis_debian8_L1.yml
+++ b/sca/debian/cis_debian8_L1.yml
@@ -535,7 +535,7 @@ checks:
       - nist_800_53: ["CM.1"]
     condition: none
     rules:
-      - 'c:dpkg -s exim4 -> install ok installed'
+      - 'c:dpkg -s exim4 -> r:install ok installed'
 
   - id: 2039
     title: "Ensure Samba is not enabled"

--- a/sca/debian/cis_debian9_L1.yml
+++ b/sca/debian/cis_debian9_L1.yml
@@ -1153,7 +1153,7 @@ checks:
       - cis_csc: ["4.4"]
     condition: all
     rules:
-      - 'c:dpkg -s libpam-pwquality -> install ok installed'
+      - 'c:dpkg -s libpam-pwquality -> r:install ok installed'
       - 'f:/etc/pam.d/common-password -> !r:^# && r:password\s*\t*requisite\s*\t*pam_pwquality.so\s*\t*retry=\d'
       - 'f:/etc/security/pwquality.conf -> !r:^# && n:minlen\s*\t*=\s*\t*(\d+) compare >= 14'
       - 'f:/etc/security/pwquality.conf -> !r:^# && r:dcredit'

--- a/sca/debian/cis_debian9_L1.yml
+++ b/sca/debian/cis_debian9_L1.yml
@@ -508,7 +508,7 @@ checks:
       - nist_800_53: ["CM.1"]
     condition: none
     rules:
-      - 'c:dpkg -s exim4 -> install ok installed'
+      - 'c:dpkg -s exim4 -> r:install ok installed'
 
   - id: 3037
     title: "Ensure Samba is not enabled"


### PR DESCRIPTION
This PR fixes https://github.com/wazuh/wazuh/issues/4210 adding the 'r:' prefix to check 3084.