### PR TITLE
Email alerts disabled by default

### DIFF
--- a/rules/0015-ossec_rules.xml
+++ b/rules/0015-ossec_rules.xml
@@ -17,7 +17,6 @@
   <rule id="501" level="3">
     <if_sid>500</if_sid>
     <if_fts />
-    <options>alert_by_email</options>
     <match>Agent started</match>
     <description>New ossec agent connected.</description>
     <group>pci_dss_10.6.1,gpg13_10.1,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.6,</group>
@@ -25,7 +24,6 @@
 
   <rule id="502" level="3">
     <if_sid>500</if_sid>
-    <options>alert_by_email</options>
     <match>Ossec started</match>
     <description>Ossec server started.</description>
     <group>pci_dss_10.6.1,gpg13_10.1,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.6,</group>
@@ -33,7 +31,6 @@
 
   <rule id="503" level="3">
     <if_sid>500</if_sid>
-    <options>alert_by_email</options>
     <match>Agent started</match>
     <description>Ossec agent started.</description>
     <group>pci_dss_10.6.1,pci_dss_10.2.6,gpg13_10.1,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.6,nist_800_53_AU.14,nist_800_53_AU.5,</group>
@@ -41,7 +38,6 @@
 
   <rule id="504" level="3">
     <if_sid>500</if_sid>
-    <options>alert_by_email</options>
     <match>Agent disconnected</match>
     <description>Ossec agent disconnected.</description>
     <group>pci_dss_10.6.1,pci_dss_10.2.6,gpg13_10.1,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.6,nist_800_53_AU.14,nist_800_53_AU.5,</group>
@@ -49,7 +45,6 @@
 
   <rule id="505" level="3">
     <if_sid>500</if_sid>
-    <options>alert_by_email</options>
     <match>Agent removed</match>
     <description>Ossec agent removed.</description>
     <group>pci_dss_10.6.1,pci_dss_10.2.6,gpg13_10.1,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.6,nist_800_53_AU.14,nist_800_53_AU.5,</group>

--- a/rules/0020-syslog_rules.xml
+++ b/rules/0020-syslog_rules.xml
@@ -499,7 +499,6 @@
   <rule id="5305" level="4">
     <if_sid>5303, 5304</if_sid>
     <if_fts></if_fts>
-    <options>alert_by_email</options>
     <description>First time (su) is executed by user.</description>
   </rule>
 
@@ -590,7 +589,6 @@
 
   <rule id="5403" level="4">
     <if_sid>5400</if_sid>
-    <options>alert_by_email</options>
     <if_fts></if_fts>
     <description>First time user executed sudo.</description>
   </rule>
@@ -646,7 +644,6 @@
 <group name="syslog,fts,">
   <rule id="10100" level="4">
     <if_group>authentication_success</if_group>
-    <options>alert_by_email</options>
     <if_fts></if_fts>
     <group>authentication_success,</group>
     <description>First time user logged in.</description>

--- a/rules/0115-arpwatch_rules.xml
+++ b/rules/0115-arpwatch_rules.xml
@@ -15,7 +15,6 @@
 
   <rule id="7201" level="4">
     <if_sid>7200</if_sid>
-    <options>alert_by_email</options>
     <if_fts />
     <description>Arpwatch new host detected.</description>
     <group>new_host,pci_dss_10.6.1,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.6,</group>

--- a/rules/0210-vpn_concentrator_rules.xml
+++ b/rules/0210-vpn_concentrator_rules.xml
@@ -30,7 +30,6 @@
   <rule id="14203" level="4">
     <if_sid>14200</if_sid>
     <id>^HTTP/47$|^SSH/16$</id>
-    <options>alert_by_email</options>
     <description>CiscoVPN: VPN Admin authentication successful.</description>
     <group>authentication_success,pci_dss_10.2.5,gpg13_7.1,gpg13_7.2,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.14,nist_800_53_AC.7,</group>
   </rule>

--- a/rules/0220-msauth_rules.xml
+++ b/rules/0220-msauth_rules.xml
@@ -148,7 +148,6 @@
 
   <rule id="18119" level="3">
     <if_sid>18107</if_sid>
-    <options>alert_by_email</options>
     <if_fts />
     <description>Windows: First time this user logged in this system.</description>
     <group>authentication_success,pci_dss_10.2.5,gpg13_7.1,gpg13_7.2,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.14,nist_800_53_AC.7,</group>
@@ -324,14 +323,12 @@
   <rule id="18146" level="5">
     <if_sid>18101</if_sid>
     <id>^11724$</id>
-    <options>alert_by_email</options>
     <description>Windows: Application Uninstalled.</description>
   </rule>
 
   <rule id="18147" level="5">
     <if_sid>18101</if_sid>
     <id>^11707$</id>
-    <options>alert_by_email</options>
     <description>Windows: Application Installed.</description>
   </rule>
 

--- a/rules/0225-mcafee_av_rules.xml
+++ b/rules/0225-mcafee_av_rules.xml
@@ -116,7 +116,6 @@
   <rule id="7514" level="5">
     <if_sid>7505</if_sid>
     <match>contains the EICAR test file</match>
-    <options>alert_by_email</options>
     <description>McAfee Windows AV - EICAR test file detected.</description>
   </rule>
 

--- a/rules/0230-ms-se_rules.xml
+++ b/rules/0230-ms-se_rules.xml
@@ -132,7 +132,6 @@
   <rule id="7718" level="5">
     <if_sid>7706, 7707</if_sid>
     <match>Virus:DOS/EICAR_Test_File</match>
-    <options>alert_by_email</options>
     <description>Microsoft Security Essentials - EICAR test file detected.</description>
   </rule>
 

--- a/rules/0235-vmware_rules.xml
+++ b/rules/0235-vmware_rules.xml
@@ -110,7 +110,6 @@
     <if_sid>19106</if_sid>
     <match>-> VM_STATE_ON</match>
     <description>Virtual machine state changed to ON.</description>
-    <options>alert_by_email</options>
     <group>gpg13_4.13,</group>
   </rule>
 
@@ -119,7 +118,6 @@
     <match>-> VM_STATE_RECONFIGURING</match>
     <description>Virtual machine being reconfigured.</description>
     <group>config_changed,pci_dss_10.2.7,gpg13_4.13,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.14,</group>
-    <options>alert_by_email</options>
   </rule>
 
 

--- a/rules/0245-web_rules.xml
+++ b/rules/0245-web_rules.xml
@@ -121,7 +121,6 @@
   <rule id="31122" level="5">
     <if_sid>31120</if_sid>
     <id>^500</id>
-    <options>alert_by_email</options>
     <description>Web server 500 error code (Internal Error).</description>
     <group>system_error,</group>
   </rule>
@@ -129,7 +128,6 @@
   <rule id="31123" level="4">
     <if_sid>31120</if_sid>
     <id>^503</id>
-    <options>alert_by_email</options>
     <description>Web server 503 error code (Service unavailable).</description>
   </rule>
 

--- a/rules/0265-php_rules.xml
+++ b/rules/0265-php_rules.xml
@@ -65,7 +65,6 @@
     <if_sid>31410</if_sid>
     <match>Failed opening|failed to open stream</match>
     <description>PHP internal error (missing file).</description>
-    <options>alert_by_email</options>
     <group>attack,pci_dss_6.5,gpg13_4.3,gdpr_IV_35.7.d,nist_800_53_SA.11,</group>
   </rule>
 
@@ -73,7 +72,6 @@
     <if_sid>31410</if_sid>
     <match>bytes written, possibly out of free disk space in</match>
     <description>PHP internal error (server out of space).</description>
-    <options>alert_by_email</options>
     <group>low_diskspace,</group>
     <group>attack,pci_dss_6.5,pci_dss_10.2.7,gpg13_4.3,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_SA.11,nist_800_53_AU.14,</group>
   </rule>
@@ -92,7 +90,6 @@ d 'includes/SkinTemplate.php'
     <if_sid>31420</if_sid>
     <match>Failed opening required |Call to undefined function </match>
     <description>PHP internal error (missing file or function).</description>
-    <options>alert_by_email</options>
     <group>pci_dss_6.5,pci_dss_6.5.5,pci_dss_10.6.1,gpg13_4.3,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_SA.11,nist_800_53_AU.6,</group>
   </rule>
 
@@ -102,7 +99,6 @@ d 'includes/SkinTemplate.php'
   <rule id="31430" level="5">
     <if_sid>31403, 31406</if_sid>
     <description>PHP Parse error.</description>
-    <options>alert_by_email</options>
     <group>pci_dss_6.5,pci_dss_6.5.5,pci_dss_10.6.1,gpg13_4.3,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_SA.11,nist_800_53_AU.6,</group>
   </rule>
 

--- a/rules/0390-fortigate_rules.xml
+++ b/rules/0390-fortigate_rules.xml
@@ -63,7 +63,6 @@ ID: 81600 - 80799
     <rule id="81607" level="7" frequency="18" timeframe="45" ignore="240">
         <if_matched_sid>81606</if_matched_sid>
         <same_source_ip />
-        <options>alert_by_email</options>
         <description>Fortigate: Multiple failed login events from same source.</description>
         <group>authentication_failures,pci_dss_10.6.1,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.6,nist_800_53_AU.14,nist_800_53_AC.7,</group>
     </rule>
@@ -75,7 +74,6 @@ ID: 81600 - 80799
     <rule id="81608" level="7">
         <if_sid>81603</if_sid>
         <match>Configuration is changed in the admin session</match>
-        <options>alert_by_email</options>
         <description>Fortigate: Configuration changed.</description>
         <group>gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
     </rule>
@@ -100,7 +98,6 @@ ID: 81600 - 80799
     <rule id="81611" level="7" frequency="18" timeframe="45" ignore="240">
         <if_matched_sid>81610</if_matched_sid>
         <same_source_ip />
-        <options>alert_by_email</options>
         <description>Fortigate: Multiple default tunneling setting events from same source.</description>
         <group>pci_dss_10.6.1,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.6,</group>
     </rule>
@@ -136,7 +133,6 @@ ID: 81600 - 80799
     <rule id="81615" level="7" frequency="18" timeframe="45" ignore="240">
         <if_matched_sid>81614</if_matched_sid>
         <same_source_ip />
-        <options>alert_by_email</options>
         <description>Fortigate: Multiple Firewall SSL VPN failed login events from same source.</description>
         <group>authentication_failures,pci_dss_10.6.1,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.6,nist_800_53_AU.14,nist_800_53_AC.7,</group>
     </rule>
@@ -173,7 +169,6 @@ ID: 81600 - 80799
     <rule id="81619" level="3" frequency="18" timeframe="45" ignore="240">
         <if_matched_sid>81618</if_matched_sid>
         <same_source_ip />
-        <options>alert_by_email</options>
         <description>Fortigate: Multiple high traffic events from same source.</description>
         <group>pci_dss_10.6.1,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.6,</group>
     </rule>

--- a/rules/0400-openvpn_rules.xml
+++ b/rules/0400-openvpn_rules.xml
@@ -27,7 +27,6 @@
     <rule id="81802" level="3" frequency="3" timeframe="60">
         <if_matched_sid>81801</if_matched_sid>
         <user />
-        <options>alert_by_email</options>
         <description>OpenVPN: Concurrent connections</description>
     </rule>
 
@@ -45,7 +44,6 @@
 
     <rule id="81804" level="4" frequency="3" timeframe="60">
         <if_matched_sid>81803</if_matched_sid>
-        <options>alert_by_email</options>
         <description>OpenVPN: Certificate failed - Possible revoked user</description>
         <group>openvpn-error,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
     </rule>

--- a/rules/0580-win-security_rules.xml
+++ b/rules/0580-win-security_rules.xml
@@ -173,7 +173,6 @@
 
   <rule id="60119" level="3">
     <if_sid>60106</if_sid>
-    <options>alert_by_email</options>
     <if_fts />
     <description>First time this user logged in this system</description>
     <options>no_full_log</options>

--- a/rules/0585-win-application_rules.xml
+++ b/rules/0585-win-application_rules.xml
@@ -103,7 +103,6 @@
   <rule id="60611" level="3">
     <if_sid>60609</if_sid>
     <field name="win.system.eventID">^11724$|^1034$</field>
-    <options>alert_by_email</options>
     <description>Application Uninstalled $(win.eventdata.data)</description>
     <options>no_full_log</options>
   </rule>
@@ -111,7 +110,6 @@
   <rule id="60612" level="3">
     <if_sid>60609</if_sid>
     <field name="win.system.eventID">^11707$|^1033$</field>
-    <options>alert_by_email</options>
     <description>Application Installed $(win.eventdata.data)</description>
     <options>no_full_log</options>
   </rule>

--- a/rules/0605-win-mcafee_rules.xml
+++ b/rules/0605-win-mcafee_rules.xml
@@ -134,7 +134,6 @@
   <rule id="62616" level="5">
     <if_sid>62607</if_sid>
     <field name="win.system.message">contains the EICAR test file</field>
-    <options>alert_by_email</options>
     <description>McAfee Windows AV - EICAR test file detected</description>
   </rule>
 

--- a/rules/0615-win-ms-se_rules.xml
+++ b/rules/0615-win-ms-se_rules.xml
@@ -141,7 +141,6 @@
   <rule id="63616" level="5">
     <if_sid>63604,63605</if_sid>
     <field name="win.system.message">\.*DOS/EICAR_Test_File</field>
-    <options>alert_by_email</options>
     <description>Microsoft Security Essentials - EICAR test file detected</description>
     <options>no_full_log</options>
   </rule>


### PR DESCRIPTION
Hello team,

I've updated the ruleset to remove the `<option>alert_by_email</option>` from every rule that used it.
This PR is related to [this issue](https://github.com/wazuh/wazuh-ruleset/issues/546).

Regards.