### PR TITLE
[Rebase] Change level rule cisco ios [#337] (PR 4.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 
+## [v4.0]
+
+### Fixed
+- Changed Cisco IOS rules level.  ([#344](https://github.com/wazuh/wazuh-ruleset/pull/344))
+
 ## [v3.9.0]
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 ## [v4.0]
 
 ### Changed
-- Changed Cisco IOS rules level.  ([#337](https://github.com/wazuh/wazuh-ruleset/pull/337))
+- Changed Cisco IOS rules level.  ([#577](https://github.com/wazuh/wazuh-ruleset/pull/577))
 
 ## [v3.9.0]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 ## [v4.0]
 
 ### Fixed
-- Changed Cisco IOS rules level.  ([#344](https://github.com/wazuh/wazuh-ruleset/pull/344))
+- Changed Cisco IOS rules level.  ([#337](https://github.com/wazuh/wazuh-ruleset/pull/337))
 
 ## [v3.9.0]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ All notable changes to this project will be documented in this file.
 
 ## [v4.0]
 
-### Fixed
+### Changed
 - Changed Cisco IOS rules level.  ([#337](https://github.com/wazuh/wazuh-ruleset/pull/337))
 
 ## [v3.9.0]

--- a/rules/0075-cisco-ios_rules.xml
+++ b/rules/0075-cisco-ios_rules.xml
@@ -13,7 +13,7 @@
     <description>Grouping of Cisco IOS rules.</description>
   </rule>
 
-  <rule id="4710" level="9">
+  <rule id="4710" level="10">
     <if_sid>4700</if_sid>
     <id>-0-</id>
     <description>Cisco IOS emergency message.</description>
@@ -21,7 +21,7 @@
   </rule>
 
 
-  <rule id="4711" level="5">
+  <rule id="4711" level="7">
     <if_sid>4700</if_sid>
     <id>-1-</id>
     <description>Cisco IOS alert message.</description>
@@ -42,7 +42,7 @@
     <group>gpg13_3.5,</group>
   </rule>
 
-  <rule id="4714" level="4">
+  <rule id="4714" level="3">
     <if_sid>4700</if_sid>
     <id>-4-</id>
     <description>Cisco IOS warning message.</description>

--- a/tools/rules-testing/tests/cisco_ios.ini
+++ b/tools/rules-testing/tests/cisco_ios.ini
@@ -18,4 +18,11 @@ rule = 4100
 alert = 0
 decoder = cisco-ios
 
+[cisco ios: error message]
+log 1 pass = 00:00:46: %LINK-3-UPDOWN: Interface Port-channel1, changed state to up
+log 2 pass = 00:00:47: %LINK-3-UPDOWN: Interface GigabitEthernet0/2, changed state to up
+rule = 4713
+alert = 4
+decoder = cisco-ios
+
 


### PR DESCRIPTION
Hi team,

This is a rebase from PR [#337] to 4.0 to change level cisco ios rules level (rules/0075-cisco-ios_rules.xml) due to didn't fit properly the level of the log compared with Cisco's rating ( [here](https://www.cisco.com/c/en/us/td/docs/routers/access/wireless/software/guide/SysMsgLogging.html#wp1054485))