### PR TITLE
Fix firewall rules - Cisco Devices - (PR v3.12)

### DIFF
--- a/decoders/0065-cisco-ios_decoders.xml
+++ b/decoders/0065-cisco-ios_decoders.xml
@@ -83,11 +83,10 @@
 
 <decoder name="cisco-ios-acl">
   <parent>cisco-ios</parent>
-  <type>firewall</type>
   <prematch>^%SEC-6-IPACCESSLOGP: </prematch>
-  <regex offset="after_prematch">^list \S+ (\w+) (\w+) </regex>
+  <regex>(%\w+-\d-\w+):\s+list \S+ (\w+) (\w+) </regex>
   <regex>(\S+)\((\d+)\) -> (\S+)\((\d+)\),</regex>
-  <order>action, protocol, srcip, srcport, dstip, dstport</order>
+  <order>id ,action, protocol, srcip, srcport, dstip, dstport</order>
 </decoder>
 
 

--- a/rules/0060-firewall_rules.xml
+++ b/rules/0060-firewall_rules.xml
@@ -17,7 +17,7 @@
     -->
   <rule id="4101" level="5">
     <if_sid>4100</if_sid>
-    <regex>DROP|Deny|deny|Denied|denied</regex>
+    <action>DROP</action>
     <options>no_log</options>
     <description>Firewall drop event.</description>
     <group>firewall_drop,pci_dss_1.4,gpg13_4.12,gdpr_IV_35.7.d,</group>

--- a/rules/0060-firewall_rules.xml
+++ b/rules/0060-firewall_rules.xml
@@ -17,7 +17,7 @@
     -->
   <rule id="4101" level="5">
     <if_sid>4100</if_sid>
-    <action>DROP</action>
+    <regex>DROP|Deny|deny|Denied|denied</regex>
     <options>no_log</options>
     <description>Firewall drop event.</description>
     <group>firewall_drop,pci_dss_1.4,gpg13_4.12,gdpr_IV_35.7.d,</group>

--- a/rules/0075-cisco-ios_rules.xml
+++ b/rules/0075-cisco-ios_rules.xml
@@ -86,4 +86,19 @@
     <group>authentication_failed,pci_dss_10.2.5,pci_dss_10.2.4,gpg13_3.6,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
   </rule>
 
+    <rule id="4731" level="5">
+    <if_sid>4716</if_sid>
+    <id>^%SEC-6-IPACCESSLOGP</id>
+    <description>Cisco ACL: denied access event.</description>
+    <group>firewall_drop,pci_dss_1.4,gpg13_4.12,gdpr_IV_35.7.d,</group>
+  </rule>
+  
+  <rule id="4732" level="10" frequency="18" timeframe="45" ignore="240">
+    <if_matched_sid>4731</if_matched_sid>
+    <id>^%SEC-6-IPACCESSLOGP</id>
+    <action>denied</action>
+    <description>Cisco ACL: multiple denied access from same source.</description>
+    <group>multiple_drops,pci_dss_1.4,pci_dss_10.6.1,gpg13_4.12,gdpr_IV_35.7.d,</group>
+  </rule>
+
 </group>

--- a/tools/rules-testing/tests/cisco_ios.ini
+++ b/tools/rules-testing/tests/cisco_ios.ini
@@ -14,8 +14,8 @@ log 1 pass = Sep  1 10:25:29 10.10.10.1 %SEC-6-IPACCESSLOGP: list 102 denied tcp
 log 2 pass = Sep  1 10:25:29 10.10.10.1 %SEC-6-IPACCESSLOGP: list 199 denied tcp 10.0.61.108(1477) -> 10.0.127.20(445), 1 packet
 
 
-rule = 4100
-alert = 0
+rule = 4731
+alert = 5
 decoder = cisco-ios
 
 


### PR DESCRIPTION
Fixes #208 

Hello team,
The firewall drop rules aren't working for Cisco devices, because they have deny action instead of drop.

Here are some samples for Cisco devices.
```
3924923: *Oct  6 03:32:04.114 gmt: %SEC-6-IPACCESSLOGP: list bcv_out denied tcp 10.0.3.100(50150) -> 192.168.216.1(443), 1 packet 

Oct 03 2018 17:34:08: %ASA-4-106023: Deny udp src office:1.1.1.1/3217 dst FE_xUI:Server_Windows/15000 by access-group "ACLoffice" [0x0, 0x0]
```
Original PR: https://github.com/wazuh/wazuh-ruleset/pull/209
Author: @migruiz4 