### PR TITLE
Add Windows firewall rules

### DIFF
--- a/rules/0575-win-base_rules.xml
+++ b/rules/0575-win-base_rules.xml
@@ -56,6 +56,13 @@
     <description>Group of Windows rules for the System channel</description>
   </rule>
 
+  <rule id="60016" level="0">
+    <if_sid>60000</if_sid>
+    <field name="win.system.channel">^Microsoft-Windows-Windows Firewall With Advanced Security/Firewall$</field>
+    <options>no_full_log</options>
+    <description>Group of Microsoft Windows Firewall With Advanced Security rules</description>
+  </rule>
+
   <rule id="60006" level="0">
     <if_sid>60003</if_sid>
     <field name="win.system.providerName">^McLogEvent$</field>

--- a/rules/0602-win-wfirewall_rules.xml
+++ b/rules/0602-win-wfirewall_rules.xml
@@ -1,0 +1,104 @@
+<!--
+  -  Windows Event Channel ruleset for the Windows Firewall With Advanced Security channel 
+  -  Created by Wazuh, Inc.
+  -  Copyright (C) 2015-2019, Wazuh Inc.
+  -  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2.
+  -  ID range: 67000 - 67499
+-->
+
+<var name="MS_FREQ">8</var>
+
+<!-- MS Windows Firewall With Advanced Security rules -->
+<group name="windows,windows_firewall,firewall,">
+  <rule id="67001" level="0">
+    <if_sid>60016</if_sid>
+    <field name="win.system.severityValue">^INFORMATION$</field>
+    <description>Windows Firewall With Advanced Security informational event</description>
+    <options>no_full_log</options>
+    <group>pci_dss_1.4,gpg13_4.12,gdpr_IV_35.7.d,hipaa_164.312.a.1,nist_800_53_SC.7,</group>
+  </rule>
+
+  <rule id="67002" level="0">
+    <if_sid>60016</if_sid>
+    <field name="win.system.severityValue">^WARNING$</field>
+    <description>Windows Firewall With Advanced Security warning event</description>
+    <options>no_full_log</options>
+    <group>pci_dss_1.4,gpg13_4.12,gdpr_IV_35.7.d,hipaa_164.312.a.1,nist_800_53_SC.7,</group>
+  </rule>
+
+  <rule id="67003" level="5">
+    <if_sid>60016</if_sid>
+    <field name="win.system.severityValue">^ERROR$</field>
+    <description>Windows Defender error event</description>
+    <options>no_full_log</options>
+    <group>system_error,pci_dss_1.4,gpg13_4.12,gdpr_IV_35.7.d,hipaa_164.312.a.1,nist_800_53_SC.7,</group>
+  </rule>
+
+  <!--  {"win":{"system":{"providerName":"Microsoft-Windows-Windows Firewall With Advanced Security","providerGuid":"{d1bc9aff-2abf-4d71-9146-ecb2a986eb85}","eventID":"2003","version":"0","level":"4","task":"0","opcode":"0","keywords":"0x8000000000000000","systemTime":"2019-11-23T00:33:26.728595000Z","eventRecordID":"3345","processID":"3708","threadID":"8868","channel":"Microsoft-Windows-Windows Firewall With Advanced Security/Firewall","computer":"DESKTOP-COGHUOH","severityValue":"INFORMATION","message":"A Windows Defender Firewall setting in the Public profile has changed."},"eventdata":{"profiles":"4","settingType":"1","settingValueSize":"4","settingValue":"01000000","settingValueString":"Yes","origin":"1","modifyingUser":"S-1-5-21-1176116133-684496316-159144361-1001","modifyingApplication":"C:WindowsSystem32dllhost.exe"}}} -->
+
+  <rule id="67004" level="7">
+    <if_sid>67001</if_sid>
+    <field name="win.system.eventID">^2003$</field>
+    <field name="win.eventdata.settingType">^1$</field>
+    <field name="win.eventdata.settingValueString">^Yes$</field>
+    <description>Windows Firewall With Advanced Security: Windows Defender Firewall enabled.</description>
+    <options>no_full_log</options>
+    <group>pci_dss_1.4,gpg13_4.12,gdpr_IV_35.7.d,hipaa_164.312.a.1,nist_800_53_SC.7,</group>
+  </rule>
+
+  <!--  {"win":{"system":{"providerName":"Microsoft-Windows-Windows Firewall With Advanced Security","providerGuid":"{d1bc9aff-2abf-4d71-9146-ecb2a986eb85}","eventID":"2003","version":"0","level":"4","task":"0","opcode":"0","keywords":"0x8000000000000000","systemTime":"2019-11-23T00:33:26.728595000Z","eventRecordID":"3345","processID":"3708","threadID":"8868","channel":"Microsoft-Windows-Windows Firewall With Advanced Security/Firewall","computer":"DESKTOP-COGHUOH","severityValue":"INFORMATION","message":"A Windows Defender Firewall setting in the Public profile has changed."},"eventdata":{"profiles":"4","settingType":"1","settingValueSize":"4","settingValue":"00000000","settingValueString":"No","origin":"1","modifyingUser":"S-1-5-21-1176116133-684496316-159144361-1001","modifyingApplication":"C:WindowsSystem32dllhost.exe"}}} -->
+
+  <rule id="67005" level="7">
+    <if_sid>67001</if_sid>
+    <field name="win.system.eventID">^2003$</field>
+    <field name="win.eventdata.settingType">^1$</field>
+    <field name="win.eventdata.settingValueString">^No$</field>
+    <description>Windows Firewall With Advanced Security: Windows Defender Firewall disabled.</description>
+    <options>no_full_log</options>
+    <group>pci_dss_1.4,gpg13_4.12,gdpr_IV_35.7.d,hipaa_164.312.a.1,nist_800_53_SC.7,</group>
+  </rule>
+
+  <!--  {"win":{"system":{"providerName":"Microsoft-Windows-Windows Firewall With Advanced Security","providerGuid":"{d1bc9aff-2abf-4d71-9146-ecb2a986eb85}","eventID":"2004","version":"0","level":"4","task":"0","opcode":"0","keywords":"0x8000020000000000","systemTime":"2019-11-23T00:25:36.602076300Z","eventRecordID":"3342","processID":"3708","threadID":"6636","channel":"Microsoft-Windows-Windows Firewall With Advanced Security/Firewall","computer":"DESKTOP-COGHUOH","severityValue":"INFORMATION","message":"A rule has been added to the Windows Defender Firewall exception list."},"eventdata":{"ruleId":"{BB4003C6-303B-40D9-B199-EF31729FCB5C}","ruleName":"test","origin":"1","direction":"2","protocol":"256","action":"3","profiles":"2147483647","localAddresses":"*","remoteAddresses":"*","flags":"1","active":"1","edgeTraversal":"0","looseSourceMapped":"0","securityOptions":"0","modifyingUser":"S-1-5-21-1176116133-684496316-159144361-1001","modifyingApplication":"C:WindowsSystem32mmc.exe","schemaVersion":"542","ruleStatus":"65536","localOnlyMapped":"0"}}} -->
+
+  <rule id="67006" level="7">
+    <if_sid>67001</if_sid>
+    <field name="win.system.eventID">^2004$</field>
+    <description>Windows Firewall With Advanced Security: $(win.eventdata.ruleId) rule has been added to the Windows Defender Firewall exception list.</description>
+    <options>no_full_log</options>
+    <group>pci_dss_1.4,gpg13_4.12,gdpr_IV_35.7.d,hipaa_164.312.a.1,nist_800_53_SC.7,</group>
+  </rule>
+
+  <!-- {"win":{"system":{"providerName":"Microsoft-Windows-Windows Firewall With Advanced Security","providerGuid":"{d1bc9aff-2abf-4d71-9146-ecb2a986eb85}","eventID":"2005","version":"0","level":"4","task":"0","opcode":"0","keywords":"0x8000020000000000","systemTime":"2019-11-22T21:58:45.526726400Z","eventRecordID":"3336","processID":"3708","threadID":"8552","channel":"Microsoft-Windows-Windows Firewall With Advanced Security/Firewall","computer":"DESKTOP-COGHUOH","severityValue":"INFORMATION","message":"A rule has been modified in the Windows Defender Firewall exception list."},"eventdata":{"ruleId":"{AC4D5FEE-B730-487C-9D02-288E5EEE0AD5}","ruleName":"@{Microsoft.Windows.CloudExperienceHost_10.0.17763.1_neutral_neutral_cw5n1h2txyewy?ms-resource://Microsoft.Windows.CloudExperienceHost/resources/appDescription}","origin":"1","direction":"2","protocol":"256","action":"3","profiles":"2147483647","localAddresses":"*","remoteAddresses":"*","embeddedContext":"@{Microsoft.Windows.CloudExperienceHost_10.0.17763.1_neutral_neutral_cw5n1h2txyewy?ms-resource://Microsoft.Windows.CloudExperienceHost/resources/appDescription}","flags":"0","active":"0","edgeTraversal":"0","looseSourceMapped":"0","securityOptions":"0","modifyingUser":"S-1-5-21-1176116133-684496316-159144361-1001","modifyingApplication":"C:WindowsSystem32mmc.exe","schemaVersion":"541","ruleStatus":"65536","localOnlyMapped":"0"}}} -->
+  
+  <rule id="67007" level="7">
+    <if_sid>67001</if_sid>
+    <field name="win.system.eventID">^2005$</field>
+    <description>Windows Firewall With Advanced Security: $(win.eventdata.ruleId) rule has been modified in the Windows Defender Firewall exception list.</description>
+    <options>no_full_log</options>
+    <group>pci_dss_1.4,gpg13_4.12,gdpr_IV_35.7.d,hipaa_164.312.a.1,nist_800_53_SC.7,</group>
+  </rule>
+
+  <!-- {"win":{"system":{"providerName":"Microsoft-Windows-Windows Firewall With Advanced Security","providerGuid":"{d1bc9aff-2abf-4d71-9146-ecb2a986eb85}","eventID":"2006","version":"0","level":"4","task":"0","opcode":"0","keywords":"0x8000020000000000","systemTime":"2019-11-23T00:15:06.598777600Z","eventRecordID":"3339","processID":"3708","threadID":"1276","channel":"Microsoft-Windows-Windows Firewall With Advanced Security/Firewall","computer":"DESKTOP-COGHUOH","severityValue":"INFORMATION","message":"A rule has been deleted in the Windows Defender Firewall exception list."},"eventdata":{"ruleId":"{B86E05D6-FC64-45C3-8AA5-1DBE14CAD67A}","ruleName":"test","modifyingUser":"S-1-5-21-1176116133-684496316-159144361-1001","modifyingApplication":"C:WindowsSystem32mmc.exe"}}} -->
+  
+  <rule id="67008" level="7">
+    <if_sid>67001</if_sid>
+    <field name="win.system.eventID">^2006$</field>
+    <description>Windows Firewall With Advanced Security: $(win.eventdata.ruleId) rule has been deleted in the Windows Defender Firewall exception list.</description>
+    <options>no_full_log</options>
+    <group>pci_dss_1.4,gpg13_4.12,gdpr_IV_35.7.d,hipaa_164.312.a.1,nist_800_53_SC.7,</group>
+  </rule>
+
+  <rule id="67009" level="10" frequency="$MS_FREQ" timeframe="120">
+    <if_matched_sid>67002</if_matched_sid>
+    <description>Multiple Windows Firewall With Advanced Security warning events</description>
+    <options>no_full_log</options>
+    <group>pci_dss_1.4,gpg13_4.12,gdpr_IV_35.7.d,hipaa_164.312.a.1,nist_800_53_SC.7,</group>
+  </rule>
+
+  <rule id="67010" level="10" frequency="$MS_FREQ" timeframe="240">
+    <if_matched_sid>67003</if_matched_sid>
+    <description>Multiple Windows Firewall With Advanced Security error events</description>
+    <options>no_full_log</options>
+    <group>system_error,pci_dss_1.4,gpg13_4.12,gdpr_IV_35.7.d,hipaa_164.312.a.1,nist_800_53_SC.7,</group>
+  </rule>
+</group>


### PR DESCRIPTION
Hello team,
this PR adds a new base rule for `Microsoft-Windows-Windows Firewall With Advanced Security/Firewall` channel.

It provides rules for eventIDs:
- `2003` settingType 1 value Yes: Windows Firewall With Advanced Security: Windows Defender Firewall enabled.
- `2003` settingType 1 value No: Windows Firewall With Advanced Security: Windows Defender Firewall disabled.
- `2004`: A rule has been added to the Windows Defender Firewall exception list.
- `2005`: A rule has been modified in the Windows Defender Firewall exception list.
- `2006`: A rule has been deleted in the Windows Defender Firewall exception list.

It also provides rules for:
- Generic informational events.
- Generic warning events.
- Generic error events.
- Multiple warnings.
- Multiple errors.

Regards,
Javier.