### PR TITLE
Let osquery daemon messages appear in alerts as the full log

### DIFF
--- a/rules/0545-osquery_rules.xml
+++ b/rules/0545-osquery_rules.xml
@@ -10,28 +10,24 @@
   <rule id="24000" level="3">
     <location>osquery$</location>
     <description>osquery message</description>
-    <options>no_full_log</options>
   </rule>
 
   <rule id="24001" level="5">
     <if_sid>24000</if_sid>
     <regex>^E\d\d\d\d </regex>
     <description>osquery error message</description>
-    <options>no_full_log</options>
   </rule>
 
   <rule id="24002" level="3">
     <if_sid>24000</if_sid>
     <regex>^W\d\d\d\d </regex>
     <description>osquery warning message</description>
-    <options>no_full_log</options>
   </rule>
 
   <rule id="24003" level="2">
     <if_sid>24000</if_sid>
     <regex>^I\d\d\d\d </regex>
     <description>osquery information message</description>
-    <options>no_full_log</options>
   </rule>
 
   <rule id="24010" level="3">


### PR DESCRIPTION
|Related mailing list thread|
|---|
|[osquery Wazuh log question](https://groups.google.com/forum/#!topic/wazuh/ZSg_MSUJ-hc)|

The current ruleset hides the `full_log` field in every alert produced by osquery. We should hide the full log just for results as they are in JSON format.