### PR TITLE
[Rebase] Updated web-accesslog decoder (PR #159)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 
+## [v4.0]
+
+### Added
+- Updated the web-accesslog decoders to be able to read logs in rsyslog format.  ([#159](https://github.com/wazuh/wazuh-ruleset/pull/159))
+
 ## [v3.9.0]
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 ## [v4.0]
 
 ### Added
-- Updated the web-accesslog decoders to be able to read logs in rsyslog format.  ([#159](https://github.com/wazuh/wazuh-ruleset/pull/159))
+- Updated the web-accesslog decoders to be able to read logs in rsyslog format.  ([#583](https://github.com/wazuh/wazuh-ruleset/pull/583))
 
 ## [v3.9.0]
 

--- a/decoders/0375-web-accesslog_decoders.xml
+++ b/decoders/0375-web-accesslog_decoders.xml
@@ -25,7 +25,20 @@
 
   2 IPs:
   10.10.10.11 10.10.10.12 - - [10/Apr/2017:13:18:05 -0700] "GET /injection/%0d%0aSet-Cookie HTTP/1.1" 404 271 "-" "Mozilla/5.0 (Windows NT 6.1; WOW64; rv:22.0) Gecko/20100101 Firefox/22.0"
+
+  With rsyslog:
+  - Jan 11 10:13:05 web01 nginx: 192.168.212.1 - - [11/Jan/2018:10:13:05 +0100] "HEAD / HTTP/1.1" 200 0 random.domain.com "-" "curl/7.47.0" - 3e8756565a738d5333c10462c1bf3913 192.168.212.51:80 /data/www/random.domain.com/php/web
+  - Jan 11 10:13:05 web01 nginx: ::ffff:202.194.15.192 190.7.138.180 - [18/Oct/2010:10:48:55 -0500] "GET //php-my-admin/config/config.inc.php?p=phpinfo(); HTTP/1.1" 404 345 "-"  "Mozilla/4.0 (compatible; MSIE 6.0; Windows 98)"
+  - Jan 11 10:13:05 web01 apache: 10.11.12.13 - - - [27/Mar/2017:13:40:40 -0700] "GET /modules.php?name=Search&type=stories&query=qualys&category=-1%20&categ=%20and%201=2%20UNION%20SELECT%200,0,aid,pwd,0,0,0,0,0,0%20from%20nuke_authors/* HTTP/1.0" 404 982 "-" "-"
+  - Jan 11 10:13:05 web01 nginx: domain.com 10.11.12.13 - - [12/Sep/2016:15:24:41 +0000] "GET /url/errors.php?mode=js HTTP/1.1" 200 0 "https://domain.com/tt-rss/" "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/53.0.2785.101 Safari/537.36"
+  - Jan 11 10:13:05 web01 nginx: 10.10.10.11 10.10.10.12 - - [10/Apr/2017:13:18:05 -0700] "GET /injection/%0d%0aSet-Cookie HTTP/1.1" 404 271 "-" "Mozilla/5.0 (Windows NT 6.1; WOW64; rv:22.0) Gecko/20100101 Firefox/22.0"
+  - Jan 11 10:13:05 web01 apache: 10.10.10.11 10.10.10.12 - - [10/Apr/2017:13:18:05 -0700] "GET /injection/%0d%0aSet-Cookie HTTP/1.1" 404 271 "-" "Mozilla/5.0 (Windows NT 6.1; WOW64; rv:22.0) Gecko/20100101 Firefox/22.0"
   -->
+
+<decoder name="web-accesslog">
+    <type>web-log</type>
+    <program_name>nginx|apache</program_name>
+</decoder>
 
 <decoder name="web-accesslog">
     <type>web-log</type>

--- a/tools/rules-testing/tests/web_rules.ini
+++ b/tools/rules-testing/tests/web_rules.ini
@@ -28,7 +28,7 @@ rule = 31104
 alert = 6
 decoder = web-accesslog-iis-default
 
-[SQL Injection Attempt - syslog format]
+[SQL Injection Attempt]
 log 1 pass = 10.11.12.13 - - - [27/Mar/2017:13:40:40 -0700] "GET /modules.php?name=Search&type=stories&query=qualys&category=-1%20&categ=%20and%201=2%20UNION%20SELECT%200,0,aid,pwd,0,0,0,0,0,0%20from%20nuke_authors/* HTTP/1.0" 404 982 "-" "-"
 rule = 31103
 alert = 6

--- a/tools/rules-testing/tests/web_rules.ini
+++ b/tools/rules-testing/tests/web_rules.ini
@@ -28,12 +28,6 @@ rule = 31104
 alert = 6
 decoder = web-accesslog-iis-default
 
-[SQL Injection Attempt]
-log 1 pass = 10.11.12.13 - - - [27/Mar/2017:13:40:40 -0700] "GET /modules.php?name=Search&type=stories&query=qualys&category=-1%20&categ=%20and%201=2%20UNION%20SELECT%200,0,aid,pwd,0,0,0,0,0,0%20from%20nuke_authors/* HTTP/1.0" 404 982 "-" "-"
-rule = 31103
-alert = 6
-decoder = web-accesslog-iis-default
-
 [A web page returned code 404 (not found) - syslog format]
 log 1 pass = Jan 11 10:13:05 web01 nginx: ::ffff:202.194.15.192 190.7.138.180 - [18/Oct/2010:10:48:55 -0500] "GET //php-my-admin/config/config.inc.php?p=phpinfo(); HTTP/1.1" 404 345 "-"  "Mozilla/4.0 (compatible; MSIE 6.0; Windows 98)"
 rule = 31101

--- a/tools/rules-testing/tests/web_rules.ini
+++ b/tools/rules-testing/tests/web_rules.ini
@@ -27,3 +27,27 @@ log 1 pass = 2015-03-11 22:01:59 1.2.3.4 GET /CFIDE/adminapi/customtags/l10n.cfm
 rule = 31104
 alert = 6
 decoder = web-accesslog-iis-default
+
+[SQL Injection Attempt - syslog format]
+log 1 pass = 10.11.12.13 - - - [27/Mar/2017:13:40:40 -0700] "GET /modules.php?name=Search&type=stories&query=qualys&category=-1%20&categ=%20and%201=2%20UNION%20SELECT%200,0,aid,pwd,0,0,0,0,0,0%20from%20nuke_authors/* HTTP/1.0" 404 982 "-" "-"
+rule = 31103
+alert = 6
+decoder = web-accesslog-iis-default
+
+[A web page returned code 404 (not found) - syslog format]
+log 1 pass = Jan 11 10:13:05 web01 nginx: ::ffff:202.194.15.192 190.7.138.180 - [18/Oct/2010:10:48:55 -0500] "GET //php-my-admin/config/config.inc.php?p=phpinfo(); HTTP/1.1" 404 345 "-"  "Mozilla/4.0 (compatible; MSIE 6.0; Windows 98)"
+rule = 31101
+alert = 5
+decoder = web-accesslog
+
+[A web attacked returned code 404 - syslog format]
+log 1 pass = Jan 11 10:13:05 web01 nginx: 10.10.10.11 10.10.10.12 - - [10/Apr/2017:13:18:05 -0700] "GET /injection/%0d%0aSet-Cookie HTTP/1.1" 404 271 "-" "Mozilla/5.0 (Windows NT 6.1; WOW64; rv:22.0) Gecko/20100101 Firefox/22.0"
+rule = 31104
+alert = 6
+decoder = web-accesslog
+
+[SQL Injection Attempt - syslog format]
+log 1 pass = Jan 11 10:13:05 web01 apache: 10.11.12.13 - - - [27/Mar/2017:13:40:40 -0700] "GET /modules.php?name=Search&type=stories&query=qualys&category=-1%20&categ=%20and%201=2%20UNION%20SELECT%200,0,aid,pwd,0,0,0,0,0,0%20from%20nuke_authors/* HTTP/1.0" 404 982 "-" "-"
+rule = 31103
+alert = 6
+decoder = web-accesslog


### PR DESCRIPTION
Ports #159 to 4.0, which allows web access events to be recognized even in rsyslog formats. In addition, some tests for the new functionality has been added to the .ini.