### PR TITLE
wazuh/wazuh-ruleset: rename pfsense to pf

### DIFF
--- a/decoders/0455-pf_decoders.xml
+++ b/decoders/0455-pf_decoders.xml
@@ -1,5 +1,5 @@
 <!--
-  -  Pfsense firewall decoders
+  -  pf firewall decoders
   -  Author Mark Alston
   -  Updated by Wazuh, Inc.
   -  Copyright (C) 2015-2019, Wazuh Inc.
@@ -7,11 +7,11 @@
 -->
 
 <!--
-- Will extract src IP, src Port, dst IP, dst Port, Protocol and action from the pfsense logs, when available.
+- Will extract src IP, src Port, dst IP, dst Port, Protocol and action from the pf logs, when available.
 -->
 
-<!-- PFSENSE
-Nov  8 12:37:34 pfSense filterlog: 5,,,1000102433,em0,match,block,in,4,0x0,,128,24677,0,none,17,udp,186,10.9.0.119,10.9.0.255,17500,17600,166
+<!-- pf filter
+Nov  8 12:37:34 hostname filterlog: 5,,,1000102433,em0,match,block,in,4,0x0,,128,24677,0,none,17,udp,186,10.9.0.119,10.9.0.255,17500,17600,166
  -->
 <decoder name="pf">
   <program_name>filterlog</program_name>

--- a/rules/0540-pf_rules.xml
+++ b/rules/0540-pf_rules.xml
@@ -1,16 +1,16 @@
 <!--
-  -  pfSense ruleset
+  -  pf ruleset
   -  Created by Wazuh, Inc.
   -  Copyright (C) 2015-2019, Wazuh Inc.
   -  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2.
   ID: 87700-87799
 -->
 
-<group name="pfsense,">
+<group name="pf,">
   <rule id="87700" level="0">
     <decoded_as>pf</decoded_as>
     <program_name>filterlog</program_name>
-    <description>pfSense firewall rules grouped.</description>
+    <description>pf firewall rules grouped.</description>
   </rule>
 
   <!-- We don't log firewall events, because they go
@@ -20,14 +20,14 @@
     <if_sid>87700</if_sid>
     <action>block</action>
     <options>no_log</options>
-    <description>pfSense firewall drop event.</description>
+    <description>pf firewall drop event.</description>
     <group>firewall_block,pci_dss_1.4,gpg13_4.12,hipaa_164.312.a.1,nist_800_53_SC.7,</group>
   </rule>
 
   <rule id="87702" level="10" frequency="18" timeframe="45" ignore="240">
     <if_matched_sid>87701</if_matched_sid>
     <same_source_ip />
-    <description>Multiple pfSense firewall blocks events from same source.</description>
+    <description>Multiple pf firewall blocks events from same source.</description>
     <group>multiple_blocks,pci_dss_1.4,pci_dss_10.6.1,gpg13_4.12,hipaa_164.312.a.1,hipaa_164.312.b,nist_800_53_SC.7,nist_800_53_AU.6,</group>
   </rule>
 </group>


### PR DESCRIPTION
The decoder and rules cover only pf which is the (p)acket (f)ilter for BSD systems in general.
When you want to monitor pf logs on a OpenBSD or NetBSD appliance it will pop up as a pfSense system which doesn't make much sense. 