### PR TITLE
3.13-feature-macOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
-- Added Mac OS sshd rules and decoders ([#593](https://github.com/wazuh/wazuh-ruleset/pull/593))
+- Added rules and decoders for macOS sshd logs ([#593](https://github.com/wazuh/wazuh-ruleset/pull/593))
 
 ## [v3.12.0]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 
+## [v3.13.0] 
+
+### Added
+
+- Added Mac OS sshd rules and decoders ([#593](https://github.com/wazuh/wazuh-ruleset/pull/593))
+
 ## [v3.12.0]
 
 ### Added

--- a/decoders/0500-macos-sshd_decoders.xml
+++ b/decoders/0500-macos-sshd_decoders.xml
@@ -1,0 +1,74 @@
+<decoder name="macos-date-format-sshd">
+  <type>syslog</type>
+  <prematch>^\d\d\d\d-\d\d-\d\d \d\d:\d\d:\d\d.\d\d\d\d\d\d\p\d\d\d\d  \S+ sshd[\d+]: </prematch>
+</decoder>
+
+<decoder name="macos-sshd-success">
+  <parent>macos-date-format-sshd</parent>
+  <prematch offset="after_parent">^Accepted \S+ </prematch>
+  <regex offset="after_prematch">^for (\S+) from (\S+) port (\d+)</regex>
+  <order>user, srcip, srcport</order>
+  <fts>name, user, location</fts>
+</decoder>
+
+
+<decoder name="macos-sshd-error">
+  <parent>macos-date-format-sshd</parent>
+  <prematch>Broken pipe|Bad protocol version</prematch>
+  <regex offset="after_parent">from (\S+) port (\S+)</regex>
+  <order>srcip, srcport</order>
+</decoder>
+
+<decoder name="macos-sshd-rmap">
+  <parent>macos-date-format-sshd</parent>
+  <prematch>but this does not map back</prematch>
+  <regex offset="after_parent">Address (\S+) maps to \S+,</regex>
+  <order>srcip</order>
+</decoder>
+
+<decoder name="macos-sshd-rmap-2">
+  <parent>macos-date-format-sshd</parent>
+  <prematch>reverse mapping</prematch>
+  <regex offset="after_prematch">for (\S+) [(\S+)] </regex>
+  <order>srcuser, srcip</order>
+</decoder>
+
+<decoder name="macos-sshd-reset">
+  <parent>macos-date-format-sshd</parent>
+  <prematch>Connection reset</prematch>
+  <regex offset="after_prematch">(\S+) (\S+) port (\d+)</regex>
+  <order>user, srcip, srcport</order>
+</decoder>
+
+<decoder name="macos-sshd-disconnect">
+  <parent>macos-date-format-sshd</parent>
+  <prematch>Disconnected from user </prematch>
+  <regex offset="after_prematch">^(\S+) (\S+) port (\d+)</regex>
+  <order>srcuser,srcip,srcport</order>
+</decoder>
+
+<decoder name="macos-sshd-insecure-connection">
+  <parent>macos-date-format-sshd</parent>
+  <prematch>Did not receive</prematch>
+  <regex offset="after_parent">from (\S+) port (\S+)</regex>
+  <order>srcip, srcport</order>
+</decoder>
+
+<decoder name="macos-sshd-closed">
+  <parent>macos-date-format-sshd</parent>
+  <prematch>Connection closed</prematch>
+  <regex offset="after_prematch">by (\S+) port (\S+)</regex>
+  <order>srcip, srcport</order>
+</decoder>
+
+<decoder name="macos-sshd-from">
+  <parent>macos-date-format-sshd</parent>
+  <regex>user (\S+) from (\S+)|for (\S+) from (\S+)</regex>
+  <order>srcuser, srcip</order>
+</decoder>
+
+<decoder name="macos-sshd-from">
+  <parent>macos-date-format-sshd</parent>
+  <regex>port (\d+)</regex>
+  <order>srcport</order>
+</decoder>

--- a/rules/0685-macos-sshd_rules.xml
+++ b/rules/0685-macos-sshd_rules.xml
@@ -1,0 +1,107 @@
+<group name="mac-os-sshd">
+
+<rule id="64250" level="0">
+  <decoded_as>macos-date-format-sshd</decoded_as>
+  <description>Grouping macos sshd rules.</description>
+</rule>
+
+<rule id="64251" level="5">
+  <if_sid>64250</if_sid>
+  <match>illegal user</match>
+  <description>sshd: Attempt to login using a non-existent user.</description>
+  <group>invalid_login,authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_10.6.1,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.14,nist_800_53_AC.7,nist_800_53_AU.6,</group>
+</rule>
+
+
+<rule id="64252" level="10" frequency="8" timeframe="120" ignore="60">
+  <if_matched_sid>64251</if_matched_sid>
+  <description>sshd: brute force trying to get access to </description>
+  <description>the system.</description>
+  <same_source_ip />
+  <group>authentication_failures,pci_dss_11.4,pci_dss_10.2.4,pci_dss_10.2.5,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_SI.4,nist_800_53_AU.14,nist_800_53_AC.7,</group>
+</rule>
+
+<rule id="64253" level="5">
+  <if_sid>64250</if_sid>
+  <match>Failed password|Failed keyboard|authentication error</match>
+  <description>sshd: authentication failed.</description>
+  <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.14,nist_800_53_AC.7,</group>
+</rule>
+
+<rule id="64254" level="8">
+  <if_sid>64250</if_sid>
+  <match>error: maximum authentication attempts</match>
+  <description>Maximum authentication attempts exceeded.</description>
+  <group>authentication_failed,gpg13_7.1,</group>
+</rule>
+
+<rule id="64255" level="0">
+  <if_sid>64250</if_sid>
+  <match>Connection closed|Disconnected from user</match>
+  <description>sshd: ssh connection closed.</description>
+  <group>pci_dss_10.2.5,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.14,nist_800_53_AC.7,</group>
+</rule>
+
+<rule id="64256" level="3">
+  <if_sid>64250</if_sid>
+  <match>Accepted</match>
+  <description>sshd: authentication success</description>
+  <group>authentication_success,pci_dss_10.2.5,gpg13_7.1,gpg13_7.2,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.14,nist_800_53_AC.7,</group>
+</rule>
+
+<rule id="64257" level="6">
+  <if_sid>64250</if_sid>
+  <match>Did not receive identification string from</match>
+  <description>sshd: insecure connection attempt (scan).</description>
+  <group>recon,pci_dss_11.4,gpg13_4.12,gdpr_IV_35.7.d,nist_800_53_SI.4,</group>
+</rule>
+
+<rule id="64258" level="0">
+  <if_sid>64250</if_sid>
+  <match>Broken pipe</match>
+  <description>sshd: Failed write due to one host disappearing.</description>
+</rule>
+
+<rule id="64259" level="4">
+  <if_sid>64250</if_sid>
+  <match>Connection reset</match>
+  <description>sshd: connection reset</description>
+</rule>
+
+<rule id="64260" level="5">
+  <if_sid>64250</if_sid>
+  <match>not listed in AllowUsers|listed in DenyUsers</match>
+  <description>sshd: Attempt to login using a denied user</description>
+  <group>invalid_login,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.14,nist_800_53_AC.7,</group>
+</rule>
+
+<rule id="64261" level="10" frequency="8" timeframe="120" ignore="60">
+  <if_matched_sid>64260</if_matched_sid>
+  <description>sshd: Multiple access attempts using a denied user.</description>
+  <group>invalid_login,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.14,nist_800_53_AC.7,nist_800_53_SI.4,</group>
+</rule>
+
+<rule id="64262" level="5">
+  <if_sid>64250</if_sid>
+  <match>reverse mapping|but this does not map back</match>
+  <description>sshd: Reverse lookup error (bad ISP or attack).</description>
+  <group>pci_dss_11.4,gpg13_4.12,gdpr_IV_35.7.d,nist_800_53_SI.4,</group>
+</rule>
+
+<rule id="64263" level="10" frequency="6" timeframe="360">
+  <if_matched_sid>64262</if_matched_sid>
+  <same_source_ip />
+  <description>sshd: Possible breakin attempt </description>
+  <description>(high number of reverse lookup errors).</description>
+  <group>pci_dss_11.4,gpg13_4.12,gdpr_IV_35.7.d,nist_800_53_SI.4,</group>
+</rule>
+
+<rule id="64264" level="8">
+  <if_sid>64250</if_sid>
+  <match>Bad protocol version identification</match>
+  <description>sshd: Possible attack on the ssh server </description>
+  <description>(or version gathering).</description>
+  <group>recon,pci_dss_11.4,gpg13_4.12,gdpr_IV_35.7.d,nist_800_53_SI.4,</group>
+</rule>
+
+</group>

--- a/tools/rules-testing/tests/macos-sshd.ini
+++ b/tools/rules-testing/tests/macos-sshd.ini
@@ -1,0 +1,94 @@
+[SSHD Attempt to login using a non-existent user]
+log 1 pass = 2020-03-23 06:47:42.801612-0700  localhost sshd[3186]: error: PAM: unknown user for illegal user badguy from 192.168.33.1
+log 2 pass = 2020-03-23 08:14:02.777660-0700  localhost sshd[8981]: error: PAM: authentication error for illegal user badguy from 192.168.33.1
+
+rule = 64251
+alert = 5
+decoder = macos-date-format-sshd
+
+[SSHD Authentication error]
+log 1 pass = 2020-03-23 09:55:42.391078-0700  localhost sshd[17329]: error: PAM: authentication error for user from 192.168.33.1
+log 2 pass = 2020-03-24 08:38:42.344447-0700  localhost sshd[2519]: Failed password for user from 172.18.1.100 port 43042 ssh2
+log 3 pass = 2020-03-25 08:01:34.584936-0700  localhost sshd[1551]: Failed keyboard-interactive/pam for invalid user user from 172.18.1.1 port 32982 ssh2
+
+rule = 64253
+alert = 5
+decoder = macos-date-format-sshd
+
+[SSHD Maximum authentication attempts exceeded]
+log 1 pass = 2020-03-23 08:14:32.766049-0700  localhost sshd[8981]: error: maximum authentication attempts exceeded for invalid user badguy from 192.168.33.1 port 55146 ssh2 [preauth]
+log 2 pass = 2020-03-23 09:58:27.102292-0700  localhost sshd[18093]: error: maximum authentication attempts exceeded for user from 192.168.33.1 port 55764 ssh2 [preauth]
+
+rule = 64254
+alert = 8
+decoder = macos-date-format-sshd
+
+[SSHD Disconnect]
+log 1 pass = 2020-03-24 06:07:15.245255-0700  localhost sshd[195]: Connection closed by 10.0.2.2 port 55462 [preauth]
+log 2 pass = 2020-03-24 08:38:47.230409-0700  localhost sshd[2531]: Disconnected from user user 172.18.1.100 port 43042
+
+rule = 64255
+alert = 0
+decoder = macos-date-format-sshd
+
+[SSHD Authentication success]
+
+log 1 pass = 2020-03-24 06:07:50.998187-0700  localhost sshd[201]: Accepted publickey for user from 10.0.2.2 port 55468 ssh2: RSA SHA256:loremipsum
+log 2 pass = 2020-03-24 08:38:44.727732-0700  localhost sshd[2519]: Accepted password for user from 172.18.1.100 port 43042 ssh2
+log 3 pass = 2020-03-24 08:40:21.958634-0700  localhost sshd[2546]: Accepted keyboard-interactive/pam for user from 172.18.1.100 port 43044 ssh2
+
+rule = 64256
+alert = 3
+decoder = macos-date-format-sshd
+
+[SSHD insecure connection attempt]
+
+log 1 pass = 2020-03-24 10:32:31.672920-0700  localhost sshd[5374]: Did not receive identification string from 172.18.1.1 port 45824
+
+rule = 64257
+alert = 6
+decoder = macos-date-format-sshd
+
+[SSHD: Failed write]
+
+log 1 pass = 2020-03-25 08:31:48.061459-0700  localhost sshd[2024]: ssh_dispatch_run_fatal: Connection from 172.18.1.202 port 54392: Broken pipe [preauth]
+log 2 pass = 2020-03-23 06:08:41.939744-0700  localhost sshd[287]: fatal: ssh_packet_send_debug: Broken pipe
+
+rule = 64258
+alert = 0
+decoder = macos-date-format-sshd
+
+[SSHD: connection reset]
+
+log 1 pass = 2020-03-25 08:23:20.933154-0700  localhost sshd[9265]: Connection reset by authenticating user user 192.168.33.1 port 51772 [preauth]
+
+rule = 64259
+alert = 4
+decoder = macos-date-format-sshd
+
+[SSHD: denied user]
+
+log 1 pass = 2020-03-25 07:46:15.205351-0700  localhost sshd[6738]: User root from 192.168.33.1 not allowed because not listed in AllowUsers
+log 2 pass = 2020-03-31 13:15:57.368975-0700  localhost sshd[2440]: User root from 172.18.1.100 not allowed because listed in DenyUsers
+
+rule = 64260
+alert = 5
+decoder = macos-date-format-sshd
+
+[SSHD: Reverse lookup error]
+
+log 1 pass = 2020-03-25 09:01:30.852002-0700  localhost sshd[11885]: Address 192.168.33.1 maps to hostname, but this does not map back to the address.
+log 2 pass = 2020-03-25 09:18:41.510217-0700  localhost sshd[2549]: reverse mapping checking getaddrinfo for hostname [172.18.1.1] failed.
+
+rule = 64262
+alert = 5
+decoder = macos-date-format-sshd
+
+[SSHD: possible attack]
+
+log 1 pass = 2020-03-25 06:37:50.176931-0700  localhost sshd[852]: Bad protocol version identification 'ls' from 172.18.1.1 port 59920
+
+
+rule = 64264
+alert = 8
+decoder = macos-date-format-sshd


### PR DESCRIPTION
As outlined in issue #590, SSH events from MacOS do not trigger alerts on Wazuh. This pull request aims to fix that by creating new rules and decoders to both parse the MacOS date format and generate alerts in spite of log differences.