### PR TITLE
Update the rules of Vulnerability Detector for 3.11

### DIFF
--- a/rules/0520-vulnerability-detector_rules.xml
+++ b/rules/0520-vulnerability-detector_rules.xml
@@ -5,7 +5,7 @@
   -  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2.
 -->
 
-<group name="vulnerability-detector,">
+<group name="vulnerability-detector,gdpr_IV_35.7.d,pci_dss_11.2.1,pci_dss_11.2.3,">
   <rule id="23501" level="0">
     <decoded_as>json</decoded_as>
     <options>no_full_log</options>
@@ -19,7 +19,6 @@
       <options>no_full_log</options>
       <field name="vulnerability.severity">Low</field>
       <description>$(vulnerability.title)</description>
-      <group>gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="23507" level="4">
@@ -27,7 +26,6 @@
       <options>no_full_log</options>
       <field name="vulnerability.package.condition">Could not</field>
       <description>It was not possible to verify whether $(vulnerability.cve) affects $(vulnerability.package.name).</description>
-      <group>gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="23504" level="7">
@@ -35,7 +33,6 @@
       <options>no_full_log</options>
       <field name="vulnerability.severity">Medium|-</field>
       <description>$(vulnerability.title)</description>
-      <group>gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="23508" level="6">
@@ -43,7 +40,6 @@
       <options>no_full_log</options>
       <field name="vulnerability.package.condition">Could not</field>
       <description>It was not possible to verify whether $(vulnerability.cve) affects $(vulnerability.package.name).</description>
-      <group>gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="23505" level="10">
@@ -51,7 +47,6 @@
       <options>no_full_log</options>
       <field name="vulnerability.severity">High</field>
       <description>$(vulnerability.title)</description>
-      <group>gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="23509" level="9">
@@ -59,7 +54,6 @@
       <options>no_full_log</options>
       <field name="vulnerability.package.condition">Could not</field>
       <description>It was not possible to verify whether $(vulnerability.cve) affects $(vulnerability.package.name).</description>
-      <group>gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="23506" level="13">
@@ -67,7 +61,6 @@
       <options>no_full_log</options>
       <field name="vulnerability.severity">Critical</field>
       <description>$(vulnerability.title)</description>
-      <group>gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="23510" level="12">
@@ -75,7 +68,6 @@
       <options>no_full_log</options>
       <field name="vulnerability.package.condition">Could not</field>
       <description>It was not possible to verify whether $(vulnerability.cve) affects $(vulnerability.package.name).</description>
-      <group>gdpr_IV_35.7.d,</group>
   </rule>
 
 </group>


### PR DESCRIPTION
This PR updates the rules of Vulnerability Detector by adding the group for PCI 11.2.1 and 11.2.3.