### PR TITLE
[Rebase] Adds Aruba rules and decoders (PR #212)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 
+## [v4.0]
+
+### Added
+- Added rules and decoders for Aruba, the OS used by HP network devices.  ([#585](https://github.com/wazuh/wazuh-ruleset/pull/585))
+
 ## [v3.9.0]
 
 ### Added

--- a/decoders/0470-aruba_decoders.xml
+++ b/decoders/0470-aruba_decoders.xml
@@ -1,0 +1,39 @@
+ruba decoders
+  -  Created by Wazuh, Inc. <support@wazuh.com>.
+  -  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2.
+-->
+
+<!--
+Aruba decoders. Based on logs received with syslog from a HP 2920 switch. To create additional decoders 
+to extract particular fields, place the new decoder before the 
+aruba-others decoder (this one will work as the default one).
+-->
+
+<!--Aruba parent decoder to split these events from the rest-->
+<decoder name="aruba">
+  <prematch>^\s\w\w\w\s*\d+\s*\d+:\d+:\d+\s*\d+.\d+.\d+.\d+\s*\d\d\d\d\d\s*\w+:</prematch>
+</decoder>
+
+<!--Decoder for ports logs-->
+<decoder name="aruba-ports">
+  <parent>aruba</parent>
+  <prematch>^\s\w\w\w\s*\d+\s*\d+:\d+:\d+\s*\d+.\d+.\d+.\d+\s*\d\d\d\d\d\s*ports:\s*port\s*\d*\s*is</prematch>
+  <regex>^\s\w\w\w\s*\d+\s*\d+:\d+:\d+\s*(\d+.\d+.\d+.\d+)\s*(\d\d\d\d\d)\s*(ports):\s* port (\d*) is (\.*)</regex>
+  <order>srcip,id,event_type,srcport,status</order>
+</decoder>
+
+<!--Decoder for SNTP: Server not found logs-->
+<decoder name="aruba-SNTP-1">
+  <parent>aruba</parent>
+  <prematch>^\s\w\w\w\s*\d+\s*\d+:\d+:\d+\s*\d+.\d+.\d+.\d+\s*\d\d\d\d\d\s*SNTP:\s*Server not</prematch>
+  <regex>^\s\w\w\w\s*\d+\s*\d+:\d+:\d+\s*(\d+.\d+.\d+.\d+)\s*(\d\d\d\d\d)\s*(SNTP):\s*Server\s*not\s*found\s*at\s*(\d*.\d*.\d*.\d*)</regex>
+  <order>srcip,id,event_type,srcport,status,sntp_server_ip</order>
+</decoder>
+
+<!--Decoder for the rest of aruba logs-->
+<decoder name="aruba-others">
+  <parent>aruba</parent>
+  <prematch>^\s\w\w\w\s*\d+\s*\d+:\d+:\d+\s*\d+.\d+.\d+.\d+\s*\d\d\d\d\d\s*\w+:</prematch>
+  <regex>^\s\w\w\w\s*\d+\s*\d+:\d+:\d+\s*(\d+.\d+.\d+.\d+)\s*(\d\d\d\d\d)\s*(\w+):(\.*)$</regex>
+  <order>srcip,id,event_type,action</order>
+</decoder>

--- a/rules/0665-aruba_rules.xml
+++ b/rules/0665-aruba_rules.xml
@@ -1,0 +1,76 @@
+<!--
+  -  Aruba rules
+  -  Created by Wazuh, Inc. <support@wazuh.com>.
+  -  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2.
+
+  ID: 91200--88299
+-->
+
+
+
+<!--General rule for grouping Aruba logs-->
+<group name="aruba,hp">
+  <rule id="91200" level="3">
+    <decoded_as>aruba</decoded_as>
+    <description>Aruba device log received (No rule defined for this specific event).</description>
+    <group></group>
+  </rule>
+
+<!--General rule for grouping Aruba SNTP logs-->
+  <rule id="91201" level="3">
+    <if_sid>91200</if_sid>
+    <field name="event_type">SNTP</field>
+    <description>Aruba device SNTP log received (No rule defined for this specific SNTP event).</description>
+    <group></group>
+  </rule>
+
+<!--General rule for grouping Aruba ports logs-->
+  <rule id="91202" level="3">
+    <if_sid>91200</if_sid>
+    <field name="event_type">ports</field>
+    <description>Aruba device ports log received (No rule defined for this specific ports event).</description>
+    <group></group>
+  </rule>
+
+<!--Particular rules-->
+  <rule id="91203" level="3">
+    <if_sid>91201</if_sid>
+    <field name="event_type">SNTP</field>
+    <match>Server not found at</match>
+    <description>Aruba SNTP log: Server not found.</description>
+    <group></group>
+  </rule>
+
+  <rule id="91204" level="3">
+    <if_sid>91201</if_sid>
+    <field name="event_type">SNTP</field>
+    <match>Unable to reach configured SNTP</match>
+    <description>Aruba SNTP log: Unable to reach configured SNTP servers.</description>
+    <group></group>
+  </rule>
+
+  <rule id="91205" level="3">
+    <if_sid>91202</if_sid>
+    <field name="event_type">ports</field>
+    <match>is Blocked by STP</match>
+    <description>Aruba ports log: Port blocked by STP.</description>
+    <group></group>
+  </rule>
+
+  <rule id="91206" level="3">
+    <if_sid>91202</if_sid>
+    <field name="event_type">ports</field>
+    <match>is now on-line</match>
+    <description>Aruba ports log: Port now on-line.</description>
+    <group></group>
+  </rule>
+
+  <rule id="91207" level="3">
+    <if_sid>91202</if_sid>
+    <field name="event_type">ports</field>
+    <match>is now off-line</match>
+    <description>Aruba ports log: Port now off-line.</description>
+    <group></group>
+  </rule>
+
+</group>

--- a/tools/rules-testing/tests/aruba_rules.ini
+++ b/tools/rules-testing/tests/aruba_rules.ini
@@ -1,0 +1,13 @@
+[Aruba server not found]
+log 1 pass =  Sep 27 10:48:29 1.2.3.4 02631 SNTP: Server not found at 1.1.1.1.
+
+rule = 91203
+alert = 3
+decoder = aruba
+
+[Aruba port offline]
+log 1 pass =  Sep 27 10:55:32 1.1.1.1 00077 ports: port 3 is now off-line
+
+rule = 91207
+alert = 3
+decoder = aruba


### PR DESCRIPTION
Ports #212 to the current branch, which adds rules and decoders for Aruba, the OS used in HP network devices.. This PR also fixes an error and a conflict in the rule ID numbers of 212.

Currently a draft until I can solve the issue with testing logs that contain leading spaces.