### PR TITLE
Fixed 51004 Trigger Conditions

### DIFF
--- a/rules/0305-dropbear_rules.xml
+++ b/rules/0305-dropbear_rules.xml
@@ -41,7 +41,7 @@
   </rule>
 
   <rule id="51004" level="10" frequency="8" timeframe="120" ignore="60">
-    <if_matched_group>authentication_failed</if_matched_group>
+    <if_matched_sid>51093</if_matched_sid>
     <same_source_ip />
     <description>Dropbear: dropbear brute force attempt.</description>
     <group>authentication_failures,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,pci_dss_8.1.5,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,hipaa_164.312.a.1,nist_800_53_AU.14,nist_800_53_AC.7,nist_800_53_SI.4,nist_800_53_AC.2,</group>


### PR DESCRIPTION
Rule ID 51004 was set to <if_matched_group>authentication_failed</if_matched_group>, meaning it would trigger on random multiple auth failures. Changed to <if_matched_sid>51093</if_matched_sid> to fix :)