### PR TITLE
Add PCI DSS and NIST compliance to SCA and CIS-CAT rules

### DIFF
--- a/rules/0510-ciscat_rules.xml
+++ b/rules/0510-ciscat_rules.xml
@@ -16,7 +16,7 @@
     Wazuh v3.2 CIS-CAT events. Field: 'cis' -->
 
 <!-- CIS-CAT rules -->
-<group name="ciscat,">
+<group name="ciscat,pci_dss_2.2,nist_800_53_CM.1,">
 
   <rule id="87401" level="0">
     <category>ossec</category>

--- a/rules/0570-sca_rules.xml
+++ b/rules/0570-sca_rules.xml
@@ -5,7 +5,7 @@
   -  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2.
 -->
 
-<group name="sca,gdpr_IV_35.7.d">
+<group name="sca,gdpr_IV_35.7.d,pci_dss_2.2,nist_800_53_CM.1,">
 
   <rule id="19000" level="0">
     <category>ossec</category>


### PR DESCRIPTION
This PR adds the PCI DSS 2.2 and NIST 800 53 CM.1 requirement to SCA and CIS-CAT rules.

Both requirements are related to secure configurations and policy monitoring. Here the references:

https://www.pcisecuritystandards.org/documents/PCI_DSS-QRG-v3_2_1.pdf
https://nvd.nist.gov/800-53/Rev4/control/CM-1

Regards.