### PR TITLE
Fixes individual file tests in runtests.py

### DIFF
--- a/tools/rules-testing/runtests.py
+++ b/tools/rules-testing/runtests.py
@@ -133,10 +133,10 @@ if __name__ == "__main__":
             selective_test += '.ini'
     else:
         selective_test = False
-        ossec_init = {}
-        initconfigpath = "/etc/ossec-init.conf"
-        getOssecConfig(ossec_init, initconfigpath)
-        provisionDR(ossec_init["DIRECTORY"])
-        OT = OssecTester(ossec_init["DIRECTORY"])
-        OT.run(selective_test)
-        cleanDR(ossec_init["DIRECTORY"])
+    ossec_init = {}
+    initconfigpath = "/etc/ossec-init.conf"
+    getOssecConfig(ossec_init, initconfigpath)
+    provisionDR(ossec_init["DIRECTORY"])
+    OT = OssecTester(ossec_init["DIRECTORY"])
+    OT.run(selective_test)
+    cleanDR(ossec_init["DIRECTORY"])


### PR DESCRIPTION
Fixes issue #599 . PR #413 accidentally broke testing individual `.ini` test files by passing it as an argument in the test script. This PR restores this functionality by moving the run tests function outside of an `if`/`else:` block in `main`.