### PR TITLE
[SCA] Fix path of file for system's network check

### DIFF
--- a/sca/debian/cis_debian8_L2.yml
+++ b/sca/debian/cis_debian8_L2.yml
@@ -263,7 +263,7 @@ checks:
       - 'f:/etc/audit/audit.rules -> r:^-w && r:/etc/issue && r:-p wa && r:-k system-locale'
       - 'f:/etc/audit/audit.rules -> r:^-w && r:/etc/issue.net && r:-p wa && r:-k system-locale'
       - 'f:/etc/audit/audit.rules -> r:^-w && r:/etc/hosts && r:-p wa && r:-k system-locale'
-      - 'f:/etc/audit/audit.rules -> r:^-w && r:/etc/sysconfig/network && r:-p wa && r:-k system-locale'
+      - 'f:/etc/audit/audit.rules -> r:^-w && r:/etc/network && r:-p wa && r:-k system-locale'
 
   - id: 2516
     title: "Ensure events that modify the system's Mandatory Access Controls are collected (SELinux)"

--- a/sca/debian/cis_debian9_L2.yml
+++ b/sca/debian/cis_debian9_L2.yml
@@ -261,7 +261,7 @@ checks:
       - 'f:/etc/audit/audit.rules -> r:^-w && r:/etc/issue && r:-p wa && r:-k system-locale'
       - 'f:/etc/audit/audit.rules -> r:^-w && r:/etc/issue.net && r:-p wa && r:-k system-locale'
       - 'f:/etc/audit/audit.rules -> r:^-w && r:/etc/hosts && r:-p wa && r:-k system-locale'
-      - 'f:/etc/audit/audit.rules -> r:^-w && r:/etc/sysconfig/network && r:-p wa && r:-k system-locale'
+      - 'f:/etc/audit/audit.rules -> r:^-w && r:/etc/network && r:-p wa && r:-k system-locale'
 
   - id: 3516
     title: "Ensure events that modify the system's Mandatory Access Controls are collected (SELinux)"


### PR DESCRIPTION
This PR fixes the issue https://github.com/wazuh/wazuh/issues/4235.

It replaces the path _/etc/sysconfig/network_ by _/etc/network_ as stated at [CIS](https://downloads.cisecurity.org/?utm_campaign=Benchmarks&utm_medium=email&_hsenc=p2ANqtz-9ms9XRMho-H1dUberlJzBpcEOJIqJNqAQh_MQTY8pO14KkWMKaC5HClBn3x-FrIoUaoSSVmqhzSnEWXORx-u9FFJD3zA&_hsmi=35678746&utm_content=35678746&utm_source=hs_automation&hsCtaTracking=41ef8b02-d0e5-4acb-b542-67c919c7098e%7C500cec43-3dc4-4f4e-8680-465ba237fae1#/) Debian Linux 9 Benchmark v1.0.0.