### PR TITLE
Updated `exim4` decoders and rules to support new logs

### DIFF
--- a/decoders/0445-exim_decoders.xml
+++ b/decoders/0445-exim_decoders.xml
@@ -15,6 +15,8 @@
   - 2017-01-24 03:09:46 SMTP connection from [10.101.1.10]:55010 (TCP/IP connection count = 1)
   - 2017-01-24 02:53:13 SMTP connection from (hydra) [10.101.1.10]:53682 lost
   - 2017-01-24 05:36:23 SMTP call from (000000) [::1]:39480 dropped: too many syntax or protocol errors (last command was "123")
+  - 2019-10-20 11:14:38 SMTP protocol synchronization error (input sent without waiting for greeting): rejected connection from H=[134.234.45.34] input="GET / HTTP/1.1\r\nHost: 24.255.212.213:98\r\nUser-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10.11; rv:47.0) Gecko/20100101 Firefox/47.0\r\nAccept: */*\r\n"
+  - 2019-10-20 09:56:39 H=123-123-12-123.example.example.net [123.123.12.123] F=<example@example.com> rejected RCPT <example@exampley.com>: Unrouteable address
 -->
 
 <decoder name="exim-authfailed">
@@ -44,3 +46,17 @@
   <regex offset="after_prematch">[(\S+)]:\d+ dropped: too many syntax or protocol errors</regex>
   <order>srcip</order>
 </decoder>
+
+<decoder name="exim-sync-error">
+  <parent>windows-date-format</parent>
+  <prematch offset="after_parent">^SMTP protocol synchronization error </prematch>
+  <regex>rejected connection from H=[(\d*.\d*.\d*.\d*)] input="(\.*)"</regex>
+  <order>srcip,input</order>
+</decoder>
+
+<decoder name="exim-unrouteable-address">
+  <parent>windows-date-format</parent>
+  <regex>H=(\.*) [(\d*.\d*.\d*.\d*)]\.*rejected RCPT \<(\.*)>: (\.*)</regex>
+  <order>host,host_ip,src_email,error_message</order>
+</decoder>
+  

--- a/rules/0515-exim_rules.xml
+++ b/rules/0515-exim_rules.xml
@@ -51,4 +51,16 @@
       <match>dropped: too many syntax or protocol errors</match>
       <description>Exim syntax or protocol errors</description>
     </rule>
+  
+  	<rule id="87511" level="6">
+      <if_sid>87500</if_sid>
+      <match>input sent without waiting for greeting</match>
+      <description>SMTP protocol synchronization error (input sent without waiting for greeting)</description>
+    </rule>
+
+    <rule id="87512" level="6">
+      <decoded_as>windows-date-format</decoded_as>
+      <match>rejected RCPT</match>
+      <description>RCPT rejected. Error: $(error_message)</description>
+    </rule>
 </group>

--- a/tools/rules-testing/tests/exim.ini
+++ b/tools/rules-testing/tests/exim.ini
@@ -27,3 +27,16 @@ rule = 87510
 alert = 5
 decoder = windows-date-format
 
+[exim protocol synchronization error]
+log 1 pass = 2019-10-20 11:14:38 SMTP protocol synchronization error (input sent without waiting for greeting): rejected connection from H=[134.234.45.34] input="GET / HTTP/1.1\r\nHost: 24.255.212.213:98\r\nUser-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10.11; rv:47.0) Gecko/20100101 Firefox/47.0\r\nAccept: */*\r\n"
+
+rule = 87511
+alert = 6
+decoder = windows-date-format
+
+[exim Unrouteable address]
+log 1 pass = 2019-10-20 09:56:39 H=123-123-12-123.example.example.net [123.123.12.123] F=<example@example.com> rejected RCPT <example@exampley.com>: Unrouteable address
+
+rule = 87512
+alert = 6
+decoder = windows-date-format


### PR DESCRIPTION
Hello team,

Exim4 is generating logs that our ruleset is not able to handle.
I've added new rules and decoders to 2 new logs types, it will be necessary to add new ones to support every relevant log.