### PR TITLE
Fixed static filters related to the system_name field

### DIFF
--- a/tools/rules-testing/rules/test_rules.xml
+++ b/tools/rules-testing/rules/test_rules.xml
@@ -202,16 +202,16 @@
   <description>Same status works</description>
 </rule>
 
-<!-- Trigger alerts which depend on same_systemname. -->
-<!-- Dec 19 17:20:08 User test_same_filters[12345]:Test same_systemname 'Srcuser' 'User' logged from 192.168.1.100:8 to 192.168.5.4:20 pro:ftp act:remove id:1 url:ossec dat:huzaw e_data:hwazu sta:rejected systemname:system1 -->
+<!-- Trigger alerts which depend on same_system_name. -->
+<!-- Dec 19 17:20:08 User test_same_filters[12345]:Test same_system_name 'Srcuser' 'User' logged from 192.168.1.100:8 to 192.168.5.4:20 pro:ftp act:remove id:1 url:ossec dat:huzaw e_data:hwazu sta:rejected systemname:system1 -->
 <rule id="999233" level="3">
-  <match>Test same_systemname</match>
-  <description>Testing same_systemname</description>
+  <match>Test same_system_name</match>
+  <description>Testing same_system_name</description>
 </rule>
 
 <rule id="999234" level="7" frequency="4" timeframe="300">
   <if_matched_sid>999233</if_matched_sid>
-  <same_systemname />
+  <same_system_name />
   <description>Same system_name works</description>
 </rule>
 
@@ -371,16 +371,16 @@
   <description>Different status works</description>
 </rule>
 
-<!-- Trigger alerts which depend on different_systemname. -->
-<!-- Dec 19 17:20:08 User test_different_filters[12345]:Test different_systemname 'Srcuser' 'User' logged from 192.168.1.100:8 to 192.168.5.4:20 pro:ftp act:remove id:1 url:ossec dat:huzaw e_data:hwazu sta:rejected systemname:system1 -->
+<!-- Trigger alerts which depend on different_system_name. -->
+<!-- Dec 19 17:20:08 User test_different_filters[12345]:Test different_system_name 'Srcuser' 'User' logged from 192.168.1.100:8 to 192.168.5.4:20 pro:ftp act:remove id:1 url:ossec dat:huzaw e_data:hwazu sta:rejected systemname:system1 -->
 <rule id="999259" level="3">
-  <match>Test different_systemname</match>
-  <description>Testing different_systemname</description>
+  <match>Test different_system_name</match>
+  <description>Testing different_system_name</description>
 </rule>
 
 <rule id="999260" level="7" frequency="4" timeframe="300">
   <if_matched_sid>999259</if_matched_sid>
-  <different_systemname />
+  <different_system_name />
   <description>Different system_name works</description>
 </rule>
 

--- a/tools/rules-testing/tests/static_filters.ini
+++ b/tools/rules-testing/tests/static_filters.ini
@@ -154,14 +154,14 @@ rule = 999232
 alert = 7
 decoder = test_same_filters
 
-[same_fields: same_systemname]
-log 1 pass = Dec 19 17:20:08 User test_same_filters[12345]:Test same_systemname 'Srcuser' 'User' logged from 192.168.1.100:8 to 192.168.5.4:20 pro:ftp act:remove id:1 url:ossec dat:huzaw e_data:hwazu sta:rejected systemname:system1
-log 1 pass = Dec 19 17:20:08 User test_same_filters[12345]:Test same_systemname 'Srcuser' 'User' logged from 192.168.1.100:8 to 192.168.5.4:20 pro:ftp act:remove id:1 url:ossec dat:huzaw e_data:hwazu sta:rejected systemname:system1
-log 1 pass = Dec 19 17:20:08 User test_same_filters[12345]:Test same_systemname 'Srcuser' 'User' logged from 192.168.1.100:8 to 192.168.5.4:20 pro:ftp act:remove id:1 url:ossec dat:huzaw e_data:hwazu sta:rejected systemname:system1
-log 1 pass = Dec 19 17:20:08 User test_same_filters[12345]:Test same_systemname 'Srcuser' 'User' logged from 192.168.1.100:8 to 192.168.5.4:20 pro:ftp act:remove id:1 url:ossec dat:huzaw e_data:hwazu sta:rejected systemname:system100
-log 1 pass = Dec 19 17:20:08 User test_same_filters[12345]:Test same_systemname 'Srcuser' 'User' logged from 192.168.1.100:8 to 192.168.5.4:20 pro:ftp act:remove id:1 url:ossec dat:huzaw e_data:hwazu sta:rejected systemname:system100
-log 1 pass = Dec 19 17:20:08 User test_same_filters[12345]:Test same_systemname 'Srcuser' 'User' logged from 192.168.1.100:8 to 192.168.5.4:20 pro:ftp act:remove id:1 url:ossec dat:huzaw e_data:hwazu sta:rejected systemname:system100
-log 1 pass = Dec 19 17:20:08 User test_same_filters[12345]:Test same_systemname 'Srcuser' 'User' logged from 192.168.1.100:8 to 192.168.5.4:20 pro:ftp act:remove id:1 url:ossec dat:huzaw e_data:hwazu sta:rejected systemname:system1
+[same_fields: same_system_name]
+log 1 pass = Dec 19 17:20:08 User test_same_filters[12345]:Test same_system_name 'Srcuser' 'User' logged from 192.168.1.100:8 to 192.168.5.4:20 pro:ftp act:remove id:1 url:ossec dat:huzaw e_data:hwazu sta:rejected systemname:system1
+log 1 pass = Dec 19 17:20:08 User test_same_filters[12345]:Test same_system_name 'Srcuser' 'User' logged from 192.168.1.100:8 to 192.168.5.4:20 pro:ftp act:remove id:1 url:ossec dat:huzaw e_data:hwazu sta:rejected systemname:system1
+log 1 pass = Dec 19 17:20:08 User test_same_filters[12345]:Test same_system_name 'Srcuser' 'User' logged from 192.168.1.100:8 to 192.168.5.4:20 pro:ftp act:remove id:1 url:ossec dat:huzaw e_data:hwazu sta:rejected systemname:system1
+log 1 pass = Dec 19 17:20:08 User test_same_filters[12345]:Test same_system_name 'Srcuser' 'User' logged from 192.168.1.100:8 to 192.168.5.4:20 pro:ftp act:remove id:1 url:ossec dat:huzaw e_data:hwazu sta:rejected systemname:system100
+log 1 pass = Dec 19 17:20:08 User test_same_filters[12345]:Test same_system_name 'Srcuser' 'User' logged from 192.168.1.100:8 to 192.168.5.4:20 pro:ftp act:remove id:1 url:ossec dat:huzaw e_data:hwazu sta:rejected systemname:system100
+log 1 pass = Dec 19 17:20:08 User test_same_filters[12345]:Test same_system_name 'Srcuser' 'User' logged from 192.168.1.100:8 to 192.168.5.4:20 pro:ftp act:remove id:1 url:ossec dat:huzaw e_data:hwazu sta:rejected systemname:system100
+log 1 pass = Dec 19 17:20:08 User test_same_filters[12345]:Test same_system_name 'Srcuser' 'User' logged from 192.168.1.100:8 to 192.168.5.4:20 pro:ftp act:remove id:1 url:ossec dat:huzaw e_data:hwazu sta:rejected systemname:system1
 rule = 999234
 alert = 7
 decoder = test_same_filters
@@ -309,13 +309,13 @@ rule = 999258
 alert = 7
 decoder = test_different_filters
 
-[different_fields: different_systemname]
-log 1 pass = Dec 19 17:20:08 User test_different_filters[12345]:Test different_systemname 'Srcuser' 'User' logged from 192.168.1.100:8 to 192.168.5.4:20 pro:ftp act:remove id:1 url:ossec dat:huzaw e_data:hwazu sta:rejected systemname:system1
-log 1 pass = Dec 19 17:20:08 User test_different_filters[12345]:Test different_systemname 'Srcuser' 'User' logged from 192.168.1.100:8 to 192.168.5.4:20 pro:ftp act:remove id:1 url:ossec dat:huzaw e_data:hwazu sta:rejected systemname:system1
-log 1 pass = Dec 19 17:20:08 User test_different_filters[12345]:Test different_systemname 'Srcuser' 'User' logged from 192.168.1.100:8 to 192.168.5.4:20 pro:ftp act:remove id:1 url:ossec dat:huzaw e_data:hwazu sta:rejected systemname:system1
-log 1 pass = Dec 19 17:20:08 User test_different_filters[12345]:Test different_systemname 'Srcuser' 'User' logged from 192.168.1.100:8 to 192.168.5.4:20 pro:ftp act:remove id:1 url:ossec dat:huzaw e_data:hwazu sta:rejected systemname:system1
-log 1 pass = Dec 19 17:20:08 User test_different_filters[12345]:Test different_systemname 'Srcuser' 'User' logged from 192.168.1.100:8 to 192.168.5.4:20 pro:ftp act:remove id:1 url:ossec dat:huzaw e_data:hwazu sta:rejected systemname:system1
-log 1 pass = Dec 19 17:20:08 User test_different_filters[12345]:Test different_systemname 'Srcuser' 'User' logged from 192.168.1.100:8 to 192.168.5.4:20 pro:ftp act:remove id:1 url:ossec dat:huzaw e_data:hwazu sta:rejected systemname:system2
+[different_fields: different_system_name]
+log 1 pass = Dec 19 17:20:08 User test_different_filters[12345]:Test different_system_name 'Srcuser' 'User' logged from 192.168.1.100:8 to 192.168.5.4:20 pro:ftp act:remove id:1 url:ossec dat:huzaw e_data:hwazu sta:rejected systemname:system1
+log 1 pass = Dec 19 17:20:08 User test_different_filters[12345]:Test different_system_name 'Srcuser' 'User' logged from 192.168.1.100:8 to 192.168.5.4:20 pro:ftp act:remove id:1 url:ossec dat:huzaw e_data:hwazu sta:rejected systemname:system1
+log 1 pass = Dec 19 17:20:08 User test_different_filters[12345]:Test different_system_name 'Srcuser' 'User' logged from 192.168.1.100:8 to 192.168.5.4:20 pro:ftp act:remove id:1 url:ossec dat:huzaw e_data:hwazu sta:rejected systemname:system1
+log 1 pass = Dec 19 17:20:08 User test_different_filters[12345]:Test different_system_name 'Srcuser' 'User' logged from 192.168.1.100:8 to 192.168.5.4:20 pro:ftp act:remove id:1 url:ossec dat:huzaw e_data:hwazu sta:rejected systemname:system1
+log 1 pass = Dec 19 17:20:08 User test_different_filters[12345]:Test different_system_name 'Srcuser' 'User' logged from 192.168.1.100:8 to 192.168.5.4:20 pro:ftp act:remove id:1 url:ossec dat:huzaw e_data:hwazu sta:rejected systemname:system1
+log 1 pass = Dec 19 17:20:08 User test_different_filters[12345]:Test different_system_name 'Srcuser' 'User' logged from 192.168.1.100:8 to 192.168.5.4:20 pro:ftp act:remove id:1 url:ossec dat:huzaw e_data:hwazu sta:rejected systemname:system2
 rule = 999260
 alert = 7
 decoder = test_different_filters


### PR DESCRIPTION
| Related issue |
| --- |
| wazuh/wazuh#5128 |

## Description
As static filters related to the system_name field changed, static filters tests were modified too. I change the name same/different_systemname for same/different_system_name

## Test
All the tests passed

![image](https://user-images.githubusercontent.com/24528466/83137608-bd2eb380-a0e9-11ea-9b3e-4737e852dd96.png)
