### PR TITLE
openvpn LDAP error handling enhancements

### DIFF
--- a/decoders/0190-openvpn_decoders.xml
+++ b/decoders/0190-openvpn_decoders.xml
@@ -64,7 +64,6 @@ Jul 21 18:32:24 fw01 openvpn: user 'chapolin' authenticated
   <order>srcuser</order>
 </decoder>
 
-
 <!--
  Author: Stuart Williams <stwilliams@workforcesoftware.com>
     Date: 2019-01-29
@@ -91,3 +90,4 @@ Jan 28 14:25:49 VPN-SERVER-05892 openvpn: Incorrect password supplied for LDAP D
   <regex offset="after_prematch">^"CN=(\.+),OU=(\.+),(\.+)"</regex>
   <order>ldap_data.Username,ldap_data.Department,ldap_data.SecurityGroup</order>
 </decoder>
+

--- a/decoders/0190-openvpn_decoders.xml
+++ b/decoders/0190-openvpn_decoders.xml
@@ -63,3 +63,31 @@ Jul 21 18:32:24 fw01 openvpn: user 'chapolin' authenticated
   <regex offset="after_prematch">^(\S+)'</regex>
   <order>srcuser</order>
 </decoder>
+
+
+<!--
+ Author: Stuart Williams <stwilliams@workforcesoftware.com>
+    Date: 2019-01-29
+    Note: Enhanced decoder rules to handle LDAP integrated authentication
+Comments: Not sure how useful the first entry is but will 'log' it - could be useful in auditing numbers etc
+-->
+
+<!--
+Jan 28 14:25:49 VPN-SERVER-05892 openvpn: LDAP bind failed: Invalid credentials (80090308: LdapErr: DSID-55555555, comment: AcceptSecurityContext error, data 775, v3839)
+-->
+<decoder name="openvpn_ldap_bind_failed">
+  <parent>openvpn</parent>
+  <prematch>^LDAP bind failed: </prematch>
+  <regex offset="after_prematch">^(\.+) \((\d+): LdapErr: (\S+), comment: (\.+),</regex>
+  <order>ldap_data.error_message,ldap_data.code,ldap_data.ldaperr,ldap_data.comment</order>
+</decoder>
+
+<!--
+Jan 28 14:25:49 VPN-SERVER-05892 openvpn: Incorrect password supplied for LDAP DN "CN=Harry T. Hacker,OU=business unit,OU=department,DC=domain,DC=com".
+-->
+<decoder name="openvpn_ldap_incorrect_password">
+  <parent>openvpn</parent>
+  <prematch>^Incorrect password supplied for LDAP DN </prematch>
+  <regex offset="after_prematch">^"CN=(\.+),OU=(\.+),(\.+)"</regex>
+  <order>ldap_data.Username,ldap_data.Department,ldap_data.SecurityGroup</order>
+</decoder>

--- a/rules/0400-openvpn_rules.xml
+++ b/rules/0400-openvpn_rules.xml
@@ -60,14 +60,14 @@ Jan 28 14:25:49 VPN-SERVER-05892 openvpn: LDAP bind failed: Invalid credentials 
 Jan 28 14:25:49 VPN-SERVER-05892 openvpn: Incorrect password supplied for LDAP DN "CN=Harry T. Hacker,OU=business unit,OU=department,DC=domain,DC=com".
 -->
 
-  <rule id="81810" level="5">
+  <rule id="81805" level="5">
     <if_sid>81800</if_sid>
     <match>^LDAP bind failed:</match>
     <description>OpenVPN LDAP Bind Failure: $(ldap_data.error_message)</description>
     <group>pci_dss_10.2.5,gpg13_7.1,gpg13_7.2,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.14,nist_800_53_AC.7</group>
   </rule>
 
-  <rule id="81820" level="5">
+  <rule id="81806" level="5">
     <if_sid>81800</if_sid>
     <match>^Incorrect password supplied for LDAP DN</match>
     <description>OpenVPN LDAP Logon Failure: $(ldap_data.Username) [$(ldap_data.Department)]</description>

--- a/rules/0400-openvpn_rules.xml
+++ b/rules/0400-openvpn_rules.xml
@@ -50,4 +50,28 @@
         <group>openvpn-error,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
     </rule>
 
+<!--
+ Author: Stuart Williams <stwilliams@workforcesoftware.com>
+    Date: 2019-01-29
+    Note: Enhanced decoder rules to handle LDAP integrated authentication
+Comments: Not sure how useful the first entry is but will 'log' it - could be useful in auditing numbers etc
+
+Jan 28 14:25:49 VPN-SERVER-05892 openvpn: LDAP bind failed: Invalid credentials (80090308: LdapErr: DSID-55555555, comment: AcceptSecurityContext error, data 775, v3839)
+Jan 28 14:25:49 VPN-SERVER-05892 openvpn: Incorrect password supplied for LDAP DN "CN=Harry T. Hacker,OU=business unit,OU=department,DC=domain,DC=com".
+-->
+
+  <rule id="81810" level="5">
+    <if_sid>81800</if_sid>
+    <match>^LDAP bind failed:</match>
+    <description>OpenVPN LDAP Bind Failure: $(ldap_data.error_message)</description>
+    <group>pci_dss_10.2.5,gpg13_7.1,gpg13_7.2,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.14,nist_800_53_AC.7</group>
+  </rule>
+
+  <rule id="81820" level="5">
+    <if_sid>81800</if_sid>
+    <match>^Incorrect password supplied for LDAP DN</match>
+    <description>OpenVPN LDAP Logon Failure: $(ldap_data.Username) [$(ldap_data.Department)]</description>
+    <group>pci_dss_10.2.5,gpg13_7.1,gpg13_7.2,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.14,nist_800_53_AC.7,</group>
+  </rule>
+  
 </group>

--- a/tools/rules-testing/tests/openvpn_ldap.ini
+++ b/tools/rules-testing/tests/openvpn_ldap.ini
@@ -1,0 +1,12 @@
+[openvpn: LDAP Bind Failed]
+log 1 fail = Jan 28 14:25:49 VPN-SERVER-05892 openvpn: LDAP bind failed: Invalid credentials (80090308: LdapErr: DSID-55555555, comment: AcceptSecurityContext error, data 775, v3839)
+rule = 81810
+alert = 5
+decoder = openvpn
+
+[openvpn: LDAP Logon Failure]
+log 1 fail = Jan 28 14:25:49 VPN-SERVER-05892 openvpn: Incorrect password supplied for LDAP DN "CN=Harry T. Hacker,OU=business unit,OU=department,DC=domain,DC=com"
+rule = 81820
+alert = 5
+decoder = openvpn
+

--- a/tools/rules-testing/tests/openvpn_ldap.ini
+++ b/tools/rules-testing/tests/openvpn_ldap.ini
@@ -1,12 +1,12 @@
 [openvpn: LDAP Bind Failed]
 log 1 fail = Jan 28 14:25:49 VPN-SERVER-05892 openvpn: LDAP bind failed: Invalid credentials (80090308: LdapErr: DSID-55555555, comment: AcceptSecurityContext error, data 775, v3839)
-rule = 81810
+rule = 81805
 alert = 5
 decoder = openvpn
 
 [openvpn: LDAP Logon Failure]
 log 1 fail = Jan 28 14:25:49 VPN-SERVER-05892 openvpn: Incorrect password supplied for LDAP DN "CN=Harry T. Hacker,OU=business unit,OU=department,DC=domain,DC=com"
-rule = 81820
+rule = 81806
 alert = 5
 decoder = openvpn
 


### PR DESCRIPTION
These additions allow for handling of LDAP authentication error messages generated by the openvpn server when the server has been configured to off-load authentication to a LDAP server (e.g. Active Directory)

Stu Williams (Workforce Software)