### PR TITLE
Fixing duplicated alerts descriptions

### DIFF
--- a/rules/0520-vulnerability-detector_rules.xml
+++ b/rules/0520-vulnerability-detector_rules.xml
@@ -10,7 +10,7 @@
     <decoded_as>json</decoded_as>
     <options>no_full_log</options>
     <field name="vulnerability.cve">\.+</field>
-    <description>$(vulnerability.title)</description>
+    <description>$(vulnerability.cve) affects $(vulnerability.package.name)</description>
   </rule>
 
 
@@ -18,7 +18,7 @@
       <if_sid>23501</if_sid>
       <options>no_full_log</options>
       <field name="vulnerability.severity">Low</field>
-      <description>$(vulnerability.title)</description>
+      <description>$(vulnerability.cve) affects $(vulnerability.package.name)</description>
   </rule>
 
   <rule id="23507" level="4">
@@ -32,7 +32,7 @@
       <if_sid>23501</if_sid>
       <options>no_full_log</options>
       <field name="vulnerability.severity">Medium|-</field>
-      <description>$(vulnerability.title)</description>
+      <description>$(vulnerability.cve) affects $(vulnerability.package.name)</description>
   </rule>
 
   <rule id="23508" level="6">
@@ -46,7 +46,7 @@
       <if_sid>23501</if_sid>
       <options>no_full_log</options>
       <field name="vulnerability.severity">High</field>
-      <description>$(vulnerability.title)</description>
+      <description>$(vulnerability.cve) affects $(vulnerability.package.name).</description>
   </rule>
 
   <rule id="23509" level="9">
@@ -60,7 +60,7 @@
       <if_sid>23501</if_sid>
       <options>no_full_log</options>
       <field name="vulnerability.severity">Critical</field>
-      <description>$(vulnerability.title)</description>
+      <description>$(vulnerability.cve) affects $(vulnerability.package.name).</description>
   </rule>
 
   <rule id="23510" level="12">

--- a/rules/0520-vulnerability-detector_rules.xml
+++ b/rules/0520-vulnerability-detector_rules.xml
@@ -25,7 +25,7 @@
       <if_sid>23503</if_sid>
       <options>no_full_log</options>
       <field name="vulnerability.package.condition">Could not</field>
-      <description>It was not possible to verify whether $(vulnerability.cve) affects $(vulnerability.package.name).</description>
+      <description>It was not possible to verify whether $(vulnerability.cve) affects $(vulnerability.package.name)</description>
   </rule>
 
   <rule id="23504" level="7">
@@ -39,35 +39,35 @@
       <if_sid>23504</if_sid>
       <options>no_full_log</options>
       <field name="vulnerability.package.condition">Could not</field>
-      <description>It was not possible to verify whether $(vulnerability.cve) affects $(vulnerability.package.name).</description>
+      <description>It was not possible to verify whether $(vulnerability.cve) affects $(vulnerability.package.name)</description>
   </rule>
 
   <rule id="23505" level="10">
       <if_sid>23501</if_sid>
       <options>no_full_log</options>
       <field name="vulnerability.severity">High</field>
-      <description>$(vulnerability.cve) affects $(vulnerability.package.name).</description>
+      <description>$(vulnerability.cve) affects $(vulnerability.package.name)</description>
   </rule>
 
   <rule id="23509" level="9">
       <if_sid>23505</if_sid>
       <options>no_full_log</options>
       <field name="vulnerability.package.condition">Could not</field>
-      <description>It was not possible to verify whether $(vulnerability.cve) affects $(vulnerability.package.name).</description>
+      <description>It was not possible to verify whether $(vulnerability.cve) affects $(vulnerability.package.name)</description>
   </rule>
 
   <rule id="23506" level="13">
       <if_sid>23501</if_sid>
       <options>no_full_log</options>
       <field name="vulnerability.severity">Critical</field>
-      <description>$(vulnerability.cve) affects $(vulnerability.package.name).</description>
+      <description>$(vulnerability.cve) affects $(vulnerability.package.name)</description>
   </rule>
 
   <rule id="23510" level="12">
       <if_sid>23506</if_sid>
       <options>no_full_log</options>
       <field name="vulnerability.package.condition">Could not</field>
-      <description>It was not possible to verify whether $(vulnerability.cve) affects $(vulnerability.package.name).</description>
+      <description>It was not possible to verify whether $(vulnerability.cve) affects $(vulnerability.package.name)</description>
   </rule>
 
 </group>


### PR DESCRIPTION
This pull request modifies the string displayed in the `description` field of the `vulnerability-detector` alerts. The main purpose id to avoid a duplicated data with the `rationale` or `title` field of the alert.

Here is an example of how an alert looks now:

```json
{
    "timestamp": "2020-04-30T20:51:55.526-0300",
    "rule": {
        "level": 10,
        "description": "CVE-2016-6489 affects libhogweed4.",
        "id": "23505",
        "firedtimes": 1122,
        "mail": false,
        "groups": [
            "vulnerability-detector"
        ],
        "gdpr": [
            "IV_35.7.d"
        ],
        "pci_dss": [
            "11.2.1",
            "11.2.3"
        ]
    },
    "agent": {
        "id": "001",
        "name": "ubuntu18-wagent",
        "ip": "192.168.0.124"
    },
    "manager": {
        "name": "centos8-wserver"
    },
    "id": "1588290715.8232793",
    "decoder": {
        "name": "json"
    },
    "data": {
        "vulnerability": {
            "cve": "CVE-2016-6489",
            "title": "The RSA and DSA decryption code in Nettle makes it easier for attackers to discover private keys via a cache side channel attack.",
            "severity": "High",
            "alert_origin": "NVD feed",
            "published": "2017-04-14",
            "updated": "2017-07-01",
            "state": "Pending confirmation",
            "cvss": {
                "cvss2": {
                    "vector": {
                        "attack_vector": "network",
                        "access_complexity": "low",
                        "authentication": "none",
                        "confidentiality_impact": "low",
                        "integrity_impact": "none",
                        "availability": "none"
                    },
                    "base_score": "5"
                },
                "cvss3": {
                    "vector": {
                        "attack_vector": "network",
                        "access_complexity": "low",
                        "confidentiality_impact": "low",
                        "integrity_impact": "none",
                        "availability": "none",
                        "privileges_required": "none",
                        "user_interaction": "none",
                        "scope": "unchanged"
                    },
                    "base_score": "7.500000"
                }
            },
            "package": {
                "name": "libhogweed4",
                "source": "nettle",
                "version": "3.4-1",
                "architecture": "amd64",
                "condition": "CVE-2016-6489 reports as vulnerable all the versions of this package"
            },
            "cwe_reference": "CWE-310",
            "references": [
                "http://rhn.redhat.com/errata/RHSA-2016-2582.html",
                "http://www.openwall.com/lists/oss-security/2016/07/29/7",
                "http://www.ubuntu.com/usn/USN-3193-1",
                "https://bugzilla.redhat.com/show_bug.cgi?id=1362016",
                "https://eprint.iacr.org/2016/596.pdf",
                "https://git.lysator.liu.se/nettle/nettle/commit/3fe1d6549765ecfb24f0b80b2ed086fdc818bff3",
                "https://security.gentoo.org/glsa/201706-21",
                "https://www.oracle.com/security-alerts/cpuapr2020.html"
            ],
            "assigner": "cve@mitre.org",
            "cve_version": "4.0"
        }
    },
    "location": "vulnerability-detector"
}
```

This pull request replaces [pull 634](https://github.com/wazuh/wazuh-ruleset/pull/634).