### PR TITLE
[Rebase] Fortigate Ruleset Update (PR #516 v4.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 ## [v4.0]
 
 ### Added
-- Added decoders for fortigate 5.6, 6.0 and 6.2 and an .ini to enable testing. ([#516](https://github.com/wazuh/wazuh-ruleset/pull/516))
+- Added decoders for fortigate 5.6, 6.0 and 6.2 and an .ini to enable testing. ([#578](https://github.com/wazuh/wazuh-ruleset/pull/578))
 
 ## [v3.9.0]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 ## [v4.0]
 
 ### Added
-- Added decoders for fortigate 5.6, 6.0 and 6.2 and an .ini to enable testing. ([#578](https://github.com/wazuh/wazuh-ruleset/pull/578))
+- Added decoders for Fortigate version 5.6, 6.0 and 6.2 ([#578](https://github.com/wazuh/wazuh-ruleset/pull/578))
 
 ## [v3.9.0]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 
+## [v4.0]
+
+### Added
+- Added decoders for fortigate 5.6, 6.0 and 6.2 and an .ini to enable testing. ([#516](https://github.com/wazuh/wazuh-ruleset/pull/516))
+
 ## [v3.9.0]
 
 ### Added

--- a/decoders/0100-fortigate_decoders.xml
+++ b/decoders/0100-fortigate_decoders.xml
@@ -33,11 +33,8 @@ Mar 24 12:19:43 date=2011-07-25 time=08: 19:42 devname=Name_of_Device device_id=
 
 <!--
 FortiOS 4.0 via syslog
-
 Feb 20 12:26:25 date=2011-02-20 time=12: 26:24 devname=Device_Name device_id=FGXXXX0000000001 log_id=9999999999 type=traffic subtype=other pri=notice status=deny vd="root" src=10.10.10.10 srcname=10.10.10.10 src_port=1111 dst=10.20.30.40 dstname=10.20.30.40 dst_port=2222 service=65535/tcp proto=6 app_type=N/A duration=0 rule=0 policyid=0 identidx=0 sent=0 rcvd=0 shaper_drop_sent=0 shaper_drop_rcvd=0 perip_drop=0 shaper_sent_name="N/A" shaper_rcvd_name="N/A" perip_name="N/A" vpn="N/A" src_int="Interface Name" dst_int="internal" SN=123456 app="N/A" app_cat="N/A" user="N/A" group="N/A" carrier_ep="N/A"
-
 Feb 19 22:00:07 date=2011-02-19 time=22: 00:07 devname=Device_Name device_id=FGXXXX1231231231 log_id=3213213213 type=traffic subtype=other pri=notice status=deny vd="root" src=10.10.10.1 srcname=10.10.10.1 src_port=1111 dst=10.9.8.7 dstname=10.9.8.7 dst_port=2222 service=65535/udp proto=17 app_type=N/A duration=0 rule=0 policyid=0 identidx=0 sent=0 rcvd=0 shaper_drop_sent=0 shaper_drop_rcvd=0 perip_drop=0 shaper_sent_name="N/A" shaper_rcvd_name="N/A" perip_name="N/A" vpn="N/A" src_int="wan1" dst_int="root" SN=333333 app="N/A" app_cat="N/A" user="N/A" group="N/A" carrier_ep="N/A"
-
 Feb 20 12:31:11 date=2011-02-20 time=12: 31:09 devname=Name_of_Device device_id=FGXXXX1000000000 log_id=8888888888 type=traffic subtype=other pri=notice status=accept vd="root" src=192.168.0.1 srcname=192.168.0.1 src_port=0 dst=192.168.254.254 dstname=192.168.254.254 dst_port=0 service=11/icmp proto=1 app_type=N/A duration=0 rule=0 policyid=0 identidx=0 sent=0 rcvd=0 shaper_drop_sent=0 shaper_drop_rcvd=0 shaper_sent_name="N/A" shaper_rcvd_name="N/A" perip_name="N/A" vpn="N/A" src_int="root" dst_int="N/A" SN=123412341234 app="N/A" app_cat="N/A" user="N/A" group="N/A" carrier_ep="N/A"
 -->
 <decoder name="fortigate-firewall-v4">
@@ -53,144 +50,1521 @@ Feb 20 12:31:11 date=2011-02-20 time=12: 31:09 devname=Name_of_Device device_id=
 </decoder>
 
 
+
+
+
+
 <!-- FortiOS 5.0 via syslog -->
-<decoder name="fortigate-firewall-v5">
-    <prematch>date=\S+ time=\.+ devname=\S+ devid=FG\w+ logid=\d+ </prematch>
-    <type>syslog</type>
-</decoder>
+
+
+<!-- Logs for Fortios 5.0, 5.4 & 5.6  -->
 
 <!--
 date=2016-06-15 time=09:41:35 devname=Device_Name devid=FGTXXXX9999999999 logid=9999999999 type=utm subtype=ips eventtype=signature level=alert vd="root" severity=info srcip=192.168.10.8 dstip=157.55.235.162 srcintf="internal2" dstintf="wan2" policyid=2 sessionid=1473454 action=dropped proto=6 service=tcp/20480 attack="HTTP.Unknown.Tunnelling" srcport=62216 dstport=80 direction=outgoing attackid=107347981 profile="default" ref="http://www.fortinet.com/ids/VID107347981" incidentserialno=1999871775 msg="http_decoder: HTTP.Unknown.Tunnelling,"
 -->
-<decoder name="fortigate-firewall-v5-utm-ips">
-    <parent>fortigate-firewall-v5</parent>
-    <prematch offset="after_parent">type=utm subtype=ips</prematch>
-    <regex offset="after_prematch">severity=(\S+) srcip=(\S+) dstip=(\S+) \.*action=(\S+) proto\.+srcport=(\d+) dstport=(\d+) \.*msg=(\.*)</regex>
-    <order>status,srcip,dstip,action,srcport,dstport,extra_data</order>
-</decoder>
 
 <!--
 Mar 22 19:21:00 10.10.10.10 date=2016-03-22 time=19:20:46 devname=Text devid=FGT3HD0000000000 logid=0000018000 type=anomaly subtype=anomaly level=alert vd="root" severity=critical srcip=10.10.10.35 dstip=10.10.10.84 srcintf="port2" sessionid=0 action=detected proto=6 service=tcp/36875 count=1903 attack="tcp_syn_flood" srcport=32835 dstport=2960 attackid=100663396 profile="DoS-policy1" ref="http://www.fortinet.com/ids/VID100663396" msg="anomaly: tcp_syn_flood, 2001 > threshold 2000, repeats 1903 times" crscore=50 crlevel=critical
-
 Mar 22 19:21:00 10.10.10.10 date=2016-03-22 time=19:20:46 devname=Text devid=FGT3HD0000000000 logid=0000018000 type=anomaly subtype=anomaly level=alert vd="root" severity=critical srcip=10.10.10.61 dstip=10.10.10.84 srcintf="port2" sessionid=0 action=dropped proto=6 service=NONE count=9 attack="IP.Bad.Header" attackid=127 profile="N/A" ref="http://www.fortinet.com/ids/VID127" msg="anomaly: IP.Bad.Header, repeats 9 times" crscore=50 crlevel=critical
 -->
-<decoder name="fortigate-firewall-v5-anomaly">
-    <parent>fortigate-firewall-v5</parent>
-    <prematch offset="after_parent">type=anomaly</prematch>
-    <regex offset="after_parent">severity=(\w+) srcip=(\S+) dstip=(\S+) srcintf=\S+ sessionid=\S+ action=(\w+) proto=\d+ service=(\S+) count=\d+ (attack)="(\.+)"</regex>
-    <order>status, srcip, dstip, action, protocol, id, extra_data</order>
-</decoder>
+
 
 <!--
 date=2016-06-15 time=11:44:46 devname=Device_Name devid=FGTXXXX9999999999 logid=9999999999 type=utm subtype=webfilter eventtype=urlfilter level=warning vd="root" urlfilteridx=3 urlfilterlist="default" policyid=2 sessionid=1563645 user="" srcip=1.2.3.11 srcport=52414 srcintf="internal2" dstip=1.5.5.92 dstport=443 dstintf="wan2" proto=6 service=HTTPS hostname="4-edge-chat.facebook.com" profile="default" action=blocked reqtype=referral url="/p?partition=-2&cb=lz1k&failure=5&sticky_token=274&sticky_pool=atn2c06_chat-proxy" sentbyte=932 rcvdbyte=0 direction=outgoing msg="URL was blocked because it is in the URL filter list" crscore=30 crlevel=high
-
-
 2016 Jun 16 00:00:00 OSSECSERVER->8.5.2.1 date=2016-06-15 time=23:57:11 devname=Device_Name devid=FGTXXXX9999999999 logid=9999999999 type=utm subtype=webfilter eventtype=urlfilter level=warning vd="root" urlfilteridx=3 urlfilterlist="default" policyid=8 sessionid=42895 user="" srcip=2.5.8.8 srcport=57629 srcintf="internal1" dstip=13.107.4.50 dstport=80 dstintf="wan1" proto=6 service=HTTP hostname="www.download.windowsupdate.com" profile="default" action=blocked reqtype=direct url="/msdownload/update/v3/static/trustedr/en/authrootstl.cab" sentbyte=217 rcvdbyte=0 direction=outgoing msg="URL was blocked because it is in the URL filter list" crscore=30 crlevel=high
 -->
-<decoder name="fortigate-firewall-v5-utm-webfilter">
-    <parent>fortigate-firewall-v5</parent>
-    <prematch offset="after_parent">type=utm subtype=webfilter</prematch>
-    <regex offset="after_parent">level=(\S+) \.+ user="(\.*)" srcip=(\S+) srcport=(\d+) \.+ dstip=(\S+) dstport=(\d+) \.+ hostname="(\.+)" \.+ action=(\w+)</regex>
-    <order>status,srcuser,srcip,srcport,dstip,dstport,url,action</order>
-</decoder>
+<!--
+2018 Apr 09 16:03:37 inwazuhmgr->172.24.0.253 date=2018-04-09 time=16:03:37 devname=BA-RSYS-FW devid=FG600C3912803212 logid="1059028704" type="utm" subtype="app-ctrl" eventtype="app-ctrl-all" level="information" vd="BA-EXORA" logtime=1523270017 appid=16009 srcip=172.24.42.175 dstip=111.221.29.254 srcport=55139 dstport=443 srcintf="port3" srcintfrole="wan" dstintf="port5" dstintfrole="undefined" proto=6 service="HTTPS" policyid=107 sessionid=3454887534 applist="block-high-risk" appcat="Update" app="MS.Windows.Update" action="pass" hostname="*.vortex-win.data.microsoft.com" incidentserialno=1405558813 url="/" msg="Update: MS.Windows.Update," apprisk="elevated" scertcname="*.vortex-win.data.microsoft.com"
+-->
+
 
 <!--
 date=2016-06-16 time=09:03:03 devname=Device_Name devid=FGTXXXX9999999999 logid=9999999999 type=event subtype=system level=information vd="root" logdesc="Object attribute configured" user="admin" ui="GUI(4.3.5.8)" action=Edit cfgtid=2162752 cfgpath="firewall.service.custom" cfgobj="Custom-TCP_10443" cfgattr="tcp-portrange[->10443]udp-portrange[->]sctp-portrange[->]" msg="Edit firewall.service.custom Custom-TCP_10443"
-
 date=2016-06-16 time=09:03:03 devname=Device_Name devid=FGTXXXX9999999999 logid=9999999999 type=event subtype=system level=information vd="root" logdesc="Object attribute configured" user="admin" ui="GUI(4.3.5.8)" action=Edit cfgtid=2162751 cfgpath="firewall.service.custom" cfgobj="Custom-TCP_10443" cfgattr="protocol[TCP/UDP/SCTP->TCP/UDP/SCTP]udp-portrange[->]sctp-portrange[->]" msg="Edit firewall.service.custom Custom-TCP_10443"
-
 date=2016-06-16 time=09:03:03 devname=Device_Name devid=FGTXXXX9999999999 logid=9999999999 type=event subtype=system level=information vd="root" logdesc="Object attribute configured" user="admin" ui="GUI(4.3.5.8)" action=Add cfgtid=2162750 cfgpath="firewall.service.custom" cfgobj="Custom-TCP_10443" cfgattr="" msg="Add firewall.service.custom Custom-TCP_10443"
-
 date=2016-06-16 time=08:41:14 devname=Mobipay_Firewall devid=FGTXXXX9999999999 logid=0100044546 type=event subtype=system level=information vd="root" logdesc="Attribute configured" user="a@b.com.na" ui="GUI(10.42.8.253)" action=Edit cfgtid=2162733 cfgpath="log.threat-weight" cfgattr="failed-connection[low->medium]" msg="Edit log.threat-weight "
-
 date=2016-06-16 time=08:48:28 devname=Device_Name devid=FGTXXXX9999999999 logid=0100032003 type=event subtype=system level=information vd="root" logdesc="Admin logout successful" sn=1466062693 user="a@b.com.na" ui=https(4.3.5.253) action=logout status=success duration=615 state="Config-Changed" reason=exit msg="Administrator a@b.com.na logged out from https(2.3.8.1)"
-
 date=2016-06-16 time=16:22:34 devname=Mobipay_Firewall devid=FGTXXXX9999999999 logid=0100032001 type=event subtype=system level=information vd="root" logdesc="Admin login successful" sn=1466090554 user="a@b.com.na" ui=https(10.42.8.253) action=login status=success reason=none profile="super_admin" msg="Administrator a@b.com.na logged in successfully from https(10.42.8.253)"
 -->
-<decoder name="fortigate-firewall-v5-event-system-information">
-    <parent>fortigate-firewall-v5</parent>
-    <prematch offset="after_parent">type=event subtype=system level=information</prematch>
-    <regex offset="after_parent">user="(\S+)" ui=\p*\w+\((\S+)\)\p* action=(\S+) </regex>
-    <order>srcuser,srcip,action</order>
-</decoder>
 
-<decoder name="fortigate-firewall-v5-event-system-information">
-    <parent>fortigate-firewall-v5</parent>
-    <regex offset="after_regex">cfgtid=(\d+) \.*cfgattr=(\.*) msg=(\.*)</regex>
-    <order>id,url,extra_data</order>
-</decoder>
-
-<decoder name="fortigate-firewall-v5-event-system-information">
-    <parent>fortigate-firewall-v5</parent>
-    <regex offset="after_regex">status=(\S+) \.*msg=(\.*)</regex>
-    <order>status,extra_data</order>
-</decoder>
 
 <!--
 date=2016-06-14 time=12:22:01 devname=Device_Name devid=FGTXXXX9999999999 logid=9999999999 type=event subtype=system level=alert vd="root" logdesc="Admin login failed" sn=0 user="gfedhf" ui=https(4.3.5.253) action=login status=failed reason="name_invalid" msg="Administrator gfedhf login failed from https(4.3.5.253) because of invalid user name"
-
 date=2016-06-17 time=02:37:41 devname=Mobipay_Firewall devid=FGTXXXX9999999999 logid=0100032002 type=event subtype=system level=alert vd="root" logdesc="Admin login failed" sn=0 user="root" ui=ssh(222.186.130.227) action=login status=failed reason="name_invalid" msg="Administrator root login failed from ssh(222.186.130.227) because of invalid user name"
 -->
-<decoder name="fortigate-firewall-v5-event-system-alert-fields1">
-    <parent>fortigate-firewall-v5</parent>
-    <prematch offset="after_parent">type=event subtype=system level=alert vd="\S+" logdesc="\.+" sn=\S+ </prematch>
-    <regex offset="after_prematch">user="(\S+)" ui=\w+\((\S+)\) action=(\S+) status=(\S+) reason="\.+" msg="(\.+)"$</regex>
-    <order>user,srcip,action,status,extra_data</order>
-</decoder>
 
-<!--
-date=2016-06-14 time=10:47:23 devname=Device_Name devid=FGTXXXX9999999999 logid=9999999999 type=event subtype=system level=alert vd="root" logdesc="Configuration changed" user="admin" ui=https(105.232.255.15) msg="Configuration is changed in the admin session"
-
-date=2016-06-16 time=08:48:28 devname=Mobipay_Firewall devid=FGTXXXX9999999999 logid=0100032400 type=event subtype=system level=alert vd="root" logdesc="Configuration changed" user="a@b.com.na" ui=https(10.42.8.253) msg="Configuration is changed in the admin session"
--->
-<decoder name="fortigate-firewall-v5-event-system-alert-fields2">
-    <parent>fortigate-firewall-v5</parent>
-    <prematch offset="after_parent">type=event subtype=system level=alert vd="\S+" logdesc="\.+" user=</prematch>
-    <regex offset="after_prematch">"(\.+)" ui=\w+\((\S+)\) msg="(\.+)"</regex>
-    <order>user,srcip,extra_data</order>
-</decoder>
-
-<!--
-date=2016-06-14 time=12:22:03 devname=Device_Name devid=FGTXXXX9999999999 logid=9999999999 type=event subtype=system level=alert vd="root" logdesc="Admin login disabled" ui=4.3.5.253 action=login status=failed reason=exceed_limit msg="Login disabled from IP 4.3.5.253 for 60 seconds because of 3 bad attempts"
--->
-<decoder name="fortigate-firewall-v5-event-system-alert-fields3">
-    <parent>fortigate-firewall-v5</parent>
-    <prematch offset="after_parent">type=event subtype=system level=alert vd="\S+" logdesc="\.+" ui=</prematch>
-    <regex offset="after_prematch">(\S+) action=(\S+) status=(\S+) reason=\S+ msg="(\.+)"</regex>
-    <order>srcip,action,status,extra_data</order>
-</decoder>
 
 <!--
 date=2016-06-15 time=10:42:31 devname=Device_Name devid=FGTXXXX9999999999 logid=9999999999 type=event subtype=vpn level=error vd="root" logdesc="IPsec DPD failed" msg="IPsec DPD failure" action=dpd remip=1.2.3.4 locip=4.3.2.1 remport=500 locport=500 outintf="wan1" cookies="fsdagfdfgfdgfdg/qwerweafasfefsd" user="N/A" group="N/A" xauthuser="N/A" xauthgroup="N/A" assignip=N/A vpntunnel="BW" status=dpd_failure
-
 date=2016-06-15 time=21:35:09 devname=Device_Name devid=FGTXXXX9999999999 logid=0101039426 type=event subtype=vpn level=alert vd="root" logdesc="SSL VPN login fail" action="ssl-login-fail" tunneltype="ssl-web" tunnelid=0 remip=2.4.6.8 tunnelip=(null) user="my_user_name" group="N/A" dst_host="N/A" reason="sslvpn_login_unknown_user" msg="SSL user failed to logged in"
-
 date=2016-06-16 time=08:47:00 devname=Device_Name devid=FGTXXXX9999999999 logid=0101039947 type=event subtype=vpn level=information vd="root" logdesc="SSL VPN tunnel up" action="tunnel-up" tunneltype="ssl-tunnel" tunnelid=1050355638 remip=9.8.7.7 tunnelip=1.2.4.6 user="my_user_name" group="SSL_VPN" dst_host="N/A" reason="N/A" msg="SSL tunnel established"
-
 date=2016-06-16 time=08:49:26 devname=Device_Name devid=FGTXXXX9999999999 logid=0101039948 type=event subtype=vpn level=information vd="root" logdesc="SSL VPN tunnel down" action="tunnel-down" tunneltype="ssl-tunnel" tunnelid=1050355638 remip=5.7.8.9 tunnelip=8.4.2.1 user="my_user_name" group="SSL_VPN" dst_host="N/A" reason="N/A" duration=147 sentbyte=2284 rcvdbyte=2630 msg="SSL tunnel shutdown"
--->
 <decoder name="fortigate-firewall-v5-event-vpn-fields1">
     <parent>fortigate-firewall-v5</parent>
     <prematch offset="after_parent">type=event subtype=vpn level=\S+ vd="\.+" logdesc="\.+" msg="\.+" action=</prematch>
     <regex>logdesc="(\.+)" msg=\.+ action=(\.*) remip=(\S+) locip=(\S+) \.+ status=(\S+)</regex>
     <order>extra_data,action,dstip,srcip,status</order>
 </decoder>
+-->
 
-<decoder name="fortigate-firewall-v5-event-vpn-fields2">
-    <parent>fortigate-firewall-v5</parent>
-    <prematch offset="after_parent">type=event subtype=vpn level=\S+ vd="\.+" logdesc="\.+" action=</prematch>
-    <regex>logdesc="(\.+)" action="(\.*)" tunneltype="(\.*)" tunnelid=\S+ remip=(\S+) tunnelip=(\S+) user="(\.+)" group=</regex>
-    <order>extra_data,action,status,dstip,srcip,srcuser</order>
-</decoder>
 
 <!--
 date=2016-06-16 time=10:19:23 devname=Device_Name devid=FGTXXXX9999999999 logid=0000000013 type=traffic subtype=forward level=notice vd=root srcip=7.3.8.5 srcport=57727 srcintf="internal1" dstip=7.8.9.81 dstport=80 dstintf="wan1" poluuid=d6217c58-8c42-51e5-c3a6-c7766895cbfd sessionid=181876 proto=6 action=deny policyid=8 dstcountry="Reserved" srccountry="Reserved" trandisp=snat transip=160.242.8.82 transport=57727 service="HTTP" appid=107347980 app="Proxy.HTTP" appcat="Proxy" apprisk=critical applist="default" appact=drop-session duration=30 sentbyte=0 rcvdbyte=3042 sentpkt=0 utmaction=block countapp=1 crscore=10 craction=1048576
-
 date=2016-06-16 time=10:49:08 devname=Device_Name devid=FGTXXXX9999999999 logid=0000000013 type=traffic subtype=forward level=notice vd=root srcip=4.3.5.161 srcport=51082 srcintf="internal1" dstip=54.192.197.185 dstport=80 dstintf="wan1" poluuid=d6217c58-8c42-51e5-c3a6-c7766895cbfd sessionid=199618 proto=6 action=deny policyid=8 dstcountry="United States" srccountry="Reserved" trandisp=snat transip=160.242.8.82 transport=51082 service="HTTP" appid=6 app="BitTorrent" appcat="P2P" apprisk=high applist="default" appact=drop-session duration=3 sentbyte=60 rcvdbyte=3050 sentpkt=1 utmaction=block countapp=1 crscore=5 craction=1048576
 -->
-<decoder name="fortigate-firewall-v5-traffic">
-    <parent>fortigate-firewall-v5</parent>
-    <prematch offset="after_parent">type=traffic</prematch>
-    <regex>srcip=(\S+) srcport=(\d+) \.+ dstip=(\S+) dstport=(\d+) \.+ appcat="(\.+)" apprisk=(\w+) applist=</regex>
-    <order>srcip,srcport,dstip,dstport,protocol,status</order>
+
+<!--
+date=2018-05-31 time=08:58:56 devname="BA-RSYS-FW" devid="FG600C3912803212" logid="0211008192" type="utm" subtype="virus" eventtype="infected" level="warning" vd="BA-EXORA" eventtime=1527737336 msg="File is infected." action="blocked" service="HTTP" sessionid=377413095 srcip=172.24.12.52 dstip=164.100.80.203 srcport=64982 dstport=80 srcintf="port5" srcintfrole="undefined" dstintf="port3" dstintfrole="wan" policyid=108 proto=6 direction="incoming" filename="FrontPageImgHandler.ashx" quarskip="File-was-not-quarantined." virus="Malware_Generic.P0" dtype="Virus" ref="http://www.fortinet.com/ve?vn=Malware_Generic.P0" virusid=7024603 url="http://www.karsec.gov.in/FrontPageImgHandler.ashx?id=12" profile="Web-Browsing" agent="Chrome/66.0.3359.181" analyticscksum="a9165dbae34e6e2952270536e95a2bb154dff0cfcdf41315f0796ee14b36123b" analyticssubmit="false" crscore=50 crlevel="critical"
+-->
+
+<decoder name="fortigate-firewall-v5">
+    <prematch>date=\S+\.+time=\.+devname=\S+\.+devid=\p*FG\S+\.+logid=</prematch>
+    <type>syslog</type>
+</decoder>
+
+
+
+<decoder name="fortigate-firewall-v5">
+  <parent>fortigate-firewall-v5</parent>
+  <regex>forwardedfor="(\.*)"|forwardedfor=(\.*)\s|forwardedfor=(\.*)$</regex>
+  <order>forwardedfor</order>
+</decoder>
+
+
+<decoder name="fortigate-firewall-v5">
+  <parent>fortigate-firewall-v5</parent>
+  <regex>action="(\.*)"|action=(\.*)\s|action=(\.*)$</regex>
+  <order>action</order>
+</decoder>
+
+<decoder name="fortigate-firewall-v5">
+  <parent>fortigate-firewall-v5</parent>
+  <regex>agent="(\.*)"|agent=(\.*)\s|agent=(\.*)$</regex>
+  <order>agent</order>
+</decoder>
+
+<decoder name="fortigate-firewall-v5">
+  <parent>fortigate-firewall-v5</parent>
+  <regex>analyticscksum="(\.*)"|analyticscksum=(\.*)\s|analyticscksum=(\.*)$</regex>
+  <order>analyticscksum</order>
+</decoder>
+
+<decoder name="fortigate-firewall-v5">
+  <parent>fortigate-firewall-v5</parent>
+  <regex>analyticssubmit="(\.*)"|analyticssubmit=(\.*)\s|analyticssubmit=(\.*)$</regex>
+  <order>analyticssubmit</order>
+</decoder>
+
+<decoder name="fortigate-firewall-v5">
+  <parent>fortigate-firewall-v5</parent>
+  <regex>app="(\.*)"|app=(\.*)\s|app=(\.*)$</regex>
+  <order>app</order>
+</decoder>
+
+<decoder name="fortigate-firewall-v5">
+  <parent>fortigate-firewall-v5</parent>
+  <regex>appact="(\.*)"|appact=(\.*)\s|appact=(\.*)$</regex>
+  <order>appact</order>
+</decoder>
+
+<decoder name="fortigate-firewall-v5">
+  <parent>fortigate-firewall-v5</parent>
+  <regex>appcat="(\.*)"|appcat=(\.*)\s|appcat=(\.*)$</regex>
+  <order>appcat</order>
+</decoder>
+
+<decoder name="fortigate-firewall-v5">
+  <parent>fortigate-firewall-v5</parent>
+  <regex>appid="(\.*)"|appid=(\.*)\s|appid=(\.*)$</regex>
+  <order>appid</order>
+</decoder>
+
+<decoder name="fortigate-firewall-v5">
+  <parent>fortigate-firewall-v5</parent>
+  <regex>applist="(\.*)"|applist=(\.*)\s|applist=(\.*)$</regex>
+  <order>applist</order>
+</decoder>
+
+<decoder name="fortigate-firewall-v5">
+  <parent>fortigate-firewall-v5</parent>
+  <regex>apprisk="(\.*)"|apprisk=(\.*)\s|apprisk=(\.*)$</regex>
+  <order>apprisk</order>
+</decoder>
+
+<decoder name="fortigate-firewall-v5">
+  <parent>fortigate-firewall-v5</parent>
+  <regex>assignip="(\.*)"|assignip=(\.*)\s|assignip=(\.*)$</regex>
+  <order>assignip</order>
+</decoder>
+
+<decoder name="fortigate-firewall-v5">
+  <parent>fortigate-firewall-v5</parent>
+  <regex>attack="(\.*)"|attack=(\.*)\s|attack=(\.*)$</regex>
+  <order>attack</order>
+</decoder>
+
+<decoder name="fortigate-firewall-v5">
+  <parent>fortigate-firewall-v5</parent>
+  <regex>attackid="(\.*)"|attackid=(\.*)\s|attackid=(\.*)$</regex>
+  <order>attackid</order>
+</decoder>
+
+
+<decoder name="fortigate-firewall-v5">
+  <parent>fortigate-firewall-v5</parent>
+  <regex>cfgattr="(\.*)"|cfgattr=(\.*)\s|cfgattr=(\.*)$</regex>
+  <order>cfgattr</order>
+</decoder>
+
+<decoder name="fortigate-firewall-v5">
+  <parent>fortigate-firewall-v5</parent>
+  <regex>cfgobj="(\.*)"|cfgobj=(\.*)\s|cfgobj=(\.*)$</regex>
+  <order>cfgobj</order>
+</decoder>
+
+<decoder name="fortigate-firewall-v5">
+  <parent>fortigate-firewall-v5</parent>
+  <regex>cfgpath="(\.*)"|cfgpath=(\.*)\s|cfgpath=(\.*)$</regex>
+  <order>cfgpath</order>
+</decoder>
+
+<decoder name="fortigate-firewall-v5">
+  <parent>fortigate-firewall-v5</parent>
+  <regex>cfgtid="(\.*)"|cfgtid=(\.*)\s|cfgtid=(\.*)$</regex>
+  <order>cfgtid</order>
+</decoder>
+
+<decoder name="fortigate-firewall-v5">
+  <parent>fortigate-firewall-v5</parent>
+  <regex>cookies="(\.*)"|cookies=(\.*)\s|cookies=(\.*)$</regex>
+  <order>cookies</order>
+</decoder>
+
+<decoder name="fortigate-firewall-v5">
+  <parent>fortigate-firewall-v5</parent>
+  <regex>count="(\.*)"|count=(\.*)\s|count=(\.*)$</regex>
+  <order>count</order>
+</decoder>
+
+<decoder name="fortigate-firewall-v5">
+  <parent>fortigate-firewall-v5</parent>
+  <regex>countapp="(\.*)"|countapp=(\.*)\s|countapp=(\.*)$</regex>
+  <order>countapp</order>
+</decoder>
+
+<decoder name="fortigate-firewall-v5">
+  <parent>fortigate-firewall-v5</parent>
+  <regex>craction="(\.*)"|craction=(\.*)\s|craction=(\.*)$</regex>
+  <order>craction</order>
+</decoder>
+
+<decoder name="fortigate-firewall-v5">
+  <parent>fortigate-firewall-v5</parent>
+  <regex>crlevel="(\.*)"|crlevel=(\.*)\s|crlevel=(\.*)$</regex>
+  <order>crlevel</order>
+</decoder>
+
+<decoder name="fortigate-firewall-v5">
+  <parent>fortigate-firewall-v5</parent>
+  <regex>crscore="(\.*)"|crscore=(\.*)\s|crscore=(\.*)$</regex>
+  <order>crscore</order>
+</decoder>
+
+<decoder name="fortigate-firewall-v5">
+  <parent>fortigate-firewall-v5</parent>
+  <regex>devid="(\.*)"|devid=(\.*)\s|devid=(\.*)$</regex>
+  <order>devid</order>
+</decoder>
+
+<decoder name="fortigate-firewall-v5">
+  <parent>fortigate-firewall-v5</parent>
+  <regex>devname="(\.*)"|devname=(\.*)\s|devname=(\.*)$</regex>
+  <order>devname</order>
+</decoder>
+
+<decoder name="fortigate-firewall-v5">
+  <parent>fortigate-firewall-v5</parent>
+  <regex>direction="(\.*)"|direction=(\.*)\s|direction=(\.*)$</regex>
+  <order>direction</order>
+</decoder>
+
+<decoder name="fortigate-firewall-v5">
+  <parent>fortigate-firewall-v5</parent>
+  <regex>dst_host="(\.*)"|dst_host=(\.*)\s|dst_host=(\.*)$</regex>
+  <order>dst_host</order>
+</decoder>
+
+<decoder name="fortigate-firewall-v5">
+  <parent>fortigate-firewall-v5</parent>
+  <regex>dstcountry="(\.*)"|dstcountry=(\.*)\s|dstcountry=(\.*)$</regex>
+  <order>dstcountry</order>
+</decoder>
+
+<decoder name="fortigate-firewall-v5">
+  <parent>fortigate-firewall-v5</parent>
+  <regex>dstintf="(\.*)"|dstintf=(\.*)\s|dstintf=(\.*)$</regex>
+  <order>dstintf</order>
+</decoder>
+
+<decoder name="fortigate-firewall-v5">
+  <parent>fortigate-firewall-v5</parent>
+  <regex>dstintfrole="(\.*)"|dstintfrole=(\.*)\s|dstintfrole=(\.*)$</regex>
+  <order>dstintfrole</order>
+</decoder>
+
+<decoder name="fortigate-firewall-v5">
+  <parent>fortigate-firewall-v5</parent>
+  <regex>dstip="(\.*)"|dstip=(\.*)\s|dstip=(\.*)$</regex>
+  <order>dstip</order>
+</decoder>
+
+<decoder name="fortigate-firewall-v5">
+  <parent>fortigate-firewall-v5</parent>
+  <regex>dstport="(\.*)"|dstport=(\.*)\s|dstport=(\.*)$</regex>
+  <order>dstport</order>
+</decoder>
+
+<decoder name="fortigate-firewall-v5">
+  <parent>fortigate-firewall-v5</parent>
+  <regex>dtype="(\.*)"|dtype=(\.*)\s|dtype=(\.*)$</regex>
+  <order>dtype</order>
+</decoder>
+
+<decoder name="fortigate-firewall-v5">
+  <parent>fortigate-firewall-v5</parent>
+  <regex>duration="(\.*)"|duration=(\.*)\s|duration=(\.*)$</regex>
+  <order>duration</order>
+</decoder>
+
+<decoder name="fortigate-firewall-v5">
+  <parent>fortigate-firewall-v5</parent>
+  <regex>eventtime="(\.*)"|eventtime=(\.*)\s|eventtime=(\.*)$</regex>
+  <order>eventtime</order>
+</decoder>
+
+<decoder name="fortigate-firewall-v5">
+  <parent>fortigate-firewall-v5</parent>
+  <regex>eventtype="(\.*)"|eventtype=(\.*)\s|eventtype=(\.*)$</regex>
+  <order>eventtype</order>
+</decoder>
+
+<decoder name="fortigate-firewall-v5">
+  <parent>fortigate-firewall-v5</parent>
+  <regex>filename="(\.*)"|filename=(\.*)\s|filename=(\.*)$</regex>
+  <order>filename</order>
+</decoder>
+
+<decoder name="fortigate-firewall-v5">
+  <parent>fortigate-firewall-v5</parent>
+  <regex>group="(\.*)"|group=(\.*)\s|group=(\.*)$</regex>
+  <order>group</order>
+</decoder>
+
+<decoder name="fortigate-firewall-v5">
+  <parent>fortigate-firewall-v5</parent>
+  <regex>hostname="(\.*)"|hostname=(\.*)\s|hostname=(\.*)$</regex>
+  <order>hostname</order>
+</decoder>
+
+<decoder name="fortigate-firewall-v5">
+  <parent>fortigate-firewall-v5</parent>
+  <regex>incidentserialno="(\.*)"|incidentserialno=(\.*)\s|incidentserialno=(\.*)$</regex>
+  <order>incidentserialno</order>
+</decoder>
+
+
+
+<decoder name="fortigate-firewall-v5">
+  <parent>fortigate-firewall-v5</parent>
+  <regex>level="(\.*)"|level=(\.*)\s|level=(\.*)$</regex>
+  <order>level</order>
+</decoder>
+
+<decoder name="fortigate-firewall-v5">
+  <parent>fortigate-firewall-v5</parent>
+  <regex>locip="(\.*)"|locip=(\.*)\s|locip=(\.*)$</regex>
+  <order>locip</order>
+</decoder>
+
+<decoder name="fortigate-firewall-v5">
+  <parent>fortigate-firewall-v5</parent>
+  <regex>locport="(\.*)"|locport=(\.*)\s|locport=(\.*)$</regex>
+  <order>locport</order>
+</decoder>
+
+<decoder name="fortigate-firewall-v5">
+  <parent>fortigate-firewall-v5</parent>
+  <regex>logdesc="(\.*)"|logdesc=(\.*)\s|logdesc=(\.*)$</regex>
+  <order>logdesc</order>
+</decoder>
+
+<decoder name="fortigate-firewall-v5">
+  <parent>fortigate-firewall-v5</parent>
+  <regex>logid="(\.*)"|logid=(\.*)\s|logid=(\.*)$</regex>
+  <order>logid</order>
+</decoder>
+
+<decoder name="fortigate-firewall-v5">
+  <parent>fortigate-firewall-v5</parent>
+  <regex>sn="(\.*)"|sn=(\.*)\s|sn=(\.*)$</regex>
+  <order>sn</order>
+</decoder>
+
+<decoder name="fortigate-firewall-v5">
+  <parent>fortigate-firewall-v5</parent>
+  <regex>logtime="(\.*)"|logtime=(\.*)\s|logtime=(\.*)$</regex>
+  <order>logtime</order>
+</decoder>
+
+<decoder name="fortigate-firewall-v5">
+  <parent>fortigate-firewall-v5</parent>
+  <regex>msg="(\.*)"|msg=(\.*)\s|msg=(\.*)$</regex>
+  <order>msg</order>
+</decoder>
+
+<decoder name="fortigate-firewall-v5">
+  <parent>fortigate-firewall-v5</parent>
+  <regex>outintf="(\.*)"|outintf=(\.*)\s|outintf=(\.*)$</regex>
+  <order>outintf</order>
+</decoder>
+
+<decoder name="fortigate-firewall-v5">
+  <parent>fortigate-firewall-v5</parent>
+  <regex>policyid="(\.*)"|policyid=(\.*)\s|policyid=(\.*)$</regex>
+  <order>policyid</order>
+</decoder>
+
+<decoder name="fortigate-firewall-v5">
+  <parent>fortigate-firewall-v5</parent>
+  <regex>poluuid="(\.*)"|poluuid=(\.*)\s|poluuid=(\.*)$</regex>
+  <order>poluuid</order>
+</decoder>
+
+<decoder name="fortigate-firewall-v5">
+  <parent>fortigate-firewall-v5</parent>
+  <regex>profile="(\.*)"|profile=(\.*)\s|profile=(\.*)$</regex>
+  <order>profile</order>
+</decoder>
+
+<decoder name="fortigate-firewall-v5">
+  <parent>fortigate-firewall-v5</parent>
+  <regex>proto="(\.*)"|proto=(\.*)\s|proto=(\.*)$</regex>
+  <order>proto</order>
+</decoder>
+
+<decoder name="fortigate-firewall-v5">
+  <parent>fortigate-firewall-v5</parent>
+  <regex>quarskip="(\.*)"|quarskip=(\.*)\s|quarskip=(\.*)$</regex>
+  <order>quarskip</order>
+</decoder>
+
+<decoder name="fortigate-firewall-v5">
+  <parent>fortigate-firewall-v5</parent>
+  <regex>rcvdbyte="(\.*)"|rcvdbyte=(\.*)\s|rcvdbyte=(\.*)$</regex>
+  <order>rcvdbyte</order>
+</decoder>
+
+<decoder name="fortigate-firewall-v5">
+  <parent>fortigate-firewall-v5</parent>
+  <regex>reason="(\.*)"|reason=(\.*)\s|reason=(\.*)$</regex>
+  <order>reason</order>
+</decoder>
+
+<decoder name="fortigate-firewall-v5">
+  <parent>fortigate-firewall-v5</parent>
+  <regex>ref="(\.*)"|ref=(\.*)\s|ref=(\.*)$</regex>
+  <order>ref</order>
+</decoder>
+
+<decoder name="fortigate-firewall-v5">
+  <parent>fortigate-firewall-v5</parent>
+  <regex>remip="(\.*)"|remip=(\.*)\s|remip=(\.*)$</regex>
+  <order>remip</order>
+</decoder>
+
+<decoder name="fortigate-firewall-v5">
+  <parent>fortigate-firewall-v5</parent>
+  <regex>remport="(\.*)"|remport=(\.*)\s|remport=(\.*)$</regex>
+  <order>remport</order>
+</decoder>
+
+<decoder name="fortigate-firewall-v5">
+  <parent>fortigate-firewall-v5</parent>
+  <regex>reqtype="(\.*)"|reqtype=(\.*)\s|reqtype=(\.*)$</regex>
+  <order>reqtype</order>
+</decoder>
+
+<decoder name="fortigate-firewall-v5">
+  <parent>fortigate-firewall-v5</parent>
+  <regex>scertcname="(\.*)"|scertcname=(\.*)\s|scertcname=(\.*)$</regex>
+  <order>scertcname</order>
+</decoder>
+
+<decoder name="fortigate-firewall-v5">
+  <parent>fortigate-firewall-v5</parent>
+  <regex>sentbyte="(\.*)"|sentbyte=(\.*)\s|sentbyte=(\.*)$</regex>
+  <order>sentbyte</order>
+</decoder>
+
+<decoder name="fortigate-firewall-v5">
+  <parent>fortigate-firewall-v5</parent>
+  <regex>sentpkt="(\.*)"|sentpkt=(\.*)\s|sentpkt=(\.*)$</regex>
+  <order>sentpkt</order>
+</decoder>
+
+<decoder name="fortigate-firewall-v5">
+  <parent>fortigate-firewall-v5</parent>
+  <regex>service="(\.*)"|service=(\.*)\s|service=(\.*)$</regex>
+  <order>service</order>
+</decoder>
+
+<decoder name="fortigate-firewall-v5">
+  <parent>fortigate-firewall-v5</parent>
+  <regex>sessionid="(\.*)"|sessionid=(\.*)\s|sessionid=(\.*)$</regex>
+  <order>sessionid</order>
+</decoder>
+
+<decoder name="fortigate-firewall-v5">
+  <parent>fortigate-firewall-v5</parent>
+  <regex>severity="(\.*)"|severity=(\.*)\s|severity=(\.*)$</regex>
+  <order>severity</order>
+</decoder>
+
+<decoder name="fortigate-firewall-v5">
+  <parent>fortigate-firewall-v5</parent>
+  <regex>srccountry="(\.*)"|srccountry=(\.*)\s|srccountry=(\.*)$</regex>
+  <order>srccountry</order>
+</decoder>
+
+<decoder name="fortigate-firewall-v5">
+  <parent>fortigate-firewall-v5</parent>
+  <regex>srcintf="(\.*)"|srcintf=(\.*)\s|srcintf=(\.*)$</regex>
+  <order>srcintf</order>
+</decoder>
+
+<decoder name="fortigate-firewall-v5">
+  <parent>fortigate-firewall-v5</parent>
+  <regex>srcintfrole="(\.*)"|srcintfrole=(\.*)\s|srcintfrole=(\.*)$</regex>
+  <order>srcintfrole</order>
+</decoder>
+
+<decoder name="fortigate-firewall-v5">
+  <parent>fortigate-firewall-v5</parent>
+  <regex>srcip="(\.*)"|srcip=(\.*)\s|srcip=(\.*)$</regex>
+  <order>srcip</order>
+</decoder>
+
+<decoder name="fortigate-firewall-v5">
+  <parent>fortigate-firewall-v5</parent>
+  <regex>srcport="(\.*)"|srcport=(\.*)\s|srcport=(\.*)$</regex>
+  <order>srcport</order>
+</decoder>
+
+<decoder name="fortigate-firewall-v5">
+  <parent>fortigate-firewall-v5</parent>
+  <regex>state="(\.*)"|state=(\.*)\s|state=(\.*)$</regex>
+  <order>state</order>
+</decoder>
+
+<decoder name="fortigate-firewall-v5">
+  <parent>fortigate-firewall-v5</parent>
+  <regex>status="(\.*)"|status=(\.*)\s|status=(\.*)$</regex>
+  <order>status</order>
+</decoder>
+
+<decoder name="fortigate-firewall-v5">
+  <parent>fortigate-firewall-v5</parent>
+  <regex>subtype="(\.*)"|subtype=(\.*)\s|subtype=(\.*)$</regex>
+  <order>subtype</order>
+</decoder>
+
+<decoder name="fortigate-firewall-v5">
+  <parent>fortigate-firewall-v5</parent>
+  <regex>time="(\.*)"|time=(\.*)\s|time=(\.*)$</regex>
+  <order>time</order>
+</decoder>
+
+<decoder name="fortigate-firewall-v5">
+  <parent>fortigate-firewall-v5</parent>
+  <regex>trandisp="(\.*)"|trandisp=(\.*)\s|trandisp=(\.*)$</regex>
+  <order>trandisp</order>
+</decoder>
+
+<decoder name="fortigate-firewall-v5">
+  <parent>fortigate-firewall-v5</parent>
+  <regex>transip="(\.*)"|transip=(\.*)\s|transip=(\.*)$</regex>
+  <order>transip</order>
+</decoder>
+
+<decoder name="fortigate-firewall-v5">
+  <parent>fortigate-firewall-v5</parent>
+  <regex>transport="(\.*)"|transport=(\.*)\s|transport=(\.*)$</regex>
+  <order>transport</order>
+</decoder>
+
+<decoder name="fortigate-firewall-v5">
+  <parent>fortigate-firewall-v5</parent>
+  <regex>tunnelid="(\.*)"|tunnelid=(\.*)\s|tunnelid=(\.*)$</regex>
+  <order>tunnelid</order>
+</decoder>
+
+<decoder name="fortigate-firewall-v5">
+  <parent>fortigate-firewall-v5</parent>
+  <regex>tunnelip="(\.*)"|tunnelip=(\.*)\s|tunnelip=(\.*)$</regex>
+  <order>tunnelip</order>
+</decoder>
+
+<decoder name="fortigate-firewall-v5">
+  <parent>fortigate-firewall-v5</parent>
+  <regex>tunneltype="(\.*)"|tunneltype=(\.*)\s|tunneltype=(\.*)$</regex>
+  <order>tunneltype</order>
+</decoder>
+
+<decoder name="fortigate-firewall-v5">
+  <parent>fortigate-firewall-v5</parent>
+  <regex>type="(\.*)"|type=(\.*)\s|type=(\.*)$</regex>
+  <order>type</order>
+</decoder>
+
+<decoder name="fortigate-firewall-v5">
+  <parent>fortigate-firewall-v5</parent>
+  <regex>ui="(\.*)"|ui=(\.*)\s|ui=(\.*)$</regex>
+  <order>ui</order>
+</decoder>
+
+<decoder name="fortigate-firewall-v5">
+  <parent>fortigate-firewall-v5</parent>
+  <regex>url="(\.*)"|url=(\.*)\s|url=(\.*)$</regex>
+  <order>url</order>
+</decoder>
+
+<decoder name="fortigate-firewall-v5">
+  <parent>fortigate-firewall-v5</parent>
+  <regex>urlfilteridx="(\.*)"|urlfilteridx=(\.*)\s|urlfilteridx=(\.*)$</regex>
+  <order>urlfilteridx</order>
+</decoder>
+
+<decoder name="fortigate-firewall-v5">
+  <parent>fortigate-firewall-v5</parent>
+  <regex>urlfilterlist="(\.*)"|urlfilterlist=(\.*)\s|urlfilterlist=(\.*)$</regex>
+  <order>urlfilterlist</order>
+</decoder>
+
+<decoder name="fortigate-firewall-v5">
+  <parent>fortigate-firewall-v5</parent>
+  <regex>user="(\.*)"|user=(\.*)\s|user=(\.*)$</regex>
+  <order>user</order>
+</decoder>
+
+<decoder name="fortigate-firewall-v5">
+  <parent>fortigate-firewall-v5</parent>
+  <regex>utmaction="(\.*)"|utmaction=(\.*)\s|utmaction=(\.*)$</regex>
+  <order>utmaction</order>
+</decoder>
+
+<decoder name="fortigate-firewall-v5">
+  <parent>fortigate-firewall-v5</parent>
+  <regex>vd="(\.*)"|vd=(\.*)\s|vd=(\.*)$</regex>
+  <order>vd</order>
+</decoder>
+
+<decoder name="fortigate-firewall-v5">
+  <parent>fortigate-firewall-v5</parent>
+  <regex>virus="(\.*)"|virus=(\.*)\s|virus=(\.*)$</regex>
+  <order>virus</order>
+</decoder>
+
+<decoder name="fortigate-firewall-v5">
+  <parent>fortigate-firewall-v5</parent>
+  <regex>virusid="(\.*)"|virusid=(\.*)\s|virusid=(\.*)$</regex>
+  <order>virusid</order>
+</decoder>
+
+<decoder name="fortigate-firewall-v5">
+  <parent>fortigate-firewall-v5</parent>
+  <regex>vpntunnel="(\.*)"|vpntunnel=(\.*)\s|vpntunnel=(\.*)$</regex>
+  <order>vpntunnel</order>
+</decoder>
+
+<decoder name="fortigate-firewall-v5">
+  <parent>fortigate-firewall-v5</parent>
+  <regex>xauthgroup="(\.*)"|xauthgroup=(\.*)\s|xauthgroup=(\.*)$</regex>
+  <order>xauthgroup</order>
+</decoder>
+
+<decoder name="fortigate-firewall-v5">
+  <parent>fortigate-firewall-v5</parent>
+  <regex>xauthuser="(\.*)"|xauthuser=(\.*)\s|xauthuser=(\.*)$</regex>
+  <order>xauthuser</order>
+</decoder>
+
+
+
+
+<!-- FortiOS 6.0 via syslog -->
+
+<!--  Logs for FortiOS 6.2 -->
+
+
+
+<!--
+
+date=2019-02-20 time=09:57:22 logid="0111046400" type="event" subtype="fortiextender" level="notice" vd="root" eventtime=1550685442 logdesc="FortiExtender system activity"   action="FortiExtender Authorized"    msg="ext SN:FX04DN4N16002352 authorized"
+date=2019-02-20 time=09:51:42 logid="0111046401" type="event" subtype="fortiextender" level="notice" vd="root" eventtime=1550685102 logdesc="FortiExtender controller activity" sn="FX04DN4N16002352" ip=11.11.11.2 action="ext session-deauthed" msg="ext SN:FX04DN4N16002352 deauthorized"
+date=2019-02-20 time=10:02:26 logid="0111046409" type="event" subtype="fortiextender" level="information" vd="root" eventtime=1550685746 logdesc="Remote FortiExtender info activity" sn="FX04DN4N16002352" ip=11.11.11.2 action="Cellular Connected" imei="359376060442770" imsi="302720502331361" iccid="89302720403038146410" phonenumber="+16045067526" carrier="Rogers" plan="Rogers-plan" apn="N/A" service="LTE" msg="FX04DN4N16002352 STATE: sim with imsi:302720502331361 in slot:2 on carrier:Rogers connected"
+date=2019-02-20 time=10:33:57 logid="0111046407" type="event" subtype="fortiextender" level="warning" vd="root" eventtime=1550687636 logdesc="Remote FortiExtender warning activity" sn="FX04DN4N16002352" ip=11.11.11.2 action="Cellular Disconnected" imei="359376060442770" imsi="N/A" iccid="N/A" phonenumber="N/A" carrier="N/A" plan="N/A" apn="N/A" service="LTE" msg="FX04DN4N16002352 STATE: sim with imsi: in slot:2 on carrier:N/A disconnected"
+date=2019-02-20 time=10:02:24 logid="0111046409" type="event" subtype="fortiextender" level="information" vd="root" eventtime=1550685744 logdesc="Remote FortiExtender info activity" sn="FX04DN4N16002352" ip=11.11.11.2 action="Cellular Connecting" imei="359376060442770" imsi="302720502331361" iccid="89302720403038146410" phonenumber="+16045067526" carrier="Rogers" plan="Rogers-plan" apn="N/A" service="N/A" msg="FX04DN4N16002352 STATE: sim with imsi:302720502331361 in slot:2 on carrier:Rogers connecting
+date=2019-02-20 time=10:47:19 logid="0111046407" type="event" subtype="fortiextender" level="warning" vd="root" eventtime=1550688438 logdesc="Remote FortiExtender warning activity" sn="FX04DN4N16002352" ip=11.11.11.2 action="SIM Change" imei="N/A" slot=2 msg="FX04DN4N16002352 SIM: SIM2 is inserted"
+date=2019-02-20 time=10:57:50 logid="0111046407" type="event" subtype="fortiextender" level="warning" vd="root" eventtime=1550689069 logdesc="Remote FortiExtender warning activity" sn="FX04DN4N16002352" ip=11.11.11.2 action="SIM Change" imei="359376060442770" slot=1 msg="FX04DN4N16002352 SIM: SIM2 is plucked out"
+date=2019-02-20 time=12:02:24 logid="0111046407" type="event" subtype="fortiextender" level="warning" vd="root" eventtime=1550692942 logdesc="Remote FortiExtender warning activity" sn="FX04DN4N16002352" ip=11.11.11.2 action="SIM Switch" imei="359376060442770" reason="sim-switch can't take effect due to unavailability of 2 sim cards" msg="FX04DN4N16002352 SIM: sim-switch can't take effect due to unavailability of 2 sim cards"
+date=2019-02-19 time=18:08:46 logid="0111046409" type="event" subtype="fortiextender" level="information" vd="root" eventtime=1550628524 logdesc="Remote FortiExtender info activity" sn="FX04DN4N16002352" ip=11.11.11.2 action="Cellular Signal Statistics" imei="359376060442770" imsi="302720502331361" iccid="89302720403038146410" phonenumber="+16045067526" carrier="Rogers" plan="Rogers-plan" service="LTE" sinr="7.0 dB" rsrp="-89 dBm" rsrq="-16 dB" signalstrength="92 dBm" rssi="-54" temperature="40 C" apn="N/A" msg="FX04DN4N16002352 INFO:  LTE RSSI=-54dBm,RSRP=-89dBm,RSRQ=-16dB,SINR=7.0dB,BAND=B2,CELLID=061C700F,BW=15MHz,RXCH=1025,TXCH=19025,TAC=8AAC,TEMPERATURE=40 C"
+date=2019-02-19 time=18:09:46 logid="0111046409" type="event" subtype="fortiextender" level="information" vd="root" eventtime=1550628585 logdesc="Remote FortiExtender info activity" sn="FX04DN4N16002352" ip=11.11.11.2 action="Cellular Data Statistics" imei="359376060442770" imsi="302720502331361" iccid="89302720403038146410" phonenumber="+16045067526" carrier="Rogers" plan="Rogers-plan" service="LTE" rcvdbyte=7760 sentbyte=3315 msg="FX04DN4N16002352 INFO: SIM2 LTE, rx=7760, tx=3315, rx_diff=2538, tx_diff=567"
+
+date=2019-05-13 time=11:45:04 logid="0000000013" type="traffic" subtype="forward" level="notice" vd="vdom1" eventtime=1557773104815101919 srcip=10.1.100.11 srcport=60446 srcintf="port12" srcintfrole="undefined" dstip=172.16.200.55 dstport=80 dstintf="port11" dstintfrole="undefined" srcuuid="48420c8a-5c88-51e9-0424-a37f9e74621e" dstuuid="187d6f46-5c86-51e9-70a0-fadcfc349c3e" poluuid="3888b41a-5c88-51e9-cb32-1c32c66b4edf" sessionid=359260 proto=6 action="close" policyid=4 policytype="policy" service="HTTP" dstcountry="Reserved" srccountry="Reserved" trandisp="snat" transip=172.16.200.2 transport=60446 appid=15893 app="HTTP.BROWSER" appcat="Web.Client" apprisk="medium" applist="g-default" duration=1 sentbyte=412 rcvdbyte=2286 sentpkt=6 rcvdpkt=6 wanin=313 wanout=92 lanin=92 lanout=92 utmaction="block" countav=1 countapp=1 crscore=50 craction=2 osname="Ubuntu" mastersrcmac="a2:e9:00:ec:40:01" srcmac="a2:e9:00:ec:40:01" srcserver=0 utmref=65497-770
+
+date=2019-05-13 time=11:45:03 logid="0211008192" type="utm" subtype="virus" eventtype="infected" level="warning" vd="vdom1" eventtime=1557773103767393505 msg="File is infected." action="blocked" service="HTTP" sessionid=359260 srcip=10.1.100.11 dstip=172.16.200.55 srcport=60446 dstport=80 srcintf="port12" srcintfrole="undefined" dstintf="port11" dstintfrole="undefined" policyid=4 proto=6 direction="incoming" filename="eicar.com" quarskip="File-was-not-quarantined." virus="EICAR_TEST_FILE" dtype="Virus" ref="http://www.fortinet.com/ve?vn=EICAR_TEST_FILE" virusid=2172 url="http://172.16.200.55/virus/eicar.com" profile="g-default" agent="curl/7.47.0" analyticscksum="275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f" analyticssubmit="false" crscore=50 craction=2 crlevel="critical"
+
+date=2019-05-13 time=16:29:45 logid="0316013056" type="utm" subtype="webfilter" eventtype="ftgd_blk" level="warning" vd="vdom1" eventtime=1557790184975119738 policyid=1 sessionid=381780 srcip=10.1.100.11 srcport=44258 srcintf="port12" srcintfrole="undefined" dstip=185.244.31.158 dstport=80 dstintf="port11" dstintfrole="undefined" proto=6 service="HTTP" hostname="morrishittu.ddns.net" profile="test-webfilter" action="blocked" reqtype="direct" url="/" sentbyte=84 rcvdbyte=0 direction="outgoing" msg="URL belongs to a denied category in policy" method="domain" cat=26 catdesc="Malicious Websites" crscore=30 craction=4194304 crlevel="high"
+
+date=2019-05-15 time=15:05:49 logid="1501054802" type="utm" subtype="dns" eventtype="dns-response" level="notice" vd="vdom1" eventtime=1557957949740931155 policyid=1 sessionid=6887 srcip=10.1.100.22 srcport=50002 srcintf="port12" srcintfrole="undefined" dstip=172.16.100.100 dstport=53 dstintf="port11" dstintfrole="undefined" proto=17 profile="dnsfilter_fgd" srcmac="a2:e9:00:ec:40:41" xid=57945 qname="changelogs.ubuntu.com" qtype="AAAA" qtypeval=28 qclass="IN" ipaddr="2001:67c:1560:8008::11" msg="Domain is monitored" action="pass" cat=52 catdesc="Information Technology"
+date=2019-05-15 time=15:05:49 logid="1500054000" type="utm" subtype="dns" eventtype="dns-query" level="information" vd="vdom1" eventtime=1557957949653103543 policyid=1 sessionid=6887 srcip=10.1.100.22 srcport=50002 srcintf="port12" srcintfrole="undefined" dstip=172.16.100.100 dstport=53 dstintf="port11" dstintfrole="undefined" proto=17 profile="dnsfilter_fgd" srcmac="a2:e9:00:ec:40:41" xid=57945 qname="changelogs.ubuntu.com" qtype="AAAA" qtypeval=28 qclass="IN"
+
+date=2019-05-15 time=15:08:49 logid="0000000013" type="traffic" subtype="forward" level="notice" vd="vdom1" eventtime=1557958129950003945 srcip=10.1.100.22 srcport=50002 srcintf="port12" srcintfrole="undefined" dstip=172.16.100.100 dstport=53 dstintf="port11" dstintfrole="undefined" srcuuid="ae28f494-5735-51e9-f247-d1d2ce663f4b" dstuuid="ae28f494-5735-51e9-f247-d1d2ce663f4b" poluuid="ccb269e0-5735-51e9-a218-a397dd08b7eb" sessionid=6887 proto=17 action="accept" policyid=1 policytype="policy" service="DNS" dstcountry="Reserved" srccountry="Reserved" trandisp="snat" transip=172.16.200.2 transport=50002 duration=180 sentbyte=67 rcvdbyte=207 sentpkt=1 rcvdpkt=1 appcat="unscanned" utmaction="allow" countdns=1 osname="Linux" mastersrcmac="a2:e9:00:ec:40:41" srcmac="a2:e9:00:ec:40:41" srcserver=0 utmref=65495-306
+
+date=2019-05-15 time=18:03:36 logid="1059028704" type="utm" subtype="app-ctrl" eventtype="app-ctrl-all" level="information" vd="root" eventtime=1557968615 appid=40568 srcip=10.1.100.22 dstip=195.8.215.136 srcport=50798 dstport=443 srcintf="port10" srcintfrole="lan" dstintf="port9" dstintfrole="wan" proto=6 service="HTTPS" direction="outgoing" policyid=1 sessionid=4414 applist="block-social.media" appcat="Web.Client" app="HTTPS.BROWSER" action="pass" hostname="www.dailymotion.com" incidentserialno=1962906680 url="/" msg="Web.Client: HTTPS.BROWSER," apprisk="medium" scertcname="*.dailymotion.com" scertissuer="DigiCert SHA2 High Assurance Server CA"
+date=2019-05-15 time=18:03:35 logid="1059028705" type="utm" subtype="app-ctrl" eventtype="app-ctrl-all" level="warning" vd="root" eventtime=1557968615 appid=16072 srcip=10.1.100.22 dstip=195.8.215.136 srcport=50798 dstport=443 srcintf="port10" srcintfrole="lan" dstintf="port9" dstintfrole="wan" proto=6 service="HTTPS" direction="incoming" policyid=1 sessionid=4414 applist="block-social.media" appcat="Video/Audio" app="Dailymotion" action="block" hostname="www.dailymotion.com" incidentserialno=1962906682 url="/" msg="Video/Audio: Dailymotion," apprisk="elevated"
+date=2019-05-15 time=18:03:35 logid="1059028705" type="utm" subtype="app-ctrl" eventtype="app-ctrl-all" level="warning" vd="root" eventtime=1557968615 appid=16072 srcip=10.1.100.22 dstip=195.8.215.136 srcport=50798 dstport=443 srcintf="port10" srcintfrole="lan" dstintf="port9" dstintfrole="wan" proto=6 service="HTTPS" direction="incoming" policyid=1 sessionid=4414 applist="block-social.media" appcat="Video/Audio" app="Dailymotion" action="block" hostname="www.dailymotion.com" incidentserialno=1962906681 url="/" msg="Video/Audio: Dailymotion," apprisk="elevated"
+
+date=2019-05-15 time=18:03:41 logid="0000000013" type="traffic" subtype="forward" level="notice" vd="root" eventtime=1557968619 srcip=10.1.100.22 srcport=50798 srcintf="port10" srcintfrole="lan" dstip=195.8.215.136 dstport=443 dstintf="port9" dstintfrole="wan" poluuid="d8ce7a90-7763-51e9-e2be-741294c96f31" sessionid=4414 proto=6 action="client-rst" policyid=1 policytype="policy" service="HTTPS" dstcountry="France" srccountry="Reserved" trandisp="snat" transip=172.16.200.10 transport=50798 appid=16072 app="Dailymotion" appcat="Video/Audio" apprisk="elevated" applist="block-social.media" appact="drop-session" duration=5 sentbyte=1150 rcvdbyte=7039 sentpkt=13 utmaction="block" countapp=3 devtype="Unknown" devcategory="None" mastersrcmac="00:0c:29:51:38:5e" srcmac="00:0c:29:51:38:5e" srcserver=0 utmref=0-330
+date=2019-05-15 time=17:56:41 logid="0419016384" type="utm" subtype="ips" eventtype="signature" level="alert" vd="root" eventtime=1557968201 severity="critical" srcip=10.1.100.22 srccountry="Reserved" dstip=172.16.200.55 srcintf="port10" srcintfrole="lan" dstintf="port9" dstintfrole="wan" sessionid=4017 action="dropped" proto=6 service="HTTP" policyid=1 attack="Adobe.Flash.newfunction.Handling.Code.Execution" srcport=46810 dstport=80 hostname="172.16.200.55" url="/ips/sig1.pdf" direction="incoming" attackid=23305 profile="block-critical-ips" ref="http://www.fortinet.com/ids/VID23305" incidentserialno=582633933 msg="applications3: Adobe.Flash.newfunction.Handling.Code.Execution," crscore=50 craction=4096 crlevel="critical"
+
+date=2019-05-15 time=17:58:10 logid="0000000013" type="traffic" subtype="forward" level="notice" vd="root" eventtime=1557968289 srcip=10.1.100.22 srcport=46810 srcintf="port10" srcintfrole="lan" dstip=172.16.200.55 dstport=80 dstintf="port9" dstintfrole="wan" poluuid="d8ce7a90-7763-51e9-e2be-741294c96f31" sessionid=4017 proto=6 action="close" policyid=1 policytype="policy" service="HTTP" dstcountry="Reserved" srccountry="Reserved" trandisp="snat" transip=172.16.200.10 transport=46810 duration=89 sentbyte=565 rcvdbyte=9112 sentpkt=9 rcvdpkt=8 appcat="unscanned" utmaction="block" countips=1 crscore=50 craction=4096 devtype="Unknown" devcategory="None" mastersrcmac="00:0c:29:51:38:5e" srcmac="00:0c:29:51:38:5e" srcserver=0 utmref=0-302
+
+date=2019-05-13 time=17:05:59 logid="0720018433" type="utm" subtype="anomaly" eventtype="anomaly" level="alert" vd="vdom1" eventtime=1557792359461869329 severity="critical" srcip=10.1.100.11 srccountry="Reserved" dstip=172.16.200.55 srcintf="port12" srcintfrole="undefined" sessionid=0 action="clear_session" proto=1 service="PING" count=1 attack="icmp_flood" icmpid="0x1474" icmptype="0x08" icmpcode="0x00" attackid=16777316 policyid=1 policytype="DoS-policy" ref="http://www.fortinet.com/ids/VID16777316" msg="anomaly: icmp_flood, 51 > threshold 50" crscore=50 craction=4096 crlevel="critical"
+
+date=2019-05-15 time=17:45:30 logid="0954024576" type="utm" subtype="dlp" eventtype="dlp" level="warning" vd="root" eventtime=1557967528 filteridx=1 dlpextra="dlp-file-size11" filtertype="file-type" filtercat="file" severity="medium" policyid=1 sessionid=3423 epoch=1740880646 eventid=0 srcip=10.1.100.22 srcport=50354 srcintf="port10" srcintfrole="lan" dstip=52.216.177.83 dstport=443 dstintf="port9" dstintfrole="wan" proto=6 service="HTTPS" filetype="pdf" direction="incoming" action="block" hostname="fortinetweb.s3.amazonaws.com" url="/docs.fortinet.com/v2/attachments/be3d0e3d-4b62-11e9-94bf-00505692583a/FortiOS_6.2.0_Log_Reference.pdf" agent="Wget/1.17.1" filename="FortiOS_6.2.0_Log_Reference.pdf" filesize=16360 profile="dlp-file-type-test"
+date=2019-05-15 time=17:45:34 logid="0000000013" type="traffic" subtype="forward" level="notice" vd="root" eventtime=1557967534 srcip=10.1.100.22 srcport=50354 srcintf="port10" srcintfrole="lan" dstip=52.216.177.83 dstport=443 dstintf="port9" dstintfrole="wan" poluuid="d8ce7a90-7763-51e9-e2be-741294c96f31" sessionid=3423 proto=6 action="server-rst" policyid=1 policytype="policy" service="HTTPS" dstcountry="United States" srccountry="Reserved" trandisp="snat" transip=172.16.200.10 transport=50354 duration=5 sentbyte=2314 rcvdbyte=5266 sentpkt=33 rcvdpkt=12 appcat="unscanned" wanin=43936 wanout=710 lanin=753 lanout=753 utmaction="block" countdlp=1 crscore=5 craction=262144 crlevel="low" devtype="Unknown" devcategory="None" mastersrcmac="00:0c:29:51:38:5e" srcmac="00:0c:29:51:38:5e" srcserver=0 utmref=0-152
+date=2019-05-15 time=16:18:17 logid="1601061010" type="utm" subtype="ssh" eventtype="ssh-channel" level="warning" vd="vdom1" eventtime=1557962296 policyid=1 sessionid=344 profile="ssh-deepscan" srcip=10.1.100.11 srcport=43580 dstip=172.16.200.44 dstport=22 srcintf="port21" srcintfrole="undefined" dstintf="port23" dstintfrole="undefined" proto=6 action="blocked" direction="outgoing" login="root" channeltype="shell"
+date=2019-05-15 time=16:18:18 logid="0000000013" type="traffic" subtype="forward" level="notice" vd="vdom1" eventtime=1557962298 srcip=10.1.100.11 srcport=43580 srcintf="port21" srcintfrole="undefined" dstip=172.16.200.44 dstport=22 dstintf="port23" dstintfrole="undefined" poluuid="49871fae-7371-51e9-17b4-43c7ff119195" sessionid=344 proto=6 action="close" policyid=1 policytype="policy" service="SSH" dstcountry="Reserved" srccountry="Reserved" trandisp="snat" transip=172.16.200.171 transport=43580 duration=8 sentbyte=3093 rcvdbyte=2973 sentpkt=18 rcvdpkt=16 appcat="unscanned" utmaction="block" countssh=1 utmref=65535-0
+date=2019-03-28 time=10:44:53 logid="1700062002" type="utm" subtype="ssl" eventtype="ssl-anomalies" level="warning" vd="vdom1" eventtime=1553795092 policyid=1 sessionid=10796 service="HTTPS" srcip=10.1.100.66 srcport=43602 dstip=104.154.89.105 dstport=443 srcintf="port2" srcintfrole="undefined" dstintf="port3" dstintfrole="undefined" proto=6 action="blocked" msg="Server certificate blocked" reason="block-cert-invalid"
+date=2019-03-28 time=10:51:17 logid="1700062002" type="utm" subtype="ssl" eventtype="ssl-anomalies" level="warning" vd="vdom1" eventtime=1553795476 policyid=1 sessionid=11110 service="HTTPS" srcip=10.1.100.66 srcport=49076 dstip=172.16.200.99 dstport=443 srcintf="port2" srcintfrole="undefined" dstintf="port3" dstintfrole="undefined" proto=6 action="blocked" msg="Server certificate blocked" reason="block-cert-untrusted"
+date=2019-03-28 time=10:55:43 logid="1700062002" type="utm" subtype="ssl" eventtype="ssl-anomalies" level="warning" vd="vdom1" eventtime=1553795742 policyid=1 sessionid=11334 service="HTTPS" srcip=10.1.100.66 srcport=49082 dstip=172.16.200.99 dstport=443 srcintf="port2" srcintfrole="undefined" dstintf="port3" dstintfrole="undefined" proto=6 action="blocked" msg="Server certificate blocked" reason="block-cert-req"
+date=2019-03-28 time=10:57:42 logid="1700062053" type="utm" subtype="ssl" eventtype="ssl-anomalies" level="warning" vd="vdom1" eventtime=1553795861 policyid=1 sessionid=11424 service="SMTPS" profile="block-unsupported-ssl" srcip=10.1.100.66 srcport=41296 dstip=172.16.200.99 dstport=8080 srcintf="port2" srcintfrole="undefined" dstintf=unknown-0 dstintfrole="undefined" proto=6 action="blocked" msg="Connection is blocked due to unsupported SSL traffic" reason="malformed input"
+date=2019-03-28 time=11:00:17 logid="1700062002" type="utm" subtype="ssl" eventtype="ssl-anomalies" level="warning" vd="vdom1" eventtime=1553796016 policyid=1 sessionid=11554 service="HTTPS" srcip=10.1.100.66 srcport=49088 dstip=172.16.200.99 dstport=443 srcintf="port2" srcintfrole="undefined" dstintf="port3" dstintfrole="undefined" proto=6 action="blocked" msg="Server certificate blocked" reason="block-cert-sni-mismatch"
+date=2019-03-28 time=11:02:07 logid="1700062000" type="utm" subtype="ssl" eventtype="ssl-anomalies" level="warning" vd="vdom1" eventtime=1553796126 policyid=1 sessionid=11667 service="HTTPS" srcip=10.1.100.66 srcport=49096 dstip=172.16.200.99 dstport=443 srcintf="port2" srcintfrole="undefined" dstintf="port3" dstintfrole="undefined" proto=6 action="blocked" msg="Certificate blacklisted" certhash="1115ec1857ed7f937301ff5e02f6b0681cf2ec4e" reason="Other"
+date=2019-03-28 time=11:06:05 logid="1701062003" type="utm" subtype="ssl" eventtype="ssl-exempt" level="notice" vd="vdom1" eventtime=1553796363 policyid=1 sessionid=11871 service="HTTPS" srcip=10.1.100.66 srcport=47384 dstip=50.18.221.132 dstport=443 srcintf="port2" srcintfrole="undefined" dstintf="port3" dstintfrole="undefined" proto=6 action="exempt" msg="SSL connection exempted" reason="exempt-whitelist"
+date=2019-03-28 time=11:09:14 logid="1701062003" type="utm" subtype="ssl" eventtype="ssl-exempt" level="notice" vd="vdom1" eventtime=1553796553 policyid=1 sessionid=12079 service="HTTPS" srcip=10.1.100.66 srcport=49102 dstip=172.16.200.99 dstport=443 srcintf="port2" srcintfrole="undefined" dstintf="port3" dstintfrole="undefined" proto=6 action="exempt" msg="SSL connection exempted" reason="exempt-addr"
+date=2019-03-28 time=11:10:55 logid="1701062003" type="utm" subtype="ssl" eventtype="ssl-exempt" level="notice" vd="vdom1" eventtime=1553796654 policyid=1 sessionid=12171 service="HTTPS" srcip=10.1.100.66 srcport=47390 dstip=50.18.221.132 dstport=443 srcintf="port2" srcintfrole="undefined" dstintf="port3" dstintfrole="undefined" proto=6 action="exempt" msg="SSL connection exempted" reason="exempt-ftgd-cat"
+date=2019-05-15 time=16:28:17 logid="1800063000" type="utm" subtype="cifs" eventtype="cifs-filefilter" level="warning" vd="vdom1" eventtime=1557962895 msg="File was blocked by file filter." direction="incoming" action="blocked" service="CIFS" srcip=10.1.100.11 dstip=172.16.200.44 srcport=56348 dstport=445 srcintf="port21" srcintfrole="undefined" dstintf="port23" dstintfrole="undefined" policyid=1 proto=16 profile="cifs" filesize="13824" filename="sample\\test.xls" filtername="1" filetype="msoffice"
+date=2017-11-15 time=11:44:16 logid="0000000013" type="traffic" subtype="forward" level="notice" vd="vdom1" eventtime=1510775056 srcip=10.1.100.155 srcname="pc1" srcport=40772 srcintf="port12" srcintfrole="undefined" dstip=35.197.51.42 dstname="fortiguard.com" dstport=443 dstintf="port11" dstintfrole="undefined" poluuid="707a0d88-c972-51e7-bbc7-4d421660557b" sessionid=8058 proto=6 action="close" policyid=1 policytype="policy" policymode="learn" service="HTTPS" dstcountry="United States" srccountry="Reserved" trandisp="snat" transip=172.16.200.2 transport=40772 appid=40568 app="HTTPS.BROWSER" appcat="Web.Client" apprisk="medium" duration=2 sentbyte=1850 rcvdbyte=39898 sentpkt=25 rcvdpkt=37 utmaction="allow" countapp=1 devtype="Linux PC" osname="Linux" mastersrcmac="a2:e9:00:ec:40:01" srcmac="a2:e9:00:ec:40:01" srcserver=0 utmref=0-220586
+-->
+
+<decoder name="fortigate-firewall-v6">
+  <prematch>date=\d\d\d\d-\d\d-\d\d time=\.+logid=\.+type=\.+subtype=\.+</prematch>
+  <type>syslog</type>
+</decoder>
+
+<decoder name="fortigate-firewall-v6">
+  <parent>fortigate-firewall-v6</parent>
+  <regex>imei="(\.*)"|imei=(\.*)\s|imei=(\.*)$</regex>
+  <order>imei</order>
+</decoder>
+
+
+<decoder name="fortigate-firewall-v6">
+  <parent>fortigate-firewall-v6</parent>
+  <regex>sn="(\.*)"|sn=(\.*)\s|sn=(\.*)$</regex>
+  <order>sn</order>
+</decoder>
+
+<decoder name="fortigate-firewall-v6">
+  <parent>fortigate-firewall-v6</parent>
+  <regex>action="(\.*)"|action=(\.*)\s|action=(\.*)$</regex>
+  <order>action</order>
+</decoder>
+
+<decoder name="fortigate-firewall-v6">
+  <parent>fortigate-firewall-v6</parent>
+  <regex>agent="(\.*)"|agent=(\.*)\s|agent=(\.*)$</regex>
+  <order>agent</order>
+</decoder>
+
+<decoder name="fortigate-firewall-v6">
+  <parent>fortigate-firewall-v6</parent>
+  <regex>analyticscksum="(\.*)"|analyticscksum=(\.*)\s|analyticscksum=(\.*)$</regex>
+  <order>analyticscksum</order>
+</decoder>
+
+<decoder name="fortigate-firewall-v6">
+  <parent>fortigate-firewall-v6</parent>
+  <regex>analyticssubmit="(\.*)"|analyticssubmit=(\.*)\s|analyticssubmit=(\.*)$</regex>
+  <order>analyticssubmit</order>
+</decoder>
+
+<decoder name="fortigate-firewall-v6">
+  <parent>fortigate-firewall-v6</parent>
+  <regex>apn="(\.*)"|apn=(\.*)\s|apn=(\.*)$</regex>
+  <order>apn</order>
+</decoder>
+
+<decoder name="fortigate-firewall-v6">
+  <parent>fortigate-firewall-v6</parent>
+  <regex>app="(\.*)"|app=(\.*)\s|app=(\.*)$</regex>
+  <order>app</order>
+</decoder>
+
+<decoder name="fortigate-firewall-v6">
+  <parent>fortigate-firewall-v6</parent>
+  <regex>appact="(\.*)"|appact=(\.*)\s|appact=(\.*)$</regex>
+  <order>appact</order>
+</decoder>
+
+<decoder name="fortigate-firewall-v6">
+  <parent>fortigate-firewall-v6</parent>
+  <regex>appcat="(\.*)"|appcat=(\.*)\s|appcat=(\.*)$</regex>
+  <order>appcat</order>
+</decoder>
+
+<decoder name="fortigate-firewall-v6">
+  <parent>fortigate-firewall-v6</parent>
+  <regex>appid="(\.*)"|appid=(\.*)\s|appid=(\.*)$</regex>
+  <order>appid</order>
+</decoder>
+
+<decoder name="fortigate-firewall-v6">
+  <parent>fortigate-firewall-v6</parent>
+  <regex>applist="(\.*)"|applist=(\.*)\s|applist=(\.*)$</regex>
+  <order>applist</order>
+</decoder>
+
+<decoder name="fortigate-firewall-v6">
+  <parent>fortigate-firewall-v6</parent>
+  <regex>apprisk="(\.*)"|apprisk=(\.*)\s|apprisk=(\.*)$</regex>
+  <order>apprisk</order>
+</decoder>
+
+<decoder name="fortigate-firewall-v6">
+  <parent>fortigate-firewall-v6</parent>
+  <regex>attack="(\.*)"|attack=(\.*)\s|attack=(\.*)$</regex>
+  <order>attack</order>
+</decoder>
+
+<decoder name="fortigate-firewall-v6">
+  <parent>fortigate-firewall-v6</parent>
+  <regex>attackid="(\.*)"|attackid=(\.*)\s|attackid=(\.*)$</regex>
+  <order>attackid</order>
+</decoder>
+
+<decoder name="fortigate-firewall-v6">
+  <parent>fortigate-firewall-v6</parent>
+  <regex>method="(\.*)"|method=(\.*)\s|method=(\.*)$</regex>
+  <order>method</order>
+</decoder>
+
+<decoder name="fortigate-firewall-v6">
+  <parent>fortigate-firewall-v6</parent>
+  <regex>certhash="(\.*)"|certhash=(\.*)\s|certhash=(\.*)$</regex>
+  <order>certhash</order>
+</decoder>
+
+
+
+<decoder name="fortigate-firewall-v6">
+  <parent>fortigate-firewall-v6</parent>
+  <regex>carrier="(\.*)"|carrier=(\.*)\s|carrier=(\.*)$</regex>
+  <order>carrier</order>
+</decoder>
+
+<decoder name="fortigate-firewall-v6">
+  <parent>fortigate-firewall-v6</parent>
+  <regex>cat="(\.*)"|cat=(\.*)\s|cat=(\.*)$</regex>
+  <order>cat</order>
+</decoder>
+
+<decoder name="fortigate-firewall-v6">
+  <parent>fortigate-firewall-v6</parent>
+  <regex>catdesc="(\.*)"|catdesc=(\.*)\s|catdesc=(\.*)$</regex>
+  <order>catdesc</order>
+</decoder>
+
+<decoder name="fortigate-firewall-v6">
+  <parent>fortigate-firewall-v6</parent>
+  <regex>channeltype="(\.*)"|channeltype=(\.*)\s|channeltype=(\.*)$</regex>
+  <order>channeltype</order>
+</decoder>
+
+<decoder name="fortigate-firewall-v6">
+  <parent>fortigate-firewall-v6</parent>
+  <regex>count="(\.*)"|count=(\.*)\s|count=(\.*)$</regex>
+  <order>count</order>
+</decoder>
+
+<decoder name="fortigate-firewall-v6">
+  <parent>fortigate-firewall-v6</parent>
+  <regex>countapp="(\.*)"|countapp=(\.*)\s|countapp=(\.*)$</regex>
+  <order>countapp</order>
+</decoder>
+
+<decoder name="fortigate-firewall-v6">
+  <parent>fortigate-firewall-v6</parent>
+  <regex>countav="(\.*)"|countav=(\.*)\s|countav=(\.*)$</regex>
+  <order>countav</order>
+</decoder>
+
+<decoder name="fortigate-firewall-v6">
+  <parent>fortigate-firewall-v6</parent>
+  <regex>countdlp="(\.*)"|countdlp=(\.*)\s|countdlp=(\.*)$</regex>
+  <order>countdlp</order>
+</decoder>
+
+<decoder name="fortigate-firewall-v6">
+  <parent>fortigate-firewall-v6</parent>
+  <regex>countdns="(\.*)"|countdns=(\.*)\s|countdns=(\.*)$</regex>
+  <order>countdns</order>
+</decoder>
+
+<decoder name="fortigate-firewall-v6">
+  <parent>fortigate-firewall-v6</parent>
+  <regex>countips="(\.*)"|countips=(\.*)\s|countips=(\.*)$</regex>
+  <order>countips</order>
+</decoder>
+
+<decoder name="fortigate-firewall-v6">
+  <parent>fortigate-firewall-v6</parent>
+  <regex>countssh="(\.*)"|countssh=(\.*)\s|countssh=(\.*)$</regex>
+  <order>countssh</order>
+</decoder>
+
+<decoder name="fortigate-firewall-v6">
+  <parent>fortigate-firewall-v6</parent>
+  <regex>craction="(\.*)"|craction=(\.*)\s|craction=(\.*)$</regex>
+  <order>craction</order>
+</decoder>
+
+<decoder name="fortigate-firewall-v6">
+  <parent>fortigate-firewall-v6</parent>
+  <regex>crlevel="(\.*)"|crlevel=(\.*)\s|crlevel=(\.*)$</regex>
+  <order>crlevel</order>
+</decoder>
+
+<decoder name="fortigate-firewall-v6">
+  <parent>fortigate-firewall-v6</parent>
+  <regex>crscore="(\.*)"|crscore=(\.*)\s|crscore=(\.*)$</regex>
+  <order>crscore</order>
+</decoder>
+
+<decoder name="fortigate-firewall-v6">
+  <parent>fortigate-firewall-v6</parent>
+  <regex>rsrp="(\.*)"|rsrp=(\.*)\s|rsrp=(\.*)$</regex>
+  <order>rsrp</order>
+</decoder>
+
+<decoder name="fortigate-firewall-v6">
+  <parent>fortigate-firewall-v6</parent>
+  <regex>signalstrength="(\.*)"|signalstrength=(\.*)\s|signalstrength=(\.*)$</regex>
+  <order>signalstrength</order>
+</decoder>
+
+<decoder name="fortigate-firewall-v6">
+  <parent>fortigate-firewall-v6</parent>
+  <regex>rsrq="(\.*)"|rsrq=(\.*)\s|rsrq=(\.*)$</regex>
+  <order>rsrq</order>
+</decoder>
+
+<decoder name="fortigate-firewall-v6">
+  <parent>fortigate-firewall-v6</parent>
+  <regex>rssi="(\.*)"|rssi=(\.*)\s|rssi=(\.*)$</regex>
+  <order>rssi</order>
+</decoder>
+
+<decoder name="fortigate-firewall-v6">
+  <parent>fortigate-firewall-v6</parent>
+  <regex>devcategory="(\.*)"|devcategory=(\.*)\s|devcategory=(\.*)$</regex>
+  <order>devcategory</order>
+</decoder>
+
+<decoder name="fortigate-firewall-v6">
+  <parent>fortigate-firewall-v6</parent>
+  <regex>devtype="(\.*)"|devtype=(\.*)\s|devtype=(\.*)$</regex>
+  <order>devtype</order>
+</decoder>
+
+<decoder name="fortigate-firewall-v6">
+  <parent>fortigate-firewall-v6</parent>
+  <regex>direction="(\.*)"|direction=(\.*)\s|direction=(\.*)$</regex>
+  <order>direction</order>
+</decoder>
+
+<decoder name="fortigate-firewall-v6">
+  <parent>fortigate-firewall-v6</parent>
+  <regex>dlpextra="(\.*)"|dlpextra=(\.*)\s|dlpextra=(\.*)$</regex>
+  <order>dlpextra</order>
+</decoder>
+
+<decoder name="fortigate-firewall-v6">
+  <parent>fortigate-firewall-v6</parent>
+  <regex>dstcountry="(\.*)"|dstcountry=(\.*)\s|dstcountry=(\.*)$</regex>
+  <order>dstcountry</order>
+</decoder>
+
+<decoder name="fortigate-firewall-v6">
+  <parent>fortigate-firewall-v6</parent>
+  <regex>dstintf="(\.*)"|dstintf=(\.*)\s|dstintf=(\.*)$</regex>
+  <order>dstintf</order>
+</decoder>
+
+<decoder name="fortigate-firewall-v6">
+  <parent>fortigate-firewall-v6</parent>
+  <regex>dstintfrole="(\.*)"|dstintfrole=(\.*)\s|dstintfrole=(\.*)$</regex>
+  <order>dstintfrole</order>
+</decoder>
+
+<decoder name="fortigate-firewall-v6">
+  <parent>fortigate-firewall-v6</parent>
+  <regex>dstip="(\.*)"|dstip=(\.*)\s|dstip=(\.*)$</regex>
+  <order>dstip</order>
+</decoder>
+
+<decoder name="fortigate-firewall-v6">
+  <parent>fortigate-firewall-v6</parent>
+  <regex>dstname="(\.*)"|dstname=(\.*)\s|dstname=(\.*)$</regex>
+  <order>dstname</order>
+</decoder>
+
+<decoder name="fortigate-firewall-v6">
+  <parent>fortigate-firewall-v6</parent>
+  <regex>dstport="(\.*)"|dstport=(\.*)\s|dstport=(\.*)$</regex>
+  <order>dstport</order>
+</decoder>
+
+<decoder name="fortigate-firewall-v6">
+  <parent>fortigate-firewall-v6</parent>
+  <regex>dstuuid="(\.*)"|dstuuid=(\.*)\s|dstuuid=(\.*)$</regex>
+  <order>dstuuid</order>
+</decoder>
+
+<decoder name="fortigate-firewall-v6">
+  <parent>fortigate-firewall-v6</parent>
+  <regex>dtype="(\.*)"|dtype=(\.*)\s|dtype=(\.*)$</regex>
+  <order>dtype</order>
+</decoder>
+
+<decoder name="fortigate-firewall-v6">
+  <parent>fortigate-firewall-v6</parent>
+  <regex>duration="(\.*)"|duration=(\.*)\s|duration=(\.*)$</regex>
+  <order>duration</order>
+</decoder>
+
+<decoder name="fortigate-firewall-v6">
+  <parent>fortigate-firewall-v6</parent>
+  <regex>epoch="(\.*)"|epoch=(\.*)\s|epoch=(\.*)$</regex>
+  <order>epoch</order>
+</decoder>
+
+<decoder name="fortigate-firewall-v6">
+  <parent>fortigate-firewall-v6</parent>
+  <regex>eventid="(\.*)"|eventid=(\.*)\s|eventid=(\.*)$</regex>
+  <order>eventid</order>
+</decoder>
+
+<decoder name="fortigate-firewall-v6">
+  <parent>fortigate-firewall-v6</parent>
+  <regex>eventtime="(\.*)"|eventtime=(\.*)\s|eventtime=(\.*)$</regex>
+  <order>eventtime</order>
+</decoder>
+
+<decoder name="fortigate-firewall-v6">
+  <parent>fortigate-firewall-v6</parent>
+  <regex>eventtype="(\.*)"|eventtype=(\.*)\s|eventtype=(\.*)$</regex>
+  <order>eventtype</order>
+</decoder>
+
+<decoder name="fortigate-firewall-v6">
+  <parent>fortigate-firewall-v6</parent>
+  <regex>filename="(\.*)"|filename=(\.*)\s|filename=(\.*)$</regex>
+  <order>filename</order>
+</decoder>
+
+<decoder name="fortigate-firewall-v6">
+  <parent>fortigate-firewall-v6</parent>
+  <regex>filesize="(\.*)"|filesize=(\.*)\s|filesize=(\.*)$</regex>
+  <order>filesize</order>
+</decoder>
+
+<decoder name="fortigate-firewall-v6">
+  <parent>fortigate-firewall-v6</parent>
+  <regex>filetype="(\.*)"|filetype=(\.*)\s|filetype=(\.*)$</regex>
+  <order>filetype</order>
+</decoder>
+
+<decoder name="fortigate-firewall-v6">
+  <parent>fortigate-firewall-v6</parent>
+  <regex>filtercat="(\.*)"|filtercat=(\.*)\s|filtercat=(\.*)$</regex>
+  <order>filtercat</order>
+</decoder>
+
+<decoder name="fortigate-firewall-v6">
+  <parent>fortigate-firewall-v6</parent>
+  <regex>filteridx="(\.*)"|filteridx=(\.*)\s|filteridx=(\.*)$</regex>
+  <order>filteridx</order>
+</decoder>
+
+<decoder name="fortigate-firewall-v6">
+  <parent>fortigate-firewall-v6</parent>
+  <regex>filtername="(\.*)"|filtername=(\.*)\s|filtername=(\.*)$</regex>
+  <order>filtername</order>
+</decoder>
+
+<decoder name="fortigate-firewall-v6">
+  <parent>fortigate-firewall-v6</parent>
+  <regex>filtertype="(\.*)"|filtertype=(\.*)\s|filtertype=(\.*)$</regex>
+  <order>filtertype</order>
+</decoder>
+
+<decoder name="fortigate-firewall-v6">
+  <parent>fortigate-firewall-v6</parent>
+  <regex>hostname="(\.*)"|hostname=(\.*)\s|hostname=(\.*)$</regex>
+  <order>hostname</order>
+</decoder>
+
+<decoder name="fortigate-firewall-v6">
+  <parent>fortigate-firewall-v6</parent>
+  <regex>iccid="(\.*)"|iccid=(\.*)\s|iccid=(\.*)$</regex>
+  <order>iccid</order>
+</decoder>
+
+
+<decoder name="fortigate-firewall-v6">
+  <parent>fortigate-firewall-v6</parent>
+  <regex>icmpcode="(\.*)"|icmpcode=(\.*)\s|icmpcode=(\.*)$</regex>
+  <order>icmpcode</order>
+</decoder>
+
+<decoder name="fortigate-firewall-v6">
+  <parent>fortigate-firewall-v6</parent>
+  <regex>icmpid="(\.*)"|icmpid=(\.*)\s|icmpid=(\.*)$</regex>
+  <order>icmpid</order>
+</decoder>
+
+<decoder name="fortigate-firewall-v6">
+  <parent>fortigate-firewall-v6</parent>
+  <regex>icmptype="(\.*)"|icmptype=(\.*)\s|icmptype=(\.*)$</regex>
+  <order>icmptype</order>
+</decoder>
+
+<decoder name="fortigate-firewall-v6">
+  <parent>fortigate-firewall-v6</parent>
+  <regex>imsi="(\.*)"|imsi=(\.*)\s|imsi=(\.*)$</regex>
+  <order>imsi</order>
+</decoder>
+
+<decoder name="fortigate-firewall-v6">
+  <parent>fortigate-firewall-v6</parent>
+  <regex>incidentserialno="(\.*)"|incidentserialno=(\.*)\s|incidentserialno=(\.*)$</regex>
+  <order>incidentserialno</order>
+</decoder>
+
+<decoder name="fortigate-firewall-v6">
+  <parent>fortigate-firewall-v6</parent>
+  <regex>ip="(\.*)"|ip=(\.*)\s|ip=(\.*)$</regex>
+  <order>ip</order>
+</decoder>
+
+<decoder name="fortigate-firewall-v6">
+  <parent>fortigate-firewall-v6</parent>
+  <regex>ipaddr="(\.*)"|ipaddr=(\.*)\s|ipaddr=(\.*)$</regex>
+  <order>ipaddr</order>
+</decoder>
+
+
+<decoder name="fortigate-firewall-v6">
+  <parent>fortigate-firewall-v6</parent>
+  <regex>lanin="(\.*)"|lanin=(\.*)\s|lanin=(\.*)$</regex>
+  <order>lanin</order>
+</decoder>
+
+<decoder name="fortigate-firewall-v6">
+  <parent>fortigate-firewall-v6</parent>
+  <regex>lanout="(\.*)"|lanout=(\.*)\s|lanout=(\.*)$</regex>
+  <order>lanout</order>
+</decoder>
+
+<decoder name="fortigate-firewall-v6">
+  <parent>fortigate-firewall-v6</parent>
+  <regex>level="(\.*)"|level=(\.*)\s|level=(\.*)$</regex>
+  <order>level</order>
+</decoder>
+
+<decoder name="fortigate-firewall-v6">
+  <parent>fortigate-firewall-v6</parent>
+  <regex>logdesc="(\.*)"|logdesc=(\.*)\s|logdesc=(\.*)$</regex>
+  <order>logdesc</order>
+</decoder>
+
+<decoder name="fortigate-firewall-v6">
+  <parent>fortigate-firewall-v6</parent>
+  <regex>logid="(\.*)"|logid=(\.*)\s|logid=(\.*)$</regex>
+  <order>logid</order>
+</decoder>
+
+<decoder name="fortigate-firewall-v6">
+  <parent>fortigate-firewall-v6</parent>
+  <regex>login="(\.*)"|login=(\.*)\s|login=(\.*)$</regex>
+  <order>login</order>
+</decoder>
+
+<decoder name="fortigate-firewall-v6">
+  <parent>fortigate-firewall-v6</parent>
+  <regex>mastersrcmac="(\.*)"|mastersrcmac=(\.*)\s|mastersrcmac=(\.*)$</regex>
+  <order>mastersrcmac</order>
+</decoder>
+
+<decoder name="fortigate-firewall-v6">
+  <parent>fortigate-firewall-v6</parent>
+  <regex>msg="(\.*)"|msg=(\.*)\s|msg=(\.*)$</regex>
+  <order>msg</order>
+</decoder>
+
+<decoder name="fortigate-firewall-v6">
+  <parent>fortigate-firewall-v6</parent>
+  <regex>osname="(\.*)"|osname=(\.*)\s|osname=(\.*)$</regex>
+  <order>osname</order>
+</decoder>
+
+<decoder name="fortigate-firewall-v6">
+  <parent>fortigate-firewall-v6</parent>
+  <regex>phonenumber="(\.*)"|phonenumber=(\.*)\s|phonenumber=(\.*)$</regex>
+  <order>phonenumber</order>
+</decoder>
+
+<decoder name="fortigate-firewall-v6">
+  <parent>fortigate-firewall-v6</parent>
+  <regex>plan="(\.*)"|plan=(\.*)\s|plan=(\.*)$</regex>
+  <order>plan</order>
+</decoder>
+
+<decoder name="fortigate-firewall-v6">
+  <parent>fortigate-firewall-v6</parent>
+  <regex>policyid="(\.*)"|policyid=(\.*)\s|policyid=(\.*)$</regex>
+  <order>policyid</order>
+</decoder>
+
+<decoder name="fortigate-firewall-v6">
+  <parent>fortigate-firewall-v6</parent>
+  <regex>policymode="(\.*)"|policymode=(\.*)\s|policymode=(\.*)$</regex>
+  <order>policymode</order>
+</decoder>
+
+<decoder name="fortigate-firewall-v6">
+  <parent>fortigate-firewall-v6</parent>
+  <regex>policytype="(\.*)"|policytype=(\.*)\s|policytype=(\.*)$</regex>
+  <order>policytype</order>
+</decoder>
+
+<decoder name="fortigate-firewall-v6">
+  <parent>fortigate-firewall-v6</parent>
+  <regex>poluuid="(\.*)"|poluuid=(\.*)\s|poluuid=(\.*)$</regex>
+  <order>poluuid</order>
+</decoder>
+
+<decoder name="fortigate-firewall-v6">
+  <parent>fortigate-firewall-v6</parent>
+  <regex>profile="(\.*)"|profile=(\.*)\s|profile=(\.*)$</regex>
+  <order>profile</order>
+</decoder>
+
+<decoder name="fortigate-firewall-v6">
+  <parent>fortigate-firewall-v6</parent>
+  <regex>proto="(\.*)"|proto=(\.*)\s|proto=(\.*)$</regex>
+  <order>proto</order>
+</decoder>
+
+<decoder name="fortigate-firewall-v6">
+  <parent>fortigate-firewall-v6</parent>
+  <regex>qclass="(\.*)"|qclass=(\.*)\s|qclass=(\.*)$</regex>
+  <order>qclass</order>
+</decoder>
+
+<decoder name="fortigate-firewall-v6">
+  <parent>fortigate-firewall-v6</parent>
+  <regex>qname="(\.*)"|qname=(\.*)\s|qname=(\.*)$</regex>
+  <order>qname</order>
+</decoder>
+
+<decoder name="fortigate-firewall-v6">
+  <parent>fortigate-firewall-v6</parent>
+  <regex>qtype="(\.*)"|qtype=(\.*)\s|qtype=(\.*)$</regex>
+  <order>qtype</order>
+</decoder>
+
+<decoder name="fortigate-firewall-v6">
+  <parent>fortigate-firewall-v6</parent>
+  <regex>qtypeval="(\.*)"|qtypeval=(\.*)\s|qtypeval=(\.*)$</regex>
+  <order>qtypeval</order>
+</decoder>
+
+<decoder name="fortigate-firewall-v6">
+  <parent>fortigate-firewall-v6</parent>
+  <regex>quarskip="(\.*)"|quarskip=(\.*)\s|quarskip=(\.*)$</regex>
+  <order>quarskip</order>
+</decoder>
+
+<decoder name="fortigate-firewall-v6">
+  <parent>fortigate-firewall-v6</parent>
+  <regex>rcvdbyte="(\.*)"|rcvdbyte=(\.*)\s|rcvdbyte=(\.*)$</regex>
+  <order>rcvdbyte</order>
+</decoder>
+
+<decoder name="fortigate-firewall-v6">
+  <parent>fortigate-firewall-v6</parent>
+  <regex>rcvdpkt="(\.*)"|rcvdpkt=(\.*)\s|rcvdpkt=(\.*)$</regex>
+  <order>rcvdpkt</order>
+</decoder>
+
+<decoder name="fortigate-firewall-v6">
+  <parent>fortigate-firewall-v6</parent>
+  <regex>reason="(\.*)"|reason=(\.*)\s|reason=(\.*)$</regex>
+  <order>reason</order>
+</decoder>
+
+<decoder name="fortigate-firewall-v6">
+  <parent>fortigate-firewall-v6</parent>
+  <regex>ref="(\.*)"|ref=(\.*)\s|ref=(\.*)$</regex>
+  <order>ref</order>
+</decoder>
+
+<decoder name="fortigate-firewall-v6">
+  <parent>fortigate-firewall-v6</parent>
+  <regex>reqtype="(\.*)"|reqtype=(\.*)\s|reqtype=(\.*)$</regex>
+  <order>reqtype</order>
+</decoder>
+
+<decoder name="fortigate-firewall-v6">
+  <parent>fortigate-firewall-v6</parent>
+  <regex>rx_diff="(\.*)"|rx_diff=(\.*)\s|rx_diff=(\.*)$</regex>
+  <order>rx_diff</order>
+</decoder>
+
+<decoder name="fortigate-firewall-v6">
+  <parent>fortigate-firewall-v6</parent>
+  <regex>scertcname="(\.*)"|scertcname=(\.*)\s|scertcname=(\.*)$</regex>
+  <order>scertcname</order>
+</decoder>
+
+<decoder name="fortigate-firewall-v6">
+  <parent>fortigate-firewall-v6</parent>
+  <regex>scertissuer="(\.*)"|scertissuer=(\.*)\s|scertissuer=(\.*)$</regex>
+  <order>scertissuer</order>
+</decoder>
+
+<decoder name="fortigate-firewall-v6">
+  <parent>fortigate-firewall-v6</parent>
+  <regex>sentbyte="(\.*)"|sentbyte=(\.*)\s|sentbyte=(\.*)$</regex>
+  <order>sentbyte</order>
+</decoder>
+
+<decoder name="fortigate-firewall-v6">
+  <parent>fortigate-firewall-v6</parent>
+  <regex>sentpkt="(\.*)"|sentpkt=(\.*)\s|sentpkt=(\.*)$</regex>
+  <order>sentpkt</order>
+</decoder>
+
+<decoder name="fortigate-firewall-v6">
+  <parent>fortigate-firewall-v6</parent>
+  <regex>service="(\.*)"|service=(\.*)\s|service=(\.*)$</regex>
+  <order>service</order>
+</decoder>
+
+
+<decoder name="fortigate-firewall-v6">
+  <parent>fortigate-firewall-v6</parent>
+  <regex>sessionid="(\.*)"|sessionid=(\.*)\s|sessionid=(\.*)$</regex>
+  <order>sessionid</order>
+</decoder>
+
+<decoder name="fortigate-firewall-v6">
+  <parent>fortigate-firewall-v6</parent>
+  <regex>severity="(\.*)"|severity=(\.*)\s|severity=(\.*)$</regex>
+  <order>severity</order>
+</decoder>
+
+<decoder name="fortigate-firewall-v6">
+  <parent>fortigate-firewall-v6</parent>
+  <regex>sinr="(\.*)"|sinr=(\.*)\s|sinr=(\.*)$</regex>
+  <order>sinr</order>
+</decoder>
+
+<decoder name="fortigate-firewall-v6">
+  <parent>fortigate-firewall-v6</parent>
+  <regex>slot="(\.*)"|slot=(\.*)\s|slot=(\.*)$</regex>
+  <order>slot</order>
+</decoder>
+
+<decoder name="fortigate-firewall-v6">
+  <parent>fortigate-firewall-v6</parent>
+  <regex>srccountry="(\.*)"|srccountry=(\.*)\s|srccountry=(\.*)$</regex>
+  <order>srccountry</order>
+</decoder>
+
+<decoder name="fortigate-firewall-v6">
+  <parent>fortigate-firewall-v6</parent>
+  <regex>srcintf="(\.*)"|srcintf=(\.*)\s|srcintf=(\.*)$</regex>
+  <order>srcintf</order>
+</decoder>
+
+<decoder name="fortigate-firewall-v6">
+  <parent>fortigate-firewall-v6</parent>
+  <regex>srcintfrole="(\.*)"|srcintfrole=(\.*)\s|srcintfrole=(\.*)$</regex>
+  <order>srcintfrole</order>
+</decoder>
+
+<decoder name="fortigate-firewall-v6">
+  <parent>fortigate-firewall-v6</parent>
+  <regex>srcip="(\.*)"|srcip=(\.*)\s|srcip=(\.*)$</regex>
+  <order>srcip</order>
+</decoder>
+
+<decoder name="fortigate-firewall-v6">
+  <parent>fortigate-firewall-v6</parent>
+  <regex>srcmac="(\.*)"|srcmac=(\.*)\s|srcmac=(\.*)$</regex>
+  <order>srcmac</order>
+</decoder>
+
+<decoder name="fortigate-firewall-v6">
+  <parent>fortigate-firewall-v6</parent>
+  <regex>srcname="(\.*)"|srcname=(\.*)\s|srcname=(\.*)$</regex>
+  <order>srcname</order>
+</decoder>
+
+<decoder name="fortigate-firewall-v6">
+  <parent>fortigate-firewall-v6</parent>
+  <regex>srcport="(\.*)"|srcport=(\.*)\s|srcport=(\.*)$</regex>
+  <order>srcport</order>
+</decoder>
+
+<decoder name="fortigate-firewall-v6">
+  <parent>fortigate-firewall-v6</parent>
+  <regex>srcserver="(\.*)"|srcserver=(\.*)\s|srcserver=(\.*)$</regex>
+  <order>srcserver</order>
+</decoder>
+
+<decoder name="fortigate-firewall-v6">
+  <parent>fortigate-firewall-v6</parent>
+  <regex>srcuuid="(\.*)"|srcuuid=(\.*)\s|srcuuid=(\.*)$</regex>
+  <order>srcuuid</order>
+</decoder>
+
+<decoder name="fortigate-firewall-v6">
+  <parent>fortigate-firewall-v6</parent>
+  <regex>status="(\.*)"|status=(\.*)\s|status=(\.*)$</regex>
+  <order>status</order>
+</decoder>
+
+<decoder name="fortigate-firewall-v6">
+  <parent>fortigate-firewall-v6</parent>
+  <regex>subtype="(\.*)"|subtype=(\.*)\s|subtype=(\.*)$</regex>
+  <order>subtype</order>
+</decoder>
+
+
+<decoder name="fortigate-firewall-v6">
+  <parent>fortigate-firewall-v6</parent>
+  <regex>temperature="(\.*)"|temperature=(\.*)\s|temperature=(\.*)$</regex>
+  <order>temperature</order>
+</decoder>
+
+<decoder name="fortigate-firewall-v6">
+  <parent>fortigate-firewall-v6</parent>
+  <regex>time="(\.*)"|time=(\.*)\s|time=(\.*)$</regex>
+  <order>time</order>
+</decoder>
+
+<decoder name="fortigate-firewall-v6">
+  <parent>fortigate-firewall-v6</parent>
+  <regex>trandisp="(\.*)"|trandisp=(\.*)\s|trandisp=(\.*)$</regex>
+  <order>trandisp</order>
+</decoder>
+
+<decoder name="fortigate-firewall-v6">
+  <parent>fortigate-firewall-v6</parent>
+  <regex>transip="(\.*)"|transip=(\.*)\s|transip=(\.*)$</regex>
+  <order>transip</order>
+</decoder>
+
+<decoder name="fortigate-firewall-v6">
+  <parent>fortigate-firewall-v6</parent>
+  <regex>transport="(\.*)"|transport=(\.*)\s|transport=(\.*)$</regex>
+  <order>transport</order>
+</decoder>
+
+<decoder name="fortigate-firewall-v6">
+  <parent>fortigate-firewall-v6</parent>
+  <regex>tx="(\.*)"|tx=(\.*)\s|tx=(\.*)$</regex>
+  <order>tx</order>
+</decoder>
+
+<decoder name="fortigate-firewall-v6">
+  <parent>fortigate-firewall-v6</parent>
+  <regex>tx_diff="(\.*)"|tx_diff=(\.*)\s|tx_diff=(\.*)$</regex>
+  <order>tx_diff</order>
+</decoder>
+
+<decoder name="fortigate-firewall-v6">
+  <parent>fortigate-firewall-v6</parent>
+  <regex>type="(\.*)"|type=(\.*)\s|type=(\.*)$</regex>
+  <order>type</order>
+</decoder>
+
+<decoder name="fortigate-firewall-v6">
+  <parent>fortigate-firewall-v6</parent>
+  <regex>url="(\.*)"|url=(\.*)\s|url=(\.*)$</regex>
+  <order>url</order>
+</decoder>
+
+<decoder name="fortigate-firewall-v6">
+  <parent>fortigate-firewall-v6</parent>
+  <regex>utmaction="(\.*)"|utmaction=(\.*)\s|utmaction=(\.*)$</regex>
+  <order>utmaction</order>
+</decoder>
+
+<decoder name="fortigate-firewall-v6">
+  <parent>fortigate-firewall-v6</parent>
+  <regex>utmref="(\.*)"|utmref=(\.*)\s|utmref=(\.*)$</regex>
+  <order>utmref</order>
+</decoder>
+
+<decoder name="fortigate-firewall-v6">
+  <parent>fortigate-firewall-v6</parent>
+  <regex>vd="(\.*)"|vd=(\.*)\s|vd=(\.*)$</regex>
+  <order>vd</order>
+</decoder>
+
+<decoder name="fortigate-firewall-v6">
+  <parent>fortigate-firewall-v6</parent>
+  <regex>virus="(\.*)"|virus=(\.*)\s|virus=(\.*)$</regex>
+  <order>virus</order>
+</decoder>
+
+<decoder name="fortigate-firewall-v6">
+  <parent>fortigate-firewall-v6</parent>
+  <regex>virusid="(\.*)"|virusid=(\.*)\s|virusid=(\.*)$</regex>
+  <order>virusid</order>
+</decoder>
+
+<decoder name="fortigate-firewall-v6">
+  <parent>fortigate-firewall-v6</parent>
+  <regex>wanin="(\.*)"|wanin=(\.*)\s|wanin=(\.*)$</regex>
+  <order>wanin</order>
+</decoder>
+
+<decoder name="fortigate-firewall-v6">
+  <parent>fortigate-firewall-v6</parent>
+  <regex>wanout="(\.*)"|wanout=(\.*)\s|wanout=(\.*)$</regex>
+  <order>wanout</order>
+</decoder>
+
+<decoder name="fortigate-firewall-v6">
+  <parent>fortigate-firewall-v6</parent>
+  <regex>xid="(\.*)"|xid=(\.*)\s|xid=(\.*)$</regex>
+  <order>xid</order>
 </decoder>

--- a/rules/0390-fortigate_rules.xml
+++ b/rules/0390-fortigate_rules.xml
@@ -91,7 +91,7 @@ ID: 81600 - 80799
     </rule>
 
     <!--
-    date=2016-06-15 time=09:41:35 devname=Device_Name devid=FGTXXXX9999999999 logid=9999999999 type=utm subtype=ips eventtype=signature level=alert vd="root" severity=info srcip=192.168.10.8 dstip=157.55.235.162 srcintf="internal2" dstintf="wan2" policyid=2 sessionid=1473454 action=dropped proto=6 service=tcp/20480 attack="HTTP.Unknown.Tunnelling" srcport=62216 dstport=80 direction=outgoing attackid=107347981 profile="default" ref="http://www.fortinet.com/ids/VID107347981" incidentserialno=1999871775 msg="http_decoder: HTTP.Unknown.Tunnelling,"
+    date=2016-06-15 time=09:41:35 devname=Device_Name devid=FGTXXXX9999999999 logid=9999999999 type=utm subtype=ips eventtype=signature level=alert vd="root" severity=info srcip=192.168.10.8 dstip=157.55.235.162 srcintf="internal2" dstintf="wan2" policyid=2 sessionid=1473454 action=reset proto=6 service=tcp/20480 attack="HTTP.Unknown.Tunnelling" srcport=62216 dstport=80 direction=outgoing attackid=107347981 profile="default" ref="http://www.fortinet.com/ids/VID107347981" incidentserialno=1999871775 msg="http_decoder: HTTP.Unknown.Tunnelling,"
     -->
     <rule id="81610" level="4">
         <if_sid>81603</if_sid>

--- a/rules/0390-fortigate_rules.xml
+++ b/rules/0390-fortigate_rules.xml
@@ -26,8 +26,13 @@ ID: 81600 - 80799
         <description>Fortigate v5 messages grouped.</description>
     </rule>
 
+    <rule id="81641" level="0">
+        <decoded_as>fortigate-firewall-v6</decoded_as>
+        <description>Fortigate v6 messages grouped.</description>
+    </rule>
+
     <rule id="81603" level="0">
-        <if_sid>81600,81601,81602</if_sid>
+        <if_sid>81600,81601,81602,81641</if_sid>
         <description>Fortigate messages grouped.</description>
     </rule>
 
@@ -119,6 +124,23 @@ ID: 81600 - 80799
         <group>pci_dss_10.6.1,gpg13_4.13,gdpr_IV_35.7.d,</group>
     </rule>
 
+    <!--
+    date=2016-06-16 time=09:03:03 devname=Device_Name devid=FGTXXXX9999999999 logid=9999999999 type=event subtype=system level=information vd="root" logdesc="Object attribute configured" user="admin" ui="GUI(4.3.5.8)" action=Add cfgtid=2162750 cfgpath="firewall.service.custom" cfgobj="Custom-TCP_10443" cfgattr="" msg="Add firewall.service.custom Custom-TCP_10443"
+    -->
+        <rule id="81631" level="3">
+        <if_sid>81603</if_sid>
+        <action>Add</action>
+        <description>Fortigate: Firewall configuration changes</description>
+        <group>pci_dss_1.4,gpg13_4.13,hipaa_164.312.a.1,nist_800_53_SC.7,</group>
+    </rule>
+
+    <rule id="81632" level="4" frequency="16" timeframe="45" ignore="240">
+        <if_matched_sid>81631</if_matched_sid>
+        <same_source_ip />
+        <description>Fortigate: Multiple Firewall edit events from same source.</description>
+        <group>pci_dss_1.4,pci_dss_10.6.1,gpg13_4.13,gdpr_IV_35.7.d,hipaa_164.312.a.1,hipaa_164.312.b,nist_800_53_SC.7,nist_800_53_AU.6,</group>
+    </rule>
+
 
     <!--
     date=2016-06-15 time=21:35:09 devname=Device_Name devid=FGTXXXX9999999999 logid=0101039426 type=event subtype=vpn level=alert vd="root" logdesc="SSL VPN login fail" action="ssl-login-fail" tunneltype="ssl-web" tunnelid=0 remip=2.4.6.8 tunnelip=(null) user="my_user_name" group="N/A" dst_host="N/A" reason="sslvpn_login_unknown_user" msg="SSL user failed to logged in"
@@ -158,10 +180,9 @@ ID: 81600 - 80799
     <!--
     date=2016-06-16 time=10:49:08 devname=Device_Name devid=FGTXXXX9999999999 logid=0000000013 type=traffic subtype=forward level=notice vd=root srcip=4.3.5.161 srcport=51082 srcintf="internal1" dstip=54.192.197.185 dstport=80 dstintf="wan1" poluuid=d6217c58-8c42-51e5-c3a6-c7766895cbfd sessionid=199618 proto=6 action=deny policyid=8 dstcountry="United States" srccountry="Reserved" trandisp=snat transip=160.242.8.82 transport=51082 service="HTTP" appid=6 app="BitTorrent" appcat="P2P" apprisk=high applist="default" appact=drop-session duration=3 sentbyte=60 rcvdbyte=3050 sentpkt=1 utmaction=block countapp=1 crscore=5 craction=1048576
     -->
-    <rule id="81618" level="1">
+    <rule id="81618" level="3">
         <if_sid>81603</if_sid>
-        <match>type=traffic</match>
-        <status>high</status>
+        <match>type=traffic|type="traffic"</match>
         <description>Fortigate: Traffic to be aware of.</description>
         <group>pci_dss_10.6.1,gdpr_IV_35.7.d,</group>
     </rule>
@@ -176,9 +197,9 @@ ID: 81600 - 80799
     <!--
     date=2016-06-15 time=11:44:46 devname=Device_Name devid=FGTXXXX9999999999 logid=9999999999 type=utm subtype=webfilter eventtype=urlfilter level=warning vd="root" urlfilteridx=3 urlfilterlist="default" policyid=2 sessionid=1563645 user="" srcip=1.2.3.11 srcport=52414 srcintf="internal2" dstip=1.5.5.92 dstport=443 dstintf="wan2" proto=6 service=HTTPS hostname="4-edge-chat.facebook.com" profile="default" action=blocked reqtype=referral url="/p?partition=-2&cb=lz1k&failure=5&sticky_token=274&sticky_pool=atn2c06_chat-proxy" sentbyte=932 rcvdbyte=0 direction=outgoing msg="URL was blocked because it is in the URL filter list" crscore=30 crlevel=high
     -->
-    <rule id="81620" level="0">
+    <rule id="81620" level="3">
         <if_sid>81603</if_sid>
-        <status>warning</status>
+        <match>level=warning|level="warning"</match>
         <action>blocked</action>
         <description>Fortigate: URL Blocked by Firewall.</description>
         <group>firewall_drop,pci_dss_10.6.1,gdpr_IV_35.7.d,</group>
@@ -196,7 +217,7 @@ ID: 81600 - 80799
     -->
     <rule id="81622" level="3">
         <if_sid>81603</if_sid>
-        <match>level=information</match>
+        <match>level=information|level="information"</match>
         <action>tunnel-up</action>
         <description>Fortigate: VPN User connected.</description>
         <group>authentication_success,pci_dss_10.2.5,gpg13_7.1,gdpr_IV_32.2,</group>
@@ -214,7 +235,7 @@ ID: 81600 - 80799
     -->
     <rule id="81624" level="3">
         <if_sid>81603</if_sid>
-        <match>level=information</match>
+        <match>level=information|level="information"</match>
         <action>tunnel-down</action>
         <description>Fortigate: VPN User disconnected.</description>
         <group>pci_dss_10.2.5,gpg13_7.1,gdpr_IV_32.2,</group>
@@ -239,6 +260,8 @@ ID: 81600 - 80799
         <group>pci_dss_10.6.1,gpg13_7.1,gpg13_7.2,gdpr_IV_32.2,</group>
     </rule>
 
+
+
     <rule id="81627" level="4" frequency="18" timeframe="45" ignore="240">
         <if_matched_sid>81626</if_matched_sid>
         <same_source_ip />
@@ -249,7 +272,6 @@ ID: 81600 - 80799
 
     <!--
     Mar 22 19:21:00 10.10.10.10 date=2016-03-22 time=19:20:46 devname=Text devid=FGT3HD0000000000 logid=0000018000 type=anomaly subtype=anomaly level=alert vd="root" severity=critical srcip=10.10.10.35 dstip=10.10.10.84 srcintf="port2" sessionid=0 action=detected proto=6 service=tcp/36875 count=1903 attack="tcp_syn_flood" srcport=32835 dstport=2960 attackid=100663396 profile="DoS-policy1" ref="http://www.fortinet.com/ids/VID100663396" msg="anomaly: tcp_syn_flood, 2001 > threshold 2000, repeats 1903 times" crscore=50 crlevel=critical
-
     Mar 22 19:21:00 10.10.10.10 date=2016-03-22 time=19:20:46 devname=Text devid=FGT3HD0000000000 logid=0000018000 type=anomaly subtype=anomaly level=alert vd="root" severity=critical srcip=10.10.10.61 dstip=10.10.10.84 srcintf="port2" sessionid=0 action=dropped proto=6 service=NONE count=9 attack="IP.Bad.Header" attackid=127 profile="N/A" ref="http://www.fortinet.com/ids/VID127" msg="anomaly: IP.Bad.Header, repeats 9 times" crscore=50 crlevel=critical
     -->
     <rule id="81628" level="11">
@@ -257,15 +279,155 @@ ID: 81600 - 80799
         <match>attack</match>
         <action>detected</action>
         <description>Fortigate Attack Detected</description>
-        <group>attack,gdpr_IV_35.7.d,</group>
+        <group>attack,pci_dss_10.6.1,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.6,</group>
     </rule>
 
-    <rule id="81629" level="3">
+    <!--
+    date=2019-05-15 time=17:56:41 logid="0419016384" type="utm" subtype="ips" eventtype="signature" level="alert" vd="root" eventtime=1557968201 severity="critical" srcip=10.1.100.22 srccountry="Reserved" dstip=172.16.200.55 srcintf="port10" srcintfrole="lan" dstintf="port9" dstintfrole="wan" sessionid=4017 action="dropped" proto=6 service="HTTP" policyid=1 attack="Adobe.Flash.newfunction.Handling.Code.Execution" srcport=46810 dstport=80 hostname="172.16.200.55" url="/ips/sig1.pdf" direction="incoming" attackid=23305 profile="block-critical-ips" ref="http://www.fortinet.com/ids/VID23305" incidentserialno=582633933 msg="applications3: Adobe.Flash.newfunction.Handling.Code.Execution," crscore=50 craction=4096 crlevel="critical"
+    -->
+    <rule id="81629" level="6">
         <if_sid>81603</if_sid>
         <match>attack</match>
         <action>dropped</action>
         <description>Fortigate Attack Dropped</description>
-        <group>attack,gdpr_IV_35.7.d,</group>
+        <group>attack,pci_dss_10.6.1,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.6,</group>
     </rule>
+
+    <!--
+    date=2019-05-13 time=17:05:59 logid="0720018433" type="utm" subtype="anomaly" eventtype="anomaly" level="alert" vd="vdom1" eventtime=1557792359461869329 severity="critical" srcip=10.1.100.11 srccountry="Reserved" dstip=172.16.200.55 srcintf="port12" srcintfrole="undefined" sessionid=0 action="clear_session" proto=1 service="PING" count=1 attack="icmp_flood" icmpid="0x1474" icmptype="0x08" icmpcode="0x00" attackid=16777316 policyid=1 policytype="DoS-policy" ref="http://www.fortinet.com/ids/VID16777316" msg="anomaly: icmp_flood, 51 > threshold 50" crscore=50 craction=4096 crlevel="critical"
+    -->
+    <rule id="81630" level="3">
+        <if_sid>81603</if_sid>
+        <match>attack</match>
+        <action>clear_session</action>
+        <description>Fortigate Attack: Session cleared.</description>
+        <group>attack,pci_dss_10.6.1,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.6,</group>
+    </rule>
+
+    <!--
+    2018 Apr 09 16:05:06 inwazuhmgr->172.24.0.253 date=2018-04-09 time=16:05:06 devname=BA-RSYS-FW devid=FG600C3912803212 logid="1059028705" type="utm" subtype="app-ctrl" eventtype="app-ctrl-all" level="warning" vd="BA-EXORA" logtime=1523270106 appid=17244 srcip=172.24.150.115 dstip=139.59.35.216 srcport=62159 dstport=443 srcintf="port5" srcintfrole="undefined" dstintf="port4" dstintfrole="wan" proto=6 service="HTTPS" policyid=107 sessionid=3454918141 applist="block-high-risk" appcat="Proxy" app="OpenVPN" action="block" incidentserialno=798746654 msg="Proxy: OpenVPN," apprisk="elevated"
+    -->
+    <rule id="81633" level="3">
+        <if_sid>81603</if_sid>
+        <match>subtype="app-ctrl"|subtype=app-ctrl</match>
+        <action>pass</action>
+        <description>Fortigate: App passed by firewall.</description>
+        <group>pci_dss_10.6.1,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.6,</group>
+    </rule>
+    <!--
+    date=2019-05-15 time=18:03:35 logid="1059028705" type="utm" subtype="app-ctrl" eventtype="app-ctrl-all" level="warning" vd="root" eventtime=1557968615 appid=16072 srcip=10.1.100.22 dstip=195.8.215.136 srcport=50798 dstport=443 srcintf="port10" srcintfrole="lan" dstintf="port9" dstintfrole="wan" proto=6 service="HTTPS" direction="incoming" policyid=1 sessionid=4414 applist="block-social.media" appcat="Video/Audio" app="Dailymotion" action="block" hostname="www.dailymotion.com" incidentserialno=1962906682 url="/" msg="Video/Audio: Dailymotion," apprisk="elevated
+    -->
+    <rule id="81634" level="5">
+        <if_sid>81603</if_sid>
+        <match>subtype="app-ctrl"|subtype=app-ctrl</match>
+        <action>block</action>
+        <description>Fortigate: App blocked by firewall.</description>
+        <group>firewall_drop,pci_dss_10.6.1,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.6,</group>
+    </rule>
+
+    <rule id="81635" level="3" frequency="16" timeframe="45" ignore="240">
+        <if_matched_sid>81620</if_matched_sid>
+        <same_source_ip />
+        <description>Fortigate: Multiple URL blocked from same source.</description>
+        <group>multiple_drops,pci_dss_10.6.1,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.6,</group>
+    </rule>
+
+    <!--
+    2018 Apr 09 16:03:11 inwazuhmgr->172.0.0.1 date=2018-04-09 time=16:03:11 devname=BA-BE-BI devid=FG600C1234567890 logid="0101037141" type="event" subtype="vpn" level="notice" vd="BA-BEBI" logtime=1523269991 logdesc="IPsec tunnel statistics" msg="IPsec tunnel statistics" action="tunnel-stats" remip=1.1.1.1 locip=1.1.1.1 remport=500 locport=500 outintf="port3" cookies="c95409asssss4d44/b8a16eeeeebe269a" user="N/A" group="N/A" xauthuser="N/A" xauthgroup="N/A" assignip=N/A vpntunnel="AWS-VPN-B" tunnelip=N/A tunnelid=2490314698 tunneltype="ipsec" duration=243565 sentbyte=116502517 rcvdbyte=347903642 nextstat=600
+    -->
+
+    <rule id="81636" level="1">
+        <if_sid>81603</if_sid>
+        <match>type="event" subtype="vpn" level="notice"|type=event subtype=vpn level=notice|type=event,subtype=vpn,level=notice</match>
+        <description>Fortigate: VPN related information.</description>
+    </rule>
+
+    <rule id="81637" level="1">
+        <if_sid>81603</if_sid>
+        <match>type="event" subtype="vpn" level="error"|type=event subtype=vpn level=error|type=event,subtype=vpn,level=error</match>
+        <description>Fortigate: VPN related error.</description>
+    </rule>
+
+<!--
+May 31 08:58:56 172.0.0.1 date=2018-05-31 time=08:58:56 devname="BA-BEBI" devid="FG600C1234567890" logid="0211008192" type="utm" subtype="virus" eventtype="infected" level="warning" vd="BA-BIBO" eventtime=1527737336 msg="File is infected." action="blocked" service="HTTP" sessionid=377413095 srcip=11.22.33.44 dstip=55.66.77.88 srcport=64982 dstport=80 srcintf="port5" srcintfrole="undefined" dstintf="port3" dstintfrole="wan" policyid=108 proto=6 direction="incoming" filename="FrontPageImgHandler.ashx" quarskip="File-was-not-quarantined." virus="Malware_Generic.P0" dtype="Virus" ref="http://www.fortinet.com/ve?vn=Malware_Generic.P0" virusid=7024603 url="http://www.badguys.web/FrontPageImgHandler.ashx?id=12" profile="Web-Browsing" agent="Chrome/66.0.3359.181" analyticscksum="a9165dbae34e6e2952270536e95a2bb154df61h6d95hfh6ee14b36123b" analyticssubmit="false" crscore=50 crlevel="critical"
+-->
+
+    <rule id="81638" level="6">
+        <if_sid>81603</if_sid>
+        <match>subtype=virus|subtype="virus"</match>
+        <description>Fortigate: Virus detected.</description>
+        <group>pci_dss_10.6.1,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.6,</group>
+    </rule>
+
+    <rule id="81639" level="6">
+        <if_sid>81638</if_sid>
+        <action>blocked</action>
+        <description>Fortigate: Blocked URL because a virus was detected.</description>
+        <group>firewall_drop,pci_dss_10.6.1,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.6,</group>
+    </rule>
+
+<!--
+2018 Jun 21 00:00:35 XXX->127.0.0.1 date=2018-06-21 time=03:00:35 devname="xxx" devid="FG123341414414" logid="111111111" type="utm" subtype="webfilter" eventtype="ftgd_allow" level="notice" vd="xxx" eventtime=111111111 policyid=111 sessionid=111111111 srcip=127.0.0.1 srcport=11111 srcintf="port1" srcintfrole="undefined" dstip=127.0.0.1 dstport=111 dstintf="port111" dstintfrole="undefined" proto=1 service="XXX" hostname="xxxxx.com" profile="xx" action="passthrough" reqtype="direct" url="/xxxxxxxxxxxx" sentbyte=11 rcvdbyte=111 direction="outgoing" msg="URL belongs to an allowed category in policy" method="domain" cat=50 catdesc="Information and Computer Security"
+NOTE: Since this rule can be noisy is set to level 1 by default.
+-->
+
+    <rule id="81640" level="1">
+        <if_sid>81603</if_sid>
+        <match>level=notice|level="notice"</match>
+        <action>passthrough</action>
+        <description>Fortigate: URL belongs to an allowed category.</description>
+    </rule>
+
+<!--
+date=2019-05-10 time=09:53:18 logid="0108037894" type="event" subtype="ha" level="critical" vd="root" eventtime=1557507199208575235 logdesc="Virtual cluster member joined" msg="Virtual cluster detected member join" vcluster=1 ha_group=0 sn="FG2K5E3916900286"
+-->
+
+    <rule id="81642" level="3">
+        <if_sid>81603</if_sid>
+        <match>subtype="ha" level="critical"|subtype=ha level=critical</match>
+        <description>Fortigate: Virtual cluster detected member join.</description>
+    </rule>
+
+<!--
+date=2019-05-10 time=15:48:31 logid="0105048038" type="event" subtype="wad" level="error" vd="root" eventtime=1557528511221374615 logdesc="SSL Fatal Alert received" session_id=5f88ddd1 policyid=0 srcip=172.18.70.15 srcport=59880 dstip=91.189.89.223 dstport=443 action="receive" alert="2" desc="unknown ca" msg="SSL Alert received"
+-->
+    <rule id="81643" level="7">
+        <if_sid>81603</if_sid>
+        <match>subtype="wad" level="error"|subtype=wad level=error</match>
+        <action>receive</action>
+        <description>Fortigate: SSL Fatal Alert.</description>
+    </rule>
+
+<!--
+date=2019-05-13 time=16:29:45 logid="0316013056" type="utm" subtype="webfilter" eventtype="ftgd_blk" level="warning" vd="vdom1" eventtime=1557790184975119738 policyid=1 sessionid=381780 srcip=10.1.100.11 srcport=44258 srcintf="port12" srcintfrole="undefined" dstip=185.244.31.158 dstport=80 dstintf="port11" dstintfrole="undefined" proto=6 service="HTTP" hostname="morrishittu.ddns.net" profile="test-webfilter" action="blocked" reqtype="direct" url="/" sentbyte=84 rcvdbyte=0 direction="outgoing" msg="URL belongs to a denied category in policy" method="domain" cat=26 catdesc="Malicious Websites" crscore=30 craction=4194304 crlevel="high"
+-->
+    <rule id="81644" level="6">
+        <if_sid>81603</if_sid>
+        <match>type="utm" subtype="webfilter"|type=utm subtype=webfilter</match>
+        <action>blocked</action>
+        <description>Fortigate: Blocked URL belongs to a denied category in policy.</description>
+    </rule>
+
+<!--
+date=2019-03-28 time=10:55:43 logid="1700062002" type="utm" subtype="ssl" eventtype="ssl-anomalies" level="warning" vd="vdom1" eventtime=1553795742 policyid=1 sessionid=11334 service="HTTPS" srcip=10.1.100.66 srcport=49082 dstip=172.16.200.99 dstport=443 srcintf="port2" srcintfrole="undefined" dstintf="port3" dstintfrole="undefined" proto=6 action="blocked" msg="Server certificate blocked" reason="block-cert-req"
+-->
+
+    <rule id="81645" level="5">
+        <if_sid>81603</if_sid>
+        <match>type="utm" subtype="ssl" eventtype="ssl-anomalies"|type=utm subtype=ssl eventtype=ssl-anomalies</match>
+        <action>blocked</action>
+        <description>Fortigate: SSL anomalies. Blocked connection.</description>
+    </rule>
+<!--
+date=2019-05-15 time=16:28:17 logid="1800063000" type="utm" subtype="cifs" eventtype="cifs-filefilter" level="warning" vd="vdom1" eventtime=1557962895 msg="File was blocked by file filter." direction="incoming" action="blocked" service="CIFS" srcip=10.1.100.11 dstip=172.16.200.44 srcport=56348 dstport=445 srcintf="port21" srcintfrole="undefined" dstintf="port23" dstintfrole="undefined" policyid=1 proto=16 profile="cifs" filesize="13824" filename="sample\\test.xls" filtername="1" filetype="msoffice"
+-->
+    <rule id="81646" level="5">
+        <if_sid>81603</if_sid>
+        <match>type="utm" subtype="cifs" eventtype="cifs-filefilter"|type=utm subtype=cifs eventtype=cifs-filefilter</match>
+        <action>blocked</action>
+        <description>Fortigate: File was blocked by File Filter.</description>
+    </rule>
+
+
 
 </group>

--- a/tools/rules-testing/tests/fortigate.ini
+++ b/tools/rules-testing/tests/fortigate.ini
@@ -17,7 +17,7 @@ alert = 3
 decoder = fortigate-firewall-v4
 
 [Fortigate: 5]
-log 1 pass = date=2016-06-15 time=09:41:35 devname=Device_Name devid=FGTXXXX9999999999 logid=9999999999 type=utm subtype=ips eventtype=signature level=alert vd="root" severity=info srcip=192.168.10.8 dstip=157.55.235.162 srcintf="internal2" dstintf="wan2" policyid=2 sessionid=1473454 action=dropped proto=6 service=tcp/20480 attack="HTTP.Unknown.Tunnelling" srcport=62216 dstport=80 direction=outgoing attackid=107347981 profile="default" ref="http://www.fortinet.com/ids/VID107347981" incidentserialno=1999871775 msg="http_decoder: HTTP.Unknown.Tunnelling,"
+log 1 pass = date=2016-06-15 time=09:41:35 devname=Device_Name devid=FGTXXXX9999999999 logid=9999999999 type=utm subtype=ips eventtype=signature level=alert vd="root" severity=info srcip=192.168.10.8 dstip=157.55.235.162 srcintf="internal2" dstintf="wan2" policyid=2 sessionid=1473454 action=reset proto=6 service=tcp/20480 attack="HTTP.Unknown.Tunnelling" srcport=62216 dstport=80 direction=outgoing attackid=107347981 profile="default" ref="http://www.fortinet.com/ids/VID107347981" incidentserialno=1999871775 msg="http_decoder: HTTP.Unknown.Tunnelling," 
 
 rule = 81610
 alert = 4

--- a/tools/rules-testing/tests/fortigate.ini
+++ b/tools/rules-testing/tests/fortigate.ini
@@ -1,0 +1,257 @@
+[Fortigate: 3 ]
+log 1 pass = Dec 23 11:13:03 date=2011-07-24 time=10: 13:03 devname=Device_Name device_id=FGTXXXX9999999999 log_id=0038016004 type=traffic subtype=other pri=notice vd=root SN=9999999999 duration=0 user=N/A group=N/A rule=0 policyid=0 proto=6 service=tcp app_type=N/A status=deny src=10.3.3.3 srcname=10.3.3.3 dst=10.4.4.4 dstname=10.4.4.4 src_int=N/A dst_int="N/A" sent=0 rcvd=0
+log 2 pass = Mar 24 12:19:43 date=2011-07-25 time=08: 19:42 devname=Name_of_Device device_id=FGXXXX9999999999 log_id=0038016002 type=traffic subtype=other pri=notice vd=root SN=9999999999 duration=0 user=N/A group=N/A rule=0 policyid=0 proto=1 service=3/icmp app_type=N/A status=accept src=10.1.1.1 srcname=10.1.1.1 dst=10.2.2.2 dstname=10.2.2.2 src_int=N/A dst_int="N/A" sent=0 rcvd=0 sent_pkt=0 rcvd_pkt=0 src_port=0 dst_port=0 vpn="N/A" tran_ip=0.0.0.0 tran_port=0 dir_disp=org tran_disp=noop
+
+rule = 81618
+alert = 3
+decoder = fortigate-firewall-v3
+
+
+[Fortigate: 4 ]
+log 1 pass = Feb 20 12:26:25 date=2011-02-20 time=12: 26:24 devname=Device_Name device_id=FGXXXX0000000001 log_id=9999999999 type=traffic subtype=other pri=notice status=deny vd="root" src=10.10.10.10 srcname=10.10.10.10 src_port=1111 dst=10.20.30.40 dstname=10.20.30.40 dst_port=2222 service=65535/tcp proto=6 app_type=N/A duration=0 rule=0 policyid=0 identidx=0 sent=0 rcvd=0 shaper_drop_sent=0 shaper_drop_rcvd=0 perip_drop=0 shaper_sent_name="N/A" shaper_rcvd_name="N/A" perip_name="N/A" vpn="N/A" src_int="Interface Name" dst_int="internal" SN=123456 app="N/A" app_cat="N/A" user="N/A" group="N/A" carrier_ep="N/A"
+log 2 pass = Feb 19 22:00:07 date=2011-02-19 time=22: 00:07 devname=Device_Name device_id=FGXXXX1231231231 log_id=3213213213 type=traffic subtype=other pri=notice status=deny vd="root" src=10.10.10.1 srcname=10.10.10.1 src_port=1111 dst=10.9.8.7 dstname=10.9.8.7 dst_port=2222 service=65535/udp proto=17 app_type=N/A duration=0 rule=0 policyid=0 identidx=0 sent=0 rcvd=0 shaper_drop_sent=0 shaper_drop_rcvd=0 perip_drop=0 shaper_sent_name="N/A" shaper_rcvd_name="N/A" perip_name="N/A" vpn="N/A" src_int="wan1" dst_int="root" SN=333333 app="N/A" app_cat="N/A" user="N/A" group="N/A" carrier_ep="N/A"
+log 3 pass = Feb 20 12:31:11 date=2011-02-20 time=12: 31:09 devname=Name_of_Device device_id=FGXXXX1000000000 log_id=8888888888 type=traffic subtype=other pri=notice status=accept vd="root" src=192.168.0.1 srcname=192.168.0.1 src_port=0 dst=192.168.254.254 dstname=192.168.254.254 dst_port=0 service=11/icmp proto=1 app_type=N/A duration=0 rule=0 policyid=0 identidx=0 sent=0 rcvd=0 shaper_drop_sent=0 shaper_drop_rcvd=0 shaper_sent_name="N/A" shaper_rcvd_name="N/A" perip_name="N/A" vpn="N/A" src_int="root" dst_int="N/A" SN=123412341234 app="N/A" app_cat="N/A" user="N/A" group="N/A" carrier_ep="N/A"
+
+rule = 81618
+alert = 3
+decoder = fortigate-firewall-v4
+
+[Fortigate: 5]
+log 1 pass = date=2016-06-15 time=09:41:35 devname=Device_Name devid=FGTXXXX9999999999 logid=9999999999 type=utm subtype=ips eventtype=signature level=alert vd="root" severity=info srcip=192.168.10.8 dstip=157.55.235.162 srcintf="internal2" dstintf="wan2" policyid=2 sessionid=1473454 action=dropped proto=6 service=tcp/20480 attack="HTTP.Unknown.Tunnelling" srcport=62216 dstport=80 direction=outgoing attackid=107347981 profile="default" ref="http://www.fortinet.com/ids/VID107347981" incidentserialno=1999871775 msg="http_decoder: HTTP.Unknown.Tunnelling,"
+
+rule = 81610
+alert = 4
+decoder = fortigate-firewall-v5
+
+[Fortigate: 5-1]
+log 1 pass = Mar 22 19:21:00 10.10.10.10 date=2016-03-22 time=19:20:46 devname=Text devid=FGT3HD0000000000 logid=0000018000 type=anomaly subtype=anomaly level=alert vd="root" severity=critical srcip=10.10.10.35 dstip=10.10.10.84 srcintf="port2" sessionid=0 action=detected proto=6 service=tcp/36875 count=1903 attack="tcp_syn_flood" srcport=32835 dstport=2960 attackid=100663396 profile="DoS-policy1" ref="http://www.fortinet.com/ids/VID100663396" msg="anomaly: tcp_syn_flood, 2001 > threshold 2000, repeats 1903 times" crscore=50 crlevel=critical
+
+rule = 81628
+alert = 11
+decoder = fortigate-firewall-v5
+
+[Fortigate: 5-2]
+log 1 pass = Mar 22 19:21:00 10.10.10.10 date=2016-03-22 time=19:20:46 devname=Text devid=FGT3HD0000000000 logid=0000018000 type=anomaly subtype=anomaly level=alert vd="root" severity=critical srcip=10.10.10.61 dstip=10.10.10.84 srcintf="port2" sessionid=0 action=dropped proto=6 service=NONE count=9 attack="IP.Bad.Header" attackid=127 profile="N/A" ref="http://www.fortinet.com/ids/VID127" msg="anomaly: IP.Bad.Header, repeats 9 times" crscore=50 crlevel=critical
+
+rule = 81629
+alert = 3
+decoder = fortigate-firewall-v5
+
+[Fortigate: 5-3]
+log 1 pass = date=2016-06-15 time=11:44:46 devname=Device_Name devid=FGTXXXX9999999999 logid=9999999999 type=utm subtype=webfilter eventtype=urlfilter level=warning vd="root" urlfilteridx=3 urlfilterlist="default" policyid=2 sessionid=1563645 user="" srcip=1.2.3.11 srcport=52414 srcintf="internal2" dstip=1.5.5.92 dstport=443 dstintf="wan2" proto=6 service=HTTPS hostname="4-edge-chat.facebook.com" profile="default" action=blocked reqtype=referral url="/p?partition=-2&cb=lz1k&failure=5&sticky_token=274&sticky_pool=atn2c06_chat-proxy" sentbyte=932 rcvdbyte=0 direction=outgoing msg="URL was blocked because it is in the URL filter list" crscore=30 crlevel=high
+log 2 pass = date=2016-06-15 time=23:57:11 devname=Device_Name devid=FGTXXXX9999999999 logid=9999999999 type=utm subtype=webfilter eventtype=urlfilter level=warning vd="root" urlfilteridx=3 urlfilterlist="default" policyid=8 sessionid=42895 user="" srcip=2.5.8.8 srcport=57629 srcintf="internal1" dstip=13.107.4.50 dstport=80 dstintf="wan1" proto=6 service=HTTP hostname="www.download.windowsupdate.com" profile="default" action=blocked reqtype=direct url="/msdownload/update/v3/static/trustedr/en/authrootstl.cab" sentbyte=217 rcvdbyte=0 direction=outgoing msg="URL was blocked because it is in the URL filter list" crscore=30 crlevel=high
+
+
+rule = 81644
+alert = 6
+decoder = fortigate-firewall-v5
+
+
+[Fortigate: 5-4]
+log 1 pass = 2018 Apr 09 16:03:37 inwazuhmgr->172.24.0.253 date=2018-04-09 time=16:03:37 devname=BA-RSYS-FW devid=FG600C3912803212 logid="1059028704" type="utm" subtype="app-ctrl" eventtype="app-ctrl-all" level="information" vd="BA-EXORA" logtime=1523270017 appid=16009 srcip=172.24.42.175 dstip=111.221.29.254 srcport=55139 dstport=443 srcintf="port3" srcintfrole="wan" dstintf="port5" dstintfrole="undefined" proto=6 service="HTTPS" policyid=107 sessionid=3454887534 applist="block-high-risk" appcat="Update" app="MS.Windows.Update" action="pass" hostname="*.vortex-win.data.microsoft.com" incidentserialno=1405558813 url="/" msg="Update: MS.Windows.Update," apprisk="elevated" scertcname="*.vortex-win.data.microsoft.com"
+
+
+rule = 81633
+alert = 3
+decoder = fortigate-firewall-v5
+
+[Fortigate: 5-5]
+log 1 pass = date=2016-06-16 time=09:03:03 devname=Device_Name devid=FGTXXXX9999999999 logid=9999999999 type=event subtype=system level=information vd="root" logdesc="Object attribute configured" user="admin" ui="GUI(4.3.5.8)" action=Edit cfgtid=2162752 cfgpath="firewall.service.custom" cfgobj="Custom-TCP_10443" cfgattr="tcp-portrange[->10443]udp-portrange[->]sctp-portrange[->]" msg="Edit firewall.service.custom Custom-TCP_10443"
+log 2 pass = date=2016-06-16 time=09:03:03 devname=Device_Name devid=FGTXXXX9999999999 logid=9999999999 type=event subtype=system level=information vd="root" logdesc="Object attribute configured" user="admin" ui="GUI(4.3.5.8)" action=Edit cfgtid=2162751 cfgpath="firewall.service.custom" cfgobj="Custom-TCP_10443" cfgattr="protocol[TCP/UDP/SCTP->TCP/UDP/SCTP]udp-portrange[->]sctp-portrange[->]" msg="Edit firewall.service.custom Custom-TCP_10443"
+log 3 pass = date=2016-06-16 time=08:41:14 devname=Mobipay_Firewall devid=FGTXXXX9999999999 logid=0100044546 type=event subtype=system level=information vd="root" logdesc="Attribute configured" user="a@b.com.na" ui="GUI(10.42.8.253)" action=Edit cfgtid=2162733 cfgpath="log.threat-weight" cfgattr="failed-connection[low->medium]" msg="Edit log.threat-weight "
+
+
+rule = 81612
+alert = 3
+decoder = fortigate-firewall-v5
+
+
+[Fortigate: 5-6]
+log 1 pass = date=2016-06-16 time=08:48:28 devname=Device_Name devid=FGTXXXX9999999999 logid=0100032003 type=event subtype=system level=information vd="root" logdesc="Admin logout successful" sn=1466062693 user="a@b.com.na" ui=https(4.3.5.253) action=logout status=success duration=615 state="Config-Changed" reason=exit msg="Administrator a@b.com.na logged out from https(2.3.8.1)"
+
+
+rule = 81616
+alert = 4
+decoder = fortigate-firewall-v5
+
+
+[Fortigate: 5-7]
+log 1 pass = date=2016-06-16 time=16:22:34 devname=Mobipay_Firewall devid=FGTXXXX9999999999 logid=0100032001 type=event subtype=system level=information vd="root" logdesc="Admin login successful" sn=1466090554 user="a@b.com.na" ui=https(10.42.8.253) action=login status=success reason=none profile="super_admin" msg="Administrator a@b.com.na logged in successfully from https(10.42.8.253)"
+
+
+rule = 81626
+alert = 3
+decoder = fortigate-firewall-v5
+
+
+
+[Fortigate: 5-8]
+log 1 pass = date=2016-06-14 time=12:22:01 devname=Device_Name devid=FGTXXXX9999999999 logid=9999999999 type=event subtype=system level=alert vd="root" logdesc="Admin login failed" sn=0 user="gfedhf" ui=https(4.3.5.253) action=login status=failed reason="name_invalid" msg="Administrator gfedhf login failed from https(4.3.5.253) because of invalid user name"
+log 2 pass = date=2016-06-17 time=02:37:41 devname=Mobipay_Firewall devid=FGTXXXX9999999999 logid=0100032002 type=event subtype=system level=alert vd="root" logdesc="Admin login failed" sn=0 user="root" ui=ssh(222.186.130.227) action=login status=failed reason="name_invalid" msg="Administrator root login failed from ssh(222.186.130.227) because of invalid user name"
+
+
+rule = 81606
+alert = 4
+decoder = fortigate-firewall-v5
+
+
+
+[Fortigate: 5-9]
+log 1 pass = date=2016-06-15 time=10:42:31 devname=Device_Name devid=FGTXXXX9999999999 logid=9999999999 type=event subtype=vpn level=error vd="root" logdesc="IPsec DPD failed" msg="IPsec DPD failure" action=dpd remip=1.2.3.4 locip=4.3.2.1 remport=500 locport=500 outintf="wan1" cookies="fsdagfdfgfdgfdg/qwerweafasfefsd" user="N/A" group="N/A" xauthuser="N/A" xauthgroup="N/A" assignip=N/A vpntunnel="BW" status=dpd_failure
+
+
+rule = 81604
+alert = 4
+decoder = fortigate-firewall-v5
+
+
+[Fortigate: 5-10]
+log 1 pass = date=2016-06-16 time=08:47:00 devname=Device_Name devid=FGTXXXX9999999999 logid=0101039947 type=event subtype=vpn level=information vd="root" logdesc="SSL VPN tunnel up" action="tunnel-up" tunneltype="ssl-tunnel" tunnelid=1050355638 remip=9.8.7.7 tunnelip=1.2.4.6 user="my_user_name" group="SSL_VPN" dst_host="N/A" reason="N/A" msg="SSL tunnel established"
+
+
+rule = 81622
+alert = 3
+decoder = fortigate-firewall-v5
+
+
+
+[Fortigate: 5-11]
+log 1 pass = date=2016-06-16 time=08:49:26 devname=Device_Name devid=FGTXXXX9999999999 logid=0101039948 type=event subtype=vpn level=information vd="root" logdesc="SSL VPN tunnel down" action="tunnel-down" tunneltype="ssl-tunnel" tunnelid=1050355638 remip=5.7.8.9 tunnelip=8.4.2.1 user="my_user_name" group="SSL_VPN" dst_host="N/A" reason="N/A" duration=147 sentbyte=2284 rcvdbyte=2630 msg="SSL tunnel shutdown"
+
+
+rule = 81624
+alert = 3
+decoder = fortigate-firewall-v5
+
+
+[Fortigate: 5-12]
+log 1 pass = date=2016-06-16 time=10:19:23 devname=Device_Name devid=FGTXXXX9999999999 logid=0000000013 type=traffic subtype=forward level=notice vd=root srcip=7.3.8.5 srcport=57727 srcintf="internal1" dstip=7.8.9.81 dstport=80 dstintf="wan1" poluuid=d6217c58-8c42-51e5-c3a6-c7766895cbfd sessionid=181876 proto=6 action=deny policyid=8 dstcountry="Reserved" srccountry="Reserved" trandisp=snat transip=160.242.8.82 transport=57727 service="HTTP" appid=107347980 app="Proxy.HTTP" appcat="Proxy" apprisk=critical applist="default" appact=drop-session duration=30 sentbyte=0 rcvdbyte=3042 sentpkt=0 utmaction=block countapp=1 crscore=10 craction=1048576
+log 2 pass = date=2016-06-16 time=10:49:08 devname=Device_Name devid=FGTXXXX9999999999 logid=0000000013 type=traffic subtype=forward level=notice vd=root srcip=4.3.5.161 srcport=51082 srcintf="internal1" dstip=54.192.197.185 dstport=80 dstintf="wan1" poluuid=d6217c58-8c42-51e5-c3a6-c7766895cbfd sessionid=199618 proto=6 action=deny policyid=8 dstcountry="United States" srccountry="Reserved" trandisp=snat transip=160.242.8.82 transport=51082 service="HTTP" appid=6 app="BitTorrent" appcat="P2P" apprisk=high applist="default" appact=drop-session duration=3 sentbyte=60 rcvdbyte=3050 sentpkt=1 utmaction=block countapp=1 crscore=5 craction=1048576
+
+
+rule = 81618
+alert = 3
+decoder = fortigate-firewall-v5
+
+[Fortigate: 5-13]
+log 1 pass = date=2018-05-31 time=08:58:56 devname="BA-RSYS-FW" devid="FG600C3912803212" logid="0211008192" type="utm" subtype="virus" eventtype="infected" level="warning" vd="BA-EXORA" eventtime=1527737336 msg="File is infected." action="blocked" service="HTTP" sessionid=377413095 srcip=172.24.12.52 dstip=164.100.80.203 srcport=64982 dstport=80 srcintf="port5" srcintfrole="undefined" dstintf="port3" dstintfrole="wan" policyid=108 proto=6 direction="incoming" filename="FrontPageImgHandler.ashx" quarskip="File-was-not-quarantined." virus="Malware_Generic.P0" dtype="Virus" ref="http://www.fortinet.com/ve?vn=Malware_Generic.P0" virusid=7024603 url="http://www.karsec.gov.in/FrontPageImgHandler.ashx?id=12" profile="Web-Browsing" agent="Chrome/66.0.3359.181" analyticscksum="a9165dbae34e6e2952270536e95a2bb154dff0cfcdf41315f0796ee14b36123b" analyticssubmit="false" crscore=50 crlevel="critical"
+
+
+rule = 81639
+alert = 5
+decoder = fortigate-firewall-v5
+
+[Fortigate: 5-14]
+log 1 pass = date=2016-06-16 time=09:03:03 devname=Device_Name devid=FGTXXXX9999999999 logid=9999999999 type=event subtype=system level=information vd="root" logdesc="Object attribute configured" user="admin" ui="GUI(4.3.5.8)" action=Add cfgtid=2162750 cfgpath="firewall.service.custom" cfgobj="Custom-TCP_10443" cfgattr="" msg="Add firewall.service.custom Custom-TCP_10443"
+
+rule = 81631
+alert = 3
+decoder = fortigate-firewall-v5
+
+[Fortigate: 5-15]
+log 1 pass = date=2016-06-15 time=21:35:09 devname=Device_Name devid=FGTXXXX9999999999 logid=0101039426 type=event subtype=vpn level=alert vd="root" logdesc="SSL VPN login fail" action="ssl-login-fail" tunneltype="ssl-web" tunnelid=0 remip=2.4.6.8 tunnelip=(null) user="my_user_name" group="N/A" dst_host="N/A" reason="sslvpn_login_unknown_user" msg="SSL user failed to logged in"
+
+rule = 81614
+alert = 4
+decoder = fortigate-firewall-v5
+
+[Fortigate: 6-1]
+log 1 pass = date=2019-05-13 time=11:45:04 logid="0000000013" type="traffic" subtype="forward" level="notice" vd="vdom1" eventtime=1557773104815101919 srcip=10.1.100.11 srcport=60446 srcintf="port12" srcintfrole="undefined" dstip=172.16.200.55 dstport=80 dstintf="port11" dstintfrole="undefined" srcuuid="48420c8a-5c88-51e9-0424-a37f9e74621e" dstuuid="187d6f46-5c86-51e9-70a0-fadcfc349c3e" poluuid="3888b41a-5c88-51e9-cb32-1c32c66b4edf" sessionid=359260 proto=6 action="close" policyid=4 policytype="policy" service="HTTP" dstcountry="Reserved" srccountry="Reserved" trandisp="snat" transip=172.16.200.2 transport=60446 appid=15893 app="HTTP.BROWSER" appcat="Web.Client" apprisk="medium" applist="g-default" duration=1 sentbyte=412 rcvdbyte=2286 sentpkt=6 rcvdpkt=6 wanin=313 wanout=92 lanin=92 lanout=92 utmaction="block" countav=1 countapp=1 crscore=50 craction=2 osname="Ubuntu" mastersrcmac="a2:e9:00:ec:40:01" srcmac="a2:e9:00:ec:40:01" srcserver=0 utmref=65497-770
+log 2 pass = date=2019-05-15 time=15:08:49 logid="0000000013" type="traffic" subtype="forward" level="notice" vd="vdom1" eventtime=1557958129950003945 srcip=10.1.100.22 srcport=50002 srcintf="port12" srcintfrole="undefined" dstip=172.16.100.100 dstport=53 dstintf="port11" dstintfrole="undefined" srcuuid="ae28f494-5735-51e9-f247-d1d2ce663f4b" dstuuid="ae28f494-5735-51e9-f247-d1d2ce663f4b" poluuid="ccb269e0-5735-51e9-a218-a397dd08b7eb" sessionid=6887 proto=17 action="accept" policyid=1 policytype="policy" service="DNS" dstcountry="Reserved" srccountry="Reserved" trandisp="snat" transip=172.16.200.2 transport=50002 duration=180 sentbyte=67 rcvdbyte=207 sentpkt=1 rcvdpkt=1 appcat="unscanned" utmaction="allow" countdns=1 osname="Linux" mastersrcmac="a2:e9:00:ec:40:41" srcmac="a2:e9:00:ec:40:41" srcserver=0 utmref=65495-306
+log 3 pass = date=2019-05-15 time=18:03:41 logid="0000000013" type="traffic" subtype="forward" level="notice" vd="root" eventtime=1557968619 srcip=10.1.100.22 srcport=50798 srcintf="port10" srcintfrole="lan" dstip=195.8.215.136 dstport=443 dstintf="port9" dstintfrole="wan" poluuid="d8ce7a90-7763-51e9-e2be-741294c96f31" sessionid=4414 proto=6 action="client-rst" policyid=1 policytype="policy" service="HTTPS" dstcountry="France" srccountry="Reserved" trandisp="snat" transip=172.16.200.10 transport=50798 appid=16072 app="Dailymotion" appcat="Video/Audio" apprisk="elevated" applist="block-social.media" appact="drop-session" duration=5 sentbyte=1150 rcvdbyte=7039 sentpkt=13 utmaction="block" countapp=3 devtype="Unknown" devcategory="None" mastersrcmac="00:0c:29:51:38:5e" srcmac="00:0c:29:51:38:5e" srcserver=0 utmref=0-330
+
+
+rule = 81618
+alert = 3
+decoder = fortigate-firewall-v6
+
+
+[Fortigate: 6-2]
+log 1 pass = date=2019-05-13 time=11:45:03 logid="0211008192" type="utm" subtype="virus" eventtype="infected" level="warning" vd="vdom1" eventtime=1557773103767393505 msg="File is infected." action="blocked" service="HTTP" sessionid=359260 srcip=10.1.100.11 dstip=172.16.200.55 srcport=60446 dstport=80 srcintf="port12" srcintfrole="undefined" dstintf="port11" dstintfrole="undefined" policyid=4 proto=6 direction="incoming" filename="eicar.com" quarskip="File-was-not-quarantined." virus="EICAR_TEST_FILE" dtype="Virus" ref="http://www.fortinet.com/ve?vn=EICAR_TEST_FILE" virusid=2172 url="http://172.16.200.55/virus/eicar.com" profile="g-default" agent="curl/7.47.0" analyticscksum="275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f" analyticssubmit="false" crscore=50 craction=2 crlevel="critical"
+
+
+rule = 81639
+alert = 5
+decoder = fortigate-firewall-v6
+
+
+
+[Fortigate: 6-3]
+log 1 pass = date=2019-05-13 time=16:29:45 logid="0316013056" type="utm" subtype="webfilter" eventtype="ftgd_blk" level="warning" vd="vdom1" eventtime=1557790184975119738 policyid=1 sessionid=381780 srcip=10.1.100.11 srcport=44258 srcintf="port12" srcintfrole="undefined" dstip=185.244.31.158 dstport=80 dstintf="port11" dstintfrole="undefined" proto=6 service="HTTP" hostname="morrishittu.ddns.net" profile="test-webfilter" action="blocked" reqtype="direct" url="/" sentbyte=84 rcvdbyte=0 direction="outgoing" msg="URL belongs to a denied category in policy" method="domain" cat=26 catdesc="Malicious Websites" crscore=30 craction=4194304 crlevel="high"
+
+
+rule = 81644
+alert = 6
+decoder = fortigate-firewall-v6
+
+
+
+
+
+[Fortigate: 6-4]
+log 1 pass = date=2019-05-15 time=18:03:36 logid="1059028704" type="utm" subtype="app-ctrl" eventtype="app-ctrl-all" level="information" vd="root" eventtime=1557968615 appid=40568 srcip=10.1.100.22 dstip=195.8.215.136 srcport=50798 dstport=443 srcintf="port10" srcintfrole="lan" dstintf="port9" dstintfrole="wan" proto=6 service="HTTPS" direction="outgoing" policyid=1 sessionid=4414 applist="block-social.media" appcat="Web.Client" app="HTTPS.BROWSER" action="pass" hostname="www.dailymotion.com" incidentserialno=1962906680 url="/" msg="Web.Client: HTTPS.BROWSER," apprisk="medium" scertcname="*.dailymotion.com" scertissuer="DigiCert SHA2 High Assurance Server CA"
+
+
+rule = 81633
+alert = 3
+decoder = fortigate-firewall-v6
+
+
+
+
+[Fortigate: 6-5]
+log 1 pass = date=2019-05-15 time=18:03:35 logid="1059028705" type="utm" subtype="app-ctrl" eventtype="app-ctrl-all" level="warning" vd="root" eventtime=1557968615 appid=16072 srcip=10.1.100.22 dstip=195.8.215.136 srcport=50798 dstport=443 srcintf="port10" srcintfrole="lan" dstintf="port9" dstintfrole="wan" proto=6 service="HTTPS" direction="incoming" policyid=1 sessionid=4414 applist="block-social.media" appcat="Video/Audio" app="Dailymotion" action="block" hostname="www.dailymotion.com" incidentserialno=1962906682 url="/" msg="Video/Audio: Dailymotion," apprisk="elevated"
+
+
+rule = 81634
+alert = 3
+decoder = fortigate-firewall-v6
+
+
+
+
+[Fortigate: 6-6]
+log 1 pass = date=2019-05-15 time=17:56:41 logid="0419016384" type="utm" subtype="ips" eventtype="signature" level="alert" vd="root" eventtime=1557968201 severity="critical" srcip=10.1.100.22 srccountry="Reserved" dstip=172.16.200.55 srcintf="port10" srcintfrole="lan" dstintf="port9" dstintfrole="wan" sessionid=4017 action="dropped" proto=6 service="HTTP" policyid=1 attack="Adobe.Flash.newfunction.Handling.Code.Execution" srcport=46810 dstport=80 hostname="172.16.200.55" url="/ips/sig1.pdf" direction="incoming" attackid=23305 profile="block-critical-ips" ref="http://www.fortinet.com/ids/VID23305" incidentserialno=582633933 msg="applications3: Adobe.Flash.newfunction.Handling.Code.Execution," crscore=50 craction=4096 crlevel="critical"
+
+
+rule = 81629
+alert = 3
+decoder = fortigate-firewall-v6
+
+
+
+
+
+[Fortigate: 6-7]
+log 1 pass = date=2019-05-13 time=17:05:59 logid="0720018433" type="utm" subtype="anomaly" eventtype="anomaly" level="alert" vd="vdom1" eventtime=1557792359461869329 severity="critical" srcip=10.1.100.11 srccountry="Reserved" dstip=172.16.200.55 srcintf="port12" srcintfrole="undefined" sessionid=0 action="clear_session" proto=1 service="PING" count=1 attack="icmp_flood" icmpid="0x1474" icmptype="0x08" icmpcode="0x00" attackid=16777316 policyid=1 policytype="DoS-policy" ref="http://www.fortinet.com/ids/VID16777316" msg="anomaly: icmp_flood, 51 > threshold 50" crscore=50 craction=4096 crlevel="critical"
+
+rule = 81630
+alert = 3
+decoder = fortigate-firewall-v6
+
+
+
+
+[Fortigate: 6-8]
+log 1 pass = date=2019-03-28 time=10:44:53 logid="1700062002" type="utm" subtype="ssl" eventtype="ssl-anomalies" level="warning" vd="vdom1" eventtime=1553795092 policyid=1 sessionid=10796 service="HTTPS" srcip=10.1.100.66 srcport=43602 dstip=104.154.89.105 dstport=443 srcintf="port2" srcintfrole="undefined" dstintf="port3" dstintfrole="undefined" proto=6 action="blocked" msg="Server certificate blocked" reason="block-cert-invalid"
+log 2 pass = date=2019-03-28 time=10:51:17 logid="1700062002" type="utm" subtype="ssl" eventtype="ssl-anomalies" level="warning" vd="vdom1" eventtime=1553795476 policyid=1 sessionid=11110 service="HTTPS" srcip=10.1.100.66 srcport=49076 dstip=172.16.200.99 dstport=443 srcintf="port2" srcintfrole="undefined" dstintf="port3" dstintfrole="undefined" proto=6 action="blocked" msg="Server certificate blocked" reason="block-cert-untrusted"
+log 3 pass = date=2019-03-28 time=10:55:43 logid="1700062002" type="utm" subtype="ssl" eventtype="ssl-anomalies" level="warning" vd="vdom1" eventtime=1553795742 policyid=1 sessionid=11334 service="HTTPS" srcip=10.1.100.66 srcport=49082 dstip=172.16.200.99 dstport=443 srcintf="port2" srcintfrole="undefined" dstintf="port3" dstintfrole="undefined" proto=6 action="blocked" msg="Server certificate blocked" reason="block-cert-req"
+log 3 pass = date=2019-03-28 time=10:57:42 logid="1700062053" type="utm" subtype="ssl" eventtype="ssl-anomalies" level="warning" vd="vdom1" eventtime=1553795861 policyid=1 sessionid=11424 service="SMTPS" profile="block-unsupported-ssl" srcip=10.1.100.66 srcport=41296 dstip=172.16.200.99 dstport=8080 srcintf="port2" srcintfrole="undefined" dstintf=unknown-0 dstintfrole="undefined" proto=6 action="blocked" msg="Connection is blocked due to unsupported SSL traffic" reason="malformed input"
+log 4 pass = date=2019-03-28 time=11:00:17 logid="1700062002" type="utm" subtype="ssl" eventtype="ssl-anomalies" level="warning" vd="vdom1" eventtime=1553796016 policyid=1 sessionid=11554 service="HTTPS" srcip=10.1.100.66 srcport=49088 dstip=172.16.200.99 dstport=443 srcintf="port2" srcintfrole="undefined" dstintf="port3" dstintfrole="undefined" proto=6 action="blocked" msg="Server certificate blocked" reason="block-cert-sni-mismatch"
+
+
+
+rule = 81645
+alert = 5
+decoder = fortigate-firewall-v6
+
+
+
+
+[Fortigate: 6-9]
+log 1 pass = date=2019-05-15 time=16:28:17 logid="1800063000" type="utm" subtype="cifs" eventtype="cifs-filefilter" level="warning" vd="vdom1" eventtime=1557962895 msg="File was blocked by file filter." direction="incoming" action="blocked" service="CIFS" srcip=10.1.100.11 dstip=172.16.200.44 srcport=56348 dstport=445 srcintf="port21" srcintfrole="undefined" dstintf="port23" dstintfrole="undefined" policyid=1 proto=16 profile="cifs" filesize="13824" filename="sample\\test.xls" filtername="1" filetype="msoffice"
+
+
+rule = 81646
+alert = 5
+decoder = fortigate-firewall-v6

--- a/tools/rules-testing/tests/fortigate.ini
+++ b/tools/rules-testing/tests/fortigate.ini
@@ -34,7 +34,7 @@ decoder = fortigate-firewall-v5
 log 1 pass = Mar 22 19:21:00 10.10.10.10 date=2016-03-22 time=19:20:46 devname=Text devid=FGT3HD0000000000 logid=0000018000 type=anomaly subtype=anomaly level=alert vd="root" severity=critical srcip=10.10.10.61 dstip=10.10.10.84 srcintf="port2" sessionid=0 action=dropped proto=6 service=NONE count=9 attack="IP.Bad.Header" attackid=127 profile="N/A" ref="http://www.fortinet.com/ids/VID127" msg="anomaly: IP.Bad.Header, repeats 9 times" crscore=50 crlevel=critical
 
 rule = 81629
-alert = 3
+alert = 6
 decoder = fortigate-firewall-v5
 
 [Fortigate: 5-3]
@@ -138,7 +138,7 @@ log 1 pass = date=2018-05-31 time=08:58:56 devname="BA-RSYS-FW" devid="FG600C391
 
 
 rule = 81639
-alert = 5
+alert = 6
 decoder = fortigate-firewall-v5
 
 [Fortigate: 5-14]
@@ -171,7 +171,7 @@ log 1 pass = date=2019-05-13 time=11:45:03 logid="0211008192" type="utm" subtype
 
 
 rule = 81639
-alert = 5
+alert = 6
 decoder = fortigate-firewall-v6
 
 
@@ -204,7 +204,7 @@ log 1 pass = date=2019-05-15 time=18:03:35 logid="1059028705" type="utm" subtype
 
 
 rule = 81634
-alert = 3
+alert = 5
 decoder = fortigate-firewall-v6
 
 
@@ -215,7 +215,7 @@ log 1 pass = date=2019-05-15 time=17:56:41 logid="0419016384" type="utm" subtype
 
 
 rule = 81629
-alert = 3
+alert = 6
 decoder = fortigate-firewall-v6
 
 


### PR DESCRIPTION
Ports changes from #516 to version 4.0, which rewrites the fortigate v5 decoder, adds a decoder for fortigate v6, adds an .ini for testing, and adds and edits a few rules. This PR also edits some of the test cases which were improperly written.