### PR TITLE
Email alerts and groups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ All notable changes to this project will be documented in this file.
 ### Changed
 
 - Changed the eventchannel field names in rules. ([#299](https://github.com/wazuh/wazuh-ruleset/pull/299))
-- Changed compliance rules groups and removed `alert_by_email` option by default.
+- Changed compliance rules groups and removed `alert_by_email` option by default. ([#559](https://github.com/wazuh/wazuh-ruleset/pull/559))
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ All notable changes to this project will be documented in this file.
 ### Changed
 
 - Changed the eventchannel field names in rules. ([#299](https://github.com/wazuh/wazuh-ruleset/pull/299))
+- Added rules `PCI` and `HIPAA` groups.
+- Removed the default `alert_by_email` option in rules.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,8 +16,7 @@ All notable changes to this project will be documented in this file.
 ### Changed
 
 - Changed the eventchannel field names in rules. ([#299](https://github.com/wazuh/wazuh-ruleset/pull/299))
-- Added rules `PCI` and `HIPAA` groups.
-- Removed the default `alert_by_email` option in rules.
+- Changed compliance rules groups and removed `alert_by_email` option by default.
 
 ### Fixed
 

--- a/rules/0015-ossec_rules.xml
+++ b/rules/0015-ossec_rules.xml
@@ -17,7 +17,6 @@
   <rule id="501" level="3">
     <if_sid>500</if_sid>
     <if_fts />
-    <options>alert_by_email</options>
     <match>Agent started</match>
     <description>New ossec agent connected.</description>
     <group>pci_dss_10.6.1,gpg13_10.1,gdpr_IV_35.7.d,</group>
@@ -25,7 +24,6 @@
 
   <rule id="502" level="3">
     <if_sid>500</if_sid>
-    <options>alert_by_email</options>
     <match>Ossec started</match>
     <description>Ossec server started.</description>
     <group>pci_dss_10.6.1,gpg13_10.1,gdpr_IV_35.7.d,</group>
@@ -33,7 +31,6 @@
 
   <rule id="503" level="3">
     <if_sid>500</if_sid>
-    <options>alert_by_email</options>
     <match>Agent started</match>
     <description>Ossec agent started.</description>
     <group>pci_dss_10.6.1,pci_dss_10.2.6,gpg13_10.1,gdpr_IV_35.7.d,</group>
@@ -41,7 +38,6 @@
 
   <rule id="504" level="3">
     <if_sid>500</if_sid>
-    <options>alert_by_email</options>
     <match>Agent disconnected</match>
     <description>Ossec agent disconnected.</description>
     <group>pci_dss_10.6.1,pci_dss_10.2.6,gpg13_10.1,gdpr_IV_35.7.d,</group>
@@ -49,7 +45,6 @@
 
   <rule id="505" level="3">
     <if_sid>500</if_sid>
-    <options>alert_by_email</options>
     <match>Agent removed</match>
     <description>Ossec agent removed.</description>
     <group>pci_dss_10.6.1,pci_dss_10.2.6,gpg13_10.1,gdpr_IV_35.7.d,</group>
@@ -59,7 +54,7 @@
     <category>ossec</category>
     <decoded_as>rootcheck</decoded_as>
     <description>Rootcheck event.</description>
-    <group>rootcheck,</group>
+    <group>pci_dss_10.6.1,rootcheck,</group>
   </rule>
 
   <rule id="510" level="7">
@@ -82,7 +77,7 @@
     <if_sid>510</if_sid>
     <match>^Windows Audit</match>
     <description>Windows Audit event.</description>
-    <group>rootcheck,</group>
+    <group>pci_dss_10.6.1,hipaa_164.312.b,rootcheck,</group>
   </rule>
 
   <rule id="513" level="9">
@@ -96,7 +91,7 @@
     <if_sid>510</if_sid>
     <match>^Application Found</match>
     <description>Windows application monitor event.</description>
-    <group>rootcheck,</group>
+    <group>pci_dss_10.6.1,hipaa_164.312.b,rootcheck,</group>
   </rule>
 
   <rule id="515" level="0">
@@ -191,6 +186,7 @@
     <check_diff />
     <options>no_log</options>
     <description>List of the last logged in users.</description>
+    <group>pci_dss_10.6.1,hipaa_164.312.b,</group>
   </rule>
 
   <rule id="536" level="0">
@@ -270,24 +266,24 @@
     <category>ossec</category>
     <if_sid>550</if_sid>
     <hostname>syscheck-registry</hostname>
-    <group>syscheck,pci_dss_11.5,gpg13_4.13,gdpr_II_5.1.f,</group>
     <description>Registry Integrity Checksum Changed</description>
+    <group>syscheck,pci_dss_11.5,gpg13_4.13,gdpr_II_5.1.f,</group>
   </rule>
 
   <rule id="597" level="5">
     <category>ossec</category>
     <if_sid>553</if_sid>
     <hostname>syscheck-registry</hostname>
-    <group>syscheck,pci_dss_11.5,gpg13_4.13,gdpr_II_5.1.f,</group>
     <description>Registry Entry Deleted.</description>
+    <group>syscheck,pci_dss_11.5,gpg13_4.13,gdpr_II_5.1.f,</group>
   </rule>
 
   <rule id="598" level="5">
     <category>ossec</category>
     <if_sid>554</if_sid>
     <hostname>syscheck-registry</hostname>
-    <group>syscheck,pci_dss_11.5,gpg13_4.13,gdpr_II_5.1.f,</group>
     <description>Registry Entry Added to the System</description>
+    <group>syscheck,pci_dss_11.5,gpg13_4.13,gdpr_II_5.1.f,</group>
   </rule>
 
   <!-- active response rules

--- a/rules/0020-syslog_rules.xml
+++ b/rules/0020-syslog_rules.xml
@@ -68,7 +68,7 @@
     <if_sid>1002</if_sid>
     <match>terminated without error|can't verify hostname: getaddrinfo|</match>
     <match>PPM exceeds tolerance</match>
-    <description>Ignoring known false positives on rule 1002..</description>
+    <description>Ignoring known false positives on rule 1002.</description>
   </rule>
 
   <rule id="1010" level="5">
@@ -93,23 +93,27 @@
     <if_sid>2100</if_sid>
     <match>nfs: mount failure</match>
     <description>Unable to mount the NFS share.</description>
+    <group>pci_dss_10.6.3</group>
   </rule>
 
   <rule id="2102" level="4">
     <if_sid>2100</if_sid>
     <match>reason given by server: Permission denied</match>
     <description>Unable to mount the NFS directory.</description>
+    <group>pci_dss_10.6.3</group>
   </rule>
 
   <rule id="2103" level="4">
     <match>^rpc.mountd: refused mount request from</match>
     <description>Unable to mount the NFS directory.</description>
+    <group>pci_dss_10.6.3</group>
   </rule>
 
   <rule id="2104" level="2">
     <if_sid>2100</if_sid>
     <regex>lookup for \S+ failed</regex>
-    <description>Automount informative message</description>
+    <description>Automount informative message.</description>
+    <group>pci_dss_10.6.1,hipaa_164.312.b</group>
   </rule>
 </group> <!-- SYSLOG,NFS -->
 
@@ -141,7 +145,7 @@
 
   <rule id="2502" level="10">
     <match>more authentication failures;|REPEATED login failures</match>
-    <description>syslog: User missed the password more than one time</description>
+    <description>syslog: User missed the password more than one time.</description>
     <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.8,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
   </rule>
 
@@ -155,7 +159,7 @@
 
   <rule id="2504" level="9">
     <match>ILLEGAL ROOT LOGIN|ROOT LOGIN REFUSED</match>
-    <description>syslog: Illegal root login. </description>
+    <description>syslog: Illegal root login.</description>
     <group>invalid_login,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_10.2.2,gpg13_7.8,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
   </rule>
 
@@ -233,19 +237,21 @@
   <rule id="2801" level="0">
     <if_sid>2800</if_sid>
     <match>No configuration file /etc/smartd.conf found</match>
-    <description>Smartd Started but not configured</description>
+    <description>Smartd Started but not configured.</description>
+    <group>pci_dss_10.6.1,hipaa_164.312.b</group>
   </rule>
 
   <rule id="2802" level="0">
     <if_sid>2800</if_sid>
     <match>Unable to register ATA device</match>
-    <description>Smartd configuration problem</description>
+    <description>Smartd configuration problem.</description>
   </rule>
 
   <rule id="2803" level="0">
     <if_sid>2800</if_sid>
     <match>No such device or address</match>
-    <description>Device configured but not available to Smartd</description>
+    <description>Device configured but not available to Smartd.</description>
+    <group>pci_dss_10.6.1,hipaa_164.312.b</group>
   </rule>
 </group> <!-- SYSLOG,SMARTD -->
 
@@ -255,19 +261,21 @@
 <group name="syslog,linuxkernel,">
   <rule id="5100" level="0" noalert="1">
     <program_name>^kernel</program_name>
-    <description>Pre-match rule for kernel messages</description>
+    <description>Pre-match rule for kernel messages.</description>
   </rule>
 
   <rule id="5101" level="0">
     <if_sid>5100</if_sid>
     <match>PCI: if you experience problems, try using option</match>
     <description>Informative message from the kernel.</description>
+    <group>pci_dss_10.6.1,hipaa_164.312.b</group>
   </rule>
 
   <rule id="5102" level="0">
     <if_sid>5100</if_sid>
     <match>modprobe: Can't locate module sound</match>
-    <description>Informative message from the kernel</description>
+    <description>Informative message from the kernel.</description>
+    <group>pci_dss_10.6.1,hipaa_164.312.b</group>
   </rule>
 
   <rule id="5103" level="9">
@@ -291,18 +299,21 @@
     <match>end_request: I/O error, dev fd0, sector 0|</match>
     <match>Buffer I/O error on device fd0, logical block 0</match>
     <description>Invalid request to /dev/fd0 (bug on the kernel).</description>
+    <group>pci_dss_10.6.1,hipaa_164.312.b</group>
   </rule>
 
   <rule id="5106" level="0">
     <if_sid>5100</if_sid>
     <match>svc: unknown program 100227 (me 100003)</match>
     <description>NFS incompatibility between Linux and Solaris.</description>
+    <group>pci_dss_10.6.1,hipaa_164.312.b</group>
   </rule>
 
   <rule id="5107" level="0">
     <if_sid>5100</if_sid>
     <match>svc: bad direction </match>
     <description>NFS incompatibility between Linux and Solaris.</description>
+    <group>pci_dss_10.6.1,hipaa_164.312.b</group>
   </rule>
 
   <rule id="5108" level="12">
@@ -316,32 +327,35 @@
   <rule id="5109" level="4">
     <if_sid>5100</if_sid>
     <match>I/O error: dev |end_request: I/O error, dev</match>
-    <description>Kernel Input/Output error</description>
+    <description>Kernel Input/Output error.</description>
+    <group>pci_dss_10.6.1,hipaa_164.312.b</group>
   </rule>
 
   <rule id="5110" level="4">
     <if_sid>5100</if_sid>
     <match>Forged DCC command from</match>
-    <description>IRC misconfiguration</description>
+    <description>IRC misconfiguration.</description>
   </rule>
 
   <rule id="5111" level="0">
     <if_sid>5100</if_sid>
     <match>ipw2200: Firmware error detected.| ACPI Error</match>
     <description>Kernel device error.</description>
+    <group>pci_dss_10.6.1,hipaa_164.312.b</group>
   </rule>
 
   <rule id="5112" level="0">
     <if_sid>5100</if_sid>
     <match>usbhid: probe of</match>
     <description>Kernel usbhid probe error (ignored).</description>
+    <group>pci_dss_10.6.1,hipaa_164.312.b</group>
   </rule>
 
   <rule id="5113" level="7">
     <if_sid>5100</if_sid>
     <match>Kernel log daemon terminating</match>
-    <group>system_shutdown,pci_dss_10.6.1,gpg13_4.14,gdpr_IV_35.7.d,</group>
     <description>System is shutting down.</description>
+    <group>system_shutdown,pci_dss_10.6.1,gpg13_4.14,gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="5130" level="7">
@@ -359,6 +373,7 @@
   <rule id="5200" level="0">
     <match>^hpiod: unable to ParDevice</match>
     <description>Ignoring hpiod for producing useless logs.</description>
+    <group>pci_dss_10.6.1,hipaa_164.312.b</group>
   </rule>
 </group> <!-- SYSLOG,LINUXKERNEL -->
 
@@ -374,7 +389,7 @@
   <rule id="2831" level="0">
     <if_sid>2830</if_sid>
     <match>^unable to exec</match>
-    <description>Wrong crond configuration</description>
+    <description>Wrong crond configuration.</description>
   </rule>
 
   <rule id="2834" level="5">
@@ -441,7 +456,6 @@
   <rule id="5305" level="4">
     <if_sid>5303, 5304</if_sid>
     <if_fts></if_fts>
-    <options>alert_by_email</options>
     <description>First time (su) is executed by user.</description>
   </rule>
 
@@ -450,6 +464,7 @@
     <match>unknown class</match>
     <info>OpenBSD uses login classes, and an inappropriate login class was used.</info>
     <description>A user has attempted to su to an unknown class.</description>
+    <group>pci_dss_10.6.1,hipaa_164.312.b</group>
   </rule>
 
 </group> <!-- SYSLOG,SU -->
@@ -460,7 +475,7 @@
 <group name="syslog,tripwire,">
   <rule id="7101" level="8">
     <match>Integrity Check failed: File could not</match>
-    <description>Problems with the tripwire checking</description>
+    <description>Problems with the tripwire checking.</description>
     <group>pci_dss_10.5.5,pci_dss_10.6.1,gdpr_II_5.1.f,gdpr_IV_35.7.d,</group>
   </rule>
 </group> <!-- SYSLOG,TRIPWIRE -->
@@ -471,25 +486,25 @@
 <group name="syslog,adduser,">
   <rule id="5901" level="8">
     <match>^new group</match>
-    <description>New group added to the system</description>
+    <description>New group added to the system.</description>
     <group>pci_dss_10.2.7,pci_dss_10.2.5,pci_dss_8.1.2,gpg13_4.13,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
   </rule>
 
   <rule id="5902" level="8">
     <match>^new user|^new account added</match>
-    <description>New user added to the system</description>
+    <description>New user added to the system.</description>
     <group>pci_dss_10.2.7,pci_dss_10.2.5,pci_dss_8.1.2,gpg13_4.13,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
   </rule>
 
   <rule id="5903" level="3">
     <match>^delete user|^account deleted|^remove group</match>
-    <description>Group (or user) deleted from the system</description>
+    <description>Group (or user) deleted from the system.</description>
     <group>pci_dss_10.2.7,pci_dss_10.2.5,pci_dss_8.1.2,gpg13_4.13,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
   </rule>
 
   <rule id="5904" level="8">
     <match>^changed user</match>
-    <description>Information from the user was changed</description>
+    <description>Information from the user was changed.</description>
     <group>pci_dss_10.2.7,pci_dss_10.2.5,pci_dss_8.1.2,gpg13_4.13,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
   </rule>
 
@@ -506,26 +521,25 @@
 <group name="syslog,sudo,">
   <rule id="5400" level="0" noalert="1">
     <decoded_as>sudo</decoded_as>
-    <description>Initial group for sudo messages</description>
+    <description>Initial group for sudo messages.</description>
   </rule>
 
   <rule id="5401" level="5">
     <if_sid>5400</if_sid>
     <match>incorrect password attempt</match>
-    <description>Failed attempt to run sudo</description>
+    <description>Failed attempt to run sudo.</description>
     <group>pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.8,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
   </rule>
 
   <rule id="5402" level="3">
     <if_sid>5400</if_sid>
     <regex> ; USER=root ; COMMAND=| ; USER=root ; TSID=\S+ ; COMMAND=</regex>
-    <description>Successful sudo to ROOT executed</description>
+    <description>Successful sudo to ROOT executed.</description>
     <group>pci_dss_10.2.5,pci_dss_10.2.2,gpg13_7.6,gpg13_7.8,gpg13_7.13,gdpr_IV_32.2,</group>
   </rule>
 
   <rule id="5403" level="4">
     <if_sid>5400</if_sid>
-    <options>alert_by_email</options>
     <if_fts></if_fts>
     <description>First time user executed sudo.</description>
   </rule>
@@ -533,7 +547,7 @@
   <rule id="5404" level="10">
     <if_sid>5401</if_sid>
     <match>3 incorrect password attempts</match>
-    <description>Three failed attempts to run sudo</description>
+    <description>Three failed attempts to run sudo.</description>
     <group>pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.8,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
   </rule>
 
@@ -558,20 +572,20 @@
 <group name="syslog,pptp,">
   <rule id="9100" level="0" noalert="1">
     <program_name>^pptpd</program_name>
-    <description>PPTPD messages grouped</description>
+    <description>PPTPD messages grouped.</description>
   </rule>
 
   <rule id="9101" level="0">
     <if_sid>9100</if_sid>
     <regex>^GRE: \S+ from \S+ failed: status = -1 </regex>
-    <description>PPTPD failed message (communication error)</description>
+    <description>PPTPD failed message (communication error).</description>
     <info type="link">http://poptop.sourceforge.net/dox/gre-protocol-unavailable.phtml</info>
   </rule>
 
   <rule id="9102" level="0">
     <if_sid>9100</if_sid>
     <match>^tcflush failed: Bad file descriptor</match>
-    <description>PPTPD communication error</description>
+    <description>PPTPD communication error.</description>
   </rule>
 </group>
 
@@ -581,7 +595,6 @@
 <group name="syslog,fts,">
   <rule id="10100" level="4">
     <if_group>authentication_success</if_group>
-    <options>alert_by_email</options>
     <if_fts></if_fts>
     <group>authentication_success,</group>
     <description>First time user logged in.</description>
@@ -592,14 +605,15 @@
 <group name="syslog,squid,">
   <rule id="9200" level="0" noalert="1">
     <program_name>^squid</program_name>
-    <description>Squid syslog messages grouped</description>
+    <description>Squid syslog messages grouped.</description>
   </rule>
 
   <rule id="9201" level="0">
     <if_sid>9200</if_sid>
     <match>^ctx: enter level|^sslRead|^urlParse: Illegal |</match>
     <match>^httpReadReply: Request not yet |^httpReadReply: Excess data</match>
-    <description>Squid debug message</description>
+    <description>Squid debug message.</description>
+    <group>pci_dss_10.6.1,hipaa_164.312.b</group>
   </rule>
 </group>
 
@@ -654,6 +668,7 @@
     <hostname>yum.log$</hostname>
     <match>^Installed|^Updated|^Erased</match>
     <description>Yum logs.</description>
+    <group>pci_dss_10.6.1,hipaa_164.312.b</group>
   </rule>
 
   <rule id="2932" level="7">
@@ -730,7 +745,7 @@
 
   <rule id="2943" level="0">
     <match>^nouveau </match>
-    <description>nouveau driver grouping</description>
+    <description>nouveau driver grouping.</description>
   </rule>
 
   <rule id="2944" level="1">

--- a/rules/0115-arpwatch_rules.xml
+++ b/rules/0115-arpwatch_rules.xml
@@ -15,7 +15,6 @@
 
   <rule id="7201" level="4">
     <if_sid>7200</if_sid>
-    <options>alert_by_email</options>
     <if_fts />
     <description>Arpwatch new host detected.</description>
     <group>new_host,pci_dss_10.6.1,gdpr_IV_35.7.d,</group>

--- a/rules/0210-vpn_concentrator_rules.xml
+++ b/rules/0210-vpn_concentrator_rules.xml
@@ -30,7 +30,6 @@
   <rule id="14203" level="4">
     <if_sid>14200</if_sid>
     <id>^HTTP/47$|^SSH/16$</id>
-    <options>alert_by_email</options>
     <description>CiscoVPN: VPN Admin authentication successful.</description>
     <group>authentication_success,pci_dss_10.2.5,gpg13_7.1,gpg13_7.2,gdpr_IV_32.2,</group>
   </rule>

--- a/rules/0220-msauth_rules.xml
+++ b/rules/0220-msauth_rules.xml
@@ -39,6 +39,7 @@
     <if_sid>18100</if_sid>
     <status>^AUDIT_SUCCESS|^success</status>
     <description>Windows audit success event.</description>
+    <group>hipaa_164.312.b</group>
   </rule>
 
   <rule id="18105" level="4">
@@ -148,7 +149,6 @@
 
   <rule id="18119" level="3">
     <if_sid>18107</if_sid>
-    <options>alert_by_email</options>
     <if_fts />
     <description>Windows: First time this user logged in this system.</description>
     <group>authentication_success,pci_dss_10.2.5,gpg13_7.1,gpg13_7.2,gdpr_IV_32.2,</group>
@@ -316,23 +316,23 @@
   <rule id="18145" level="3">
     <if_sid>18101</if_sid>
     <id>^7040$</id>
-    <group>policy_changed,pci_dss_10.6,gdpr_IV_35.7.d,</group>
     <description>Windows: Service startup type was changed.</description>
+    <group>policy_changed,pci_dss_10.6,gdpr_IV_35.7.d,</group>
     <info type="text">This does not appear to be logged on Windows 2000.</info>
   </rule>
 
   <rule id="18146" level="5">
     <if_sid>18101</if_sid>
     <id>^11724$</id>
-    <options>alert_by_email</options>
     <description>Windows: Application Uninstalled.</description>
+    <group>pci_dss_10.6.2,</group>
   </rule>
 
   <rule id="18147" level="5">
     <if_sid>18101</if_sid>
     <id>^11707$</id>
-    <options>alert_by_email</options>
     <description>Windows: Application Installed.</description>
+    <group>pci_dss_10.6.2,</group>
   </rule>
 
   <rule id="18148" level="3">

--- a/rules/0220-msauth_rules.xml
+++ b/rules/0220-msauth_rules.xml
@@ -1156,7 +1156,6 @@
 
   <rule id="20020" level="3">
     <if_sid>20007</if_sid>
-    <options>alert_by_email</options>
     <if_fts />
     <description>Windows: First time this user logged in this system</description>
     <options>no_full_log</options>
@@ -1345,7 +1344,6 @@
   <rule id="20046" level="5">
     <if_sid>20001</if_sid>
     <field name="win.system.eventID">^11724$</field>
-    <options>alert_by_email</options>
     <description>Windows: Application Uninstalled $(win.eventdata.data)</description>
     <options>no_full_log</options>
   </rule>
@@ -1353,7 +1351,6 @@
   <rule id="20047" level="5">
     <if_sid>20001</if_sid>
     <field name="win.system.eventID">^11707$</field>
-    <options>alert_by_email</options>
     <description>Windows: Application Installed $(win.eventdata.data)</description>
     <options>no_full_log</options>
   </rule>

--- a/rules/0225-mcafee_av_rules.xml
+++ b/rules/0225-mcafee_av_rules.xml
@@ -26,20 +26,21 @@
     <if_sid>7500</if_sid>
     <id>$MCAFEE_INFO</id>
     <description>McAfee Windows AV informational event.</description>
+    <group>pci_dss_10.6.1</group>
   </rule>
 
   <rule id="7502" level="3">
     <if_sid>7500</if_sid>
     <id>$MCAFEE_WARN</id>
     <description>McAfee Windows AV warning event.</description>
-    <group>gpg13_4.12,</group>
+    <group>gpg13_4.12,pci_dss_10.6.1,hipaa_164.312.b</group>
   </rule>
 
   <rule id="7503" level="4">
     <if_sid>7500</if_sid>
     <id>$MCAFEE_ERROR</id>
     <description>McAfee Windows AV error event.</description>
-    <group>gpg13_4.3,</group>
+    <group>gpg13_4.3,pci_dss_10.6.1,hipaa_164.312.b</group>
   </rule>
 
   <rule id="7504" level="12">
@@ -116,7 +117,6 @@
   <rule id="7514" level="5">
     <if_sid>7505</if_sid>
     <match>contains the EICAR test file</match>
-    <options>alert_by_email</options>
     <description>McAfee Windows AV - EICAR test file detected.</description>
   </rule>
 

--- a/rules/0225-mcafee_av_rules.xml
+++ b/rules/0225-mcafee_av_rules.xml
@@ -229,7 +229,6 @@
   <rule id="20214" level="5">
     <if_sid>20205</if_sid>
     <field name="win.system.message">contains the EICAR test file</field>
-    <options>alert_by_email</options>
     <description>McAfee Windows AV - EICAR test file detected</description>
   </rule>
 

--- a/rules/0230-ms-se_rules.xml
+++ b/rules/0230-ms-se_rules.xml
@@ -238,7 +238,6 @@
   <rule id="20182" level="5">
     <if_sid>20170, 20171</if_sid>
     <field name="win.system.message">\.*DOS/EICAR_Test_File</field>
-    <options>alert_by_email</options>
     <description>Microsoft Security Essentials - EICAR test file detected</description>
     <options>no_full_log</options>
   </rule>

--- a/rules/0230-ms-se_rules.xml
+++ b/rules/0230-ms-se_rules.xml
@@ -108,7 +108,6 @@
   <rule id="7731" level="5">
     <if_sid>7711, 7712</if_sid>
     <match>Virus:DOS/EICAR_Test_File</match>
-    <options>alert_by_email</options>
     <description>Microsoft Security Essentials - EICAR test file detected.</description>
   </rule>
 

--- a/rules/0235-vmware_rules.xml
+++ b/rules/0235-vmware_rules.xml
@@ -110,7 +110,6 @@
     <if_sid>19106</if_sid>
     <match>-> VM_STATE_ON</match>
     <description>Virtual machine state changed to ON.</description>
-    <options>alert_by_email</options>
     <group>gpg13_4.13,</group>
   </rule>
 
@@ -119,7 +118,6 @@
     <match>-> VM_STATE_RECONFIGURING</match>
     <description>Virtual machine being reconfigured.</description>
     <group>config_changed,pci_dss_10.2.7,gpg13_4.13,gdpr_IV_35.7.d,</group>
-    <options>alert_by_email</options>
   </rule>
 
 

--- a/rules/0245-web_rules.xml
+++ b/rules/0245-web_rules.xml
@@ -18,13 +18,13 @@
     <id>^2|^3</id>
     <compiled_rule>is_simple_http_request</compiled_rule>
     <description>Ignored URLs (simple queries).</description>
-   </rule>
+  </rule>
 
   <rule id="31101" level="5">
     <if_sid>31100</if_sid>
     <id>^4</id>
     <description>Web server 400 error code.</description>
-	<group>attack,pci_dss_6.5,pci_dss_11.4,gdpr_IV_35.7.d,</group>
+    <group>attack,pci_dss_6.5,pci_dss_11.4,gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="31102" level="0">
@@ -121,7 +121,6 @@
   <rule id="31122" level="5">
     <if_sid>31120</if_sid>
     <id>^500</id>
-    <options>alert_by_email</options>
     <description>Web server 500 error code (Internal Error).</description>
     <group>system_error,</group>
   </rule>
@@ -129,7 +128,6 @@
   <rule id="31123" level="4">
     <if_sid>31120</if_sid>
     <id>^503</id>
-    <options>alert_by_email</options>
     <description>Web server 503 error code (Service unavailable).</description>
   </rule>
 
@@ -247,7 +245,5 @@
 	<info type="cve">CVE-2014-6278</info>
 	<info type="link">https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2014-6278</info>
         <group>attack,pci_dss_11.4,</group>
-    </rule>
-
-
+    </rule>  
 </group>

--- a/rules/0265-php_rules.xml
+++ b/rules/0265-php_rules.xml
@@ -65,7 +65,6 @@
     <if_sid>31410</if_sid>
     <match>Failed opening|failed to open stream</match>
     <description>PHP internal error (missing file).</description>
-    <options>alert_by_email</options>
     <group>attack,pci_dss_6.5,gpg13_4.3,gdpr_IV_35.7.d,</group>
   </rule>
 
@@ -73,7 +72,6 @@
     <if_sid>31410</if_sid>
     <match>bytes written, possibly out of free disk space in</match>
     <description>PHP internal error (server out of space).</description>
-    <options>alert_by_email</options>
     <group>low_diskspace,</group>
     <group>attack,pci_dss_6.5,pci_dss_10.2.7,gpg13_4.3,gdpr_IV_35.7.d,</group>
   </rule>
@@ -92,7 +90,6 @@ d 'includes/SkinTemplate.php'
     <if_sid>31420</if_sid>
     <match>Failed opening required |Call to undefined function </match>
     <description>PHP internal error (missing file or function).</description>
-    <options>alert_by_email</options>
     <group>pci_dss_6.5,pci_dss_6.5.5,pci_dss_10.6.1,gpg13_4.3,gdpr_IV_35.7.d,</group>
   </rule>
 
@@ -102,7 +99,6 @@ d 'includes/SkinTemplate.php'
   <rule id="31430" level="5">
     <if_sid>31403, 31406</if_sid>
     <description>PHP Parse error.</description>
-    <options>alert_by_email</options>
     <group>pci_dss_6.5,pci_dss_6.5.5,pci_dss_10.6.1,gpg13_4.3,gdpr_IV_35.7.d,</group>
   </rule>
 

--- a/rules/0390-fortigate_rules.xml
+++ b/rules/0390-fortigate_rules.xml
@@ -63,7 +63,6 @@ ID: 81600 - 80799
     <rule id="81607" level="7" frequency="18" timeframe="45" ignore="240">
         <if_matched_sid>81606</if_matched_sid>
         <same_source_ip />
-        <options>alert_by_email</options>
         <description>Fortigate: Multiple failed login events from same source.</description>
         <group>authentication_failures,pci_dss_10.6.1,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
     </rule>
@@ -75,7 +74,6 @@ ID: 81600 - 80799
     <rule id="81608" level="7">
         <if_sid>81603</if_sid>
         <match>Configuration is changed in the admin session</match>
-        <options>alert_by_email</options>
         <description>Fortigate: Configuration changed.</description>
         <group>gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
     </rule>
@@ -100,7 +98,6 @@ ID: 81600 - 80799
     <rule id="81611" level="7" frequency="18" timeframe="45" ignore="240">
         <if_matched_sid>81610</if_matched_sid>
         <same_source_ip />
-        <options>alert_by_email</options>
         <description>Fortigate: Multiple default tunneling setting events from same source.</description>
         <group>pci_dss_10.6.1,gdpr_IV_35.7.d,</group>
     </rule>
@@ -136,7 +133,6 @@ ID: 81600 - 80799
     <rule id="81615" level="7" frequency="18" timeframe="45" ignore="240">
         <if_matched_sid>81614</if_matched_sid>
         <same_source_ip />
-        <options>alert_by_email</options>
         <description>Fortigate: Multiple Firewall SSL VPN failed login events from same source.</description>
         <group>authentication_failures,pci_dss_10.6.1,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
     </rule>
@@ -173,7 +169,6 @@ ID: 81600 - 80799
     <rule id="81619" level="3" frequency="18" timeframe="45" ignore="240">
         <if_matched_sid>81618</if_matched_sid>
         <same_source_ip />
-        <options>alert_by_email</options>
         <description>Fortigate: Multiple high traffic events from same source.</description>
         <group>pci_dss_10.6.1,gdpr_IV_35.7.d,</group>
     </rule>

--- a/rules/0400-openvpn_rules.xml
+++ b/rules/0400-openvpn_rules.xml
@@ -27,7 +27,6 @@
     <rule id="81802" level="3" frequency="3" timeframe="60">
         <if_matched_sid>81801</if_matched_sid>
         <user />
-        <options>alert_by_email</options>
         <description>OpenVPN: Concurrent connections</description>
     </rule>
 
@@ -45,7 +44,6 @@
 
     <rule id="81804" level="4" frequency="3" timeframe="60">
         <if_matched_sid>81803</if_matched_sid>
-        <options>alert_by_email</options>
         <description>OpenVPN: Certificate failed - Possible revoked user</description>
         <group>openvpn-error,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
     </rule>


### PR DESCRIPTION
Changed Compliance rules groups and replicated the changes in this PR https://github.com/wazuh/wazuh-ruleset/pull/548 that aimed to remove the `alert_by_email` option by default in the rules.
