### PR TITLE
Updated Rouncube decoder and log example for version >= 1.4

### DIFF
--- a/decoders/0255-roundcube_decoders.xml
+++ b/decoders/0255-roundcube_decoders.xml
@@ -15,8 +15,11 @@
  - Apr 10 23:01:23 hostname roundcube: [10-Apr-2009 23:01:23 -0500]: Successful login for username (id 1) from 127.0.0.1
  - Oct 28 19:31:08 hostname roundcube: <isj89gtf> IMAP Error: Login failed for username from 127.0.0.1. AUTHENTICATE PLAIN: Authentication failed. in /var/www/html/roundcube/program/lib/Roundcube/rcube_imap.php on line 193 (POST /roundcube/?_task=login&_action=login)
 
-   Example from roundcube internal logfile (/path/to/roundcube/logs/errors):
+   Example from roundcube internal logfile in versions < 1.4 (/path/to/roundcube/logs/errors):
  - [04-Oct-2017 17:03:30 +0200]: <jkgnfe79> IMAP Error: Login failed for username from 127.0.0.1. AUTHENTICATE PLAIN: Authentication failed. in /var/www/html/roundcube/program/lib/Roundcube/rcube_imap.php on line 193 (POST /roundcube/?_task=login&_action=login)
+
+   Example from roundcube internal logfile in versions >= 1.4 (/path/to/roundcube/logs/errors.log):
+- [04-Oct-2017 17:03:30 +0200]: <jkgnfe79> IMAP Error: Login failed for username against mailhost.example.com from 127.0.0.1. AUTHENTICATE PLAIN: Authentication failed. in /var/www/html/roundcube/program/lib/Roundcube/rcube_imap.php on line 200 (POST /roundcube/?_task=login&_action=login)
 
    Examples if log_logins is enabled (/path/to/roundcube/logs/userlogins):
  - [04-Oct-2017 16:08:01 +0200]: <lrpo6s0r> Failed login for test from 127.0.0.1 in session abcdefg (error: 0)

--- a/decoders/0255-roundcube_decoders.xml
+++ b/decoders/0255-roundcube_decoders.xml
@@ -51,6 +51,6 @@
 <decoder name="roundcube-denied-new">
   <parent>roundcube</parent>
   <prematch>> \w+ Error: Login failed |> Failed login </prematch>
-  <regex offset="after_prematch">^for (\S+) from (\S+)\. |^for (\S+) from (\S+) in session </regex>
+  <regex offset="after_prematch">^for (\S+) from (\S+)\. |^for (\S+) from (\S+) in session |^for (\S+) against \S+ from (\S+)\. |^for (\S+) against \S+ from (\S+) in session </regex>
   <order>user, srcip</order>
 </decoder>


### PR DESCRIPTION
Filename in 1.4 changed from `errors` to `errors.log`, in addition the log entry now includes the additional `against mailhost.example.com` text.

The ~decoder and the~ login failed rule still works against the new log so no change required here (besides updating the logfile location in wazuh).

Edit: Assumption of the decoder above was wrong, b152a600aa7496bf88c442d0883e4c59d2c23305 updated the decoder as well.