### PR TITLE
[Rebase] Extract dstuser nginx decoders (Branch: 3.12-rebase-old-PRs) (Issue: #597)

### DIFF
--- a/decoders/0170-nginx_decoders.xml
+++ b/decoders/0170-nginx_decoders.xml
@@ -8,10 +8,12 @@
 -->
 
 <!--
-  - Will extract the srcip.
+  - Will extract the srcip. Additionally extract the username for basic authentication if present.
   - Examples:
   - 2009/09/15 20:55:40 [error] 63858#0: *3663 open() "/srv/www/ossec.net/robots.txt" failed (2: No such file or directory), client: 1.2.3.4, server: ossec.net, request: "GET /robots.txt HTTP/1.1", host: "www.ossec.net"
   - 2009/09/15 19:51:07 [error] 37992#0: accept() failed (53: Software caused connection abort)
+  - 2018/05/26 06:46:11 [error] 31963#31963: *28769 user "test user" was not found in "/etc/nginx/conf.d/users.htpasswd", client: 1.2.3.4, server: example.com, request: "GET / HTTP/1.1", host: "example.com"
+  - 2018/05/27 10:22:20 [error] 31972#31972: *52363 user "user2": password mismatch, client: 1.2.3.4, server: example.com, request: "GET / HTTP/2.0", host: "example.com"
   -->
 <decoder name="nginx-errorlog">
   <prematch>^20\d\d/\d\d/\d\d \d\d:\d\d:\d\d [</prematch>
@@ -27,6 +29,19 @@ Extract NAXSI WAF alert information https://github.com/nbs-system/naxsi/wiki/nax
   <prematch offset="after_parent">NAXSI_FMT:</prematch>
   <regex offset="after_parent">ip=(\S+)&server=(\S+)&uri=(\S+)&learning=(\d+)&vers=(\S+)&total_processed=(\d+)&total_blocked=(\d+)&block=(\d+)&cscore0=(\S+)&score0=(\S+)&</regex>
   <order>srcip,server,uri,learning,vers,total_processed,total_blocked,block,attack,score</order>
+</decoder>
+
+<decoder name="nginx-errorlog-user-ip">
+  <parent>nginx-errorlog</parent>
+  <prematch offset="after_parent"> user "\.+"</prematch>
+  <regex offset="after_parent"> user "(\.+)"</regex>
+  <order>dstuser</order>
+</decoder>
+
+<decoder name="nginx-errorlog-user-ip">
+  <parent>nginx-errorlog</parent>
+  <regex offset="after_regex">client: (\S+),</regex>
+  <order>srcip</order>
 </decoder>
 
 <decoder name="nginx-errorlog-ip">


### PR DESCRIPTION
Hi team,

This is a rebase from PR [#151] to add new decoders able to extract 'dstuser' field on Nginx basic authentication logs (decoders/0170-nginx_decoders.xml).