### PR TITLE
Adding WAF rules

### DIFF
--- a/rules/0350-amazon_rules.xml
+++ b/rules/0350-amazon_rules.xml
@@ -264,6 +264,14 @@ ID: 80200 - 80499
         <same_field>aws.httpRequest.clientIp</same_field>
         <options>no_full_log</options>
     </rule>
+ 
+    <rule id="80443" level="3">
+        <if_sid>80440</if_sid>
+        <match>"ALLOW"</match>
+        <description>AWS WAF - Allowed request.</description>
+        <group>aws_waf,aws_waf_allow,</group>
+        <options>no_full_log</options>
+    </rule>
   
     <!-- AWS Config -->
     <!-- Documentation: https://docs.aws.amazon.com/config/latest/developerguide/WhatIsConfig.html -->

--- a/rules/0350-amazon_rules.xml
+++ b/rules/0350-amazon_rules.xml
@@ -265,7 +265,7 @@ ID: 80200 - 80499
         <options>no_full_log</options>
     </rule>
  
-    <rule id="80443" level="3">
+    <rule id="80443" level="0">
         <if_sid>80440</if_sid>
         <match>"ALLOW"</match>
         <description>AWS WAF - Allowed request.</description>

--- a/rules/0350-amazon_rules.xml
+++ b/rules/0350-amazon_rules.xml
@@ -248,28 +248,27 @@ ID: 80200 - 80499
         <group>aws_waf,</group>
         <options>no_full_log</options>
     </rule>
-  
-    <rule id="80441" level="3">
+
+    <rule id="80441" level="0">
         <if_sid>80440</if_sid>
+        <match>"ALLOW"</match>
+        <description>AWS WAF - Allowed request.</description>
+        <group>aws_waf,aws_waf_allow,</group>
+        <options>no_full_log</options>
+    </rule>
+
+    <rule id="80442" level="3">
+        <if_sid>80440,80441</if_sid>
         <match>"BLOCK"</match>
         <description>AWS WAF - Blocked request.</description>
         <group>aws_waf,aws_waf_block,</group>
         <options>no_full_log</options>
     </rule>
-  
-    <rule id="80442" level="10" frequency="8" timeframe="120" ignore="60">
-        <if_matched_sid>80440</if_matched_sid>
-        <match>"BLOCK"</match>
+
+    <rule id="80443" level="10" frequency="8" timeframe="120" ignore="60">
+        <if_matched_sid>80442</if_matched_sid>
         <description>AWS WAF - Multiple Blocked request.</description>
         <same_field>aws.httpRequest.clientIp</same_field>
-        <options>no_full_log</options>
-    </rule>
- 
-    <rule id="80443" level="0">
-        <if_sid>80440</if_sid>
-        <match>"ALLOW"</match>
-        <description>AWS WAF - Allowed request.</description>
-        <group>aws_waf,aws_waf_allow,</group>
         <options>no_full_log</options>
     </rule>
   

--- a/rules/0350-amazon_rules.xml
+++ b/rules/0350-amazon_rules.xml
@@ -239,7 +239,32 @@ ID: 80200 - 80499
         <options>no_full_log</options>
     </rule>
 
-
+    <!-- AWS WAF -->
+    <!-- Documentation: https://docs.aws.amazon.com/waf/latest/developerguide/logging.html -->
+    <rule id="80440" level="0">
+        <if_sid>80200</if_sid>
+        <field name="aws.source">waf</field>
+        <description>AWS WAF alert.</description>
+        <group>aws_waf,</group>
+        <options>no_full_log</options>
+    </rule>
+  
+    <rule id="80441" level="3">
+        <if_sid>80440</if_sid>
+        <match>"BLOCK"</match>
+        <description>AWS WAF - Blocked request.</description>
+        <group>aws_waf,aws_waf_block,</group>
+        <options>no_full_log</options>
+    </rule>
+  
+    <rule id="80442" level="10" frequency="8" timeframe="120" ignore="60">
+        <if_matched_sid>80440</if_matched_sid>
+        <match>"BLOCK"</match>
+        <description>AWS WAF - Multiple Blocked request.</description>
+        <same_field>aws.httpRequest.clientIp</same_field>
+        <options>no_full_log</options>
+    </rule>
+  
     <!-- AWS Config -->
     <!-- Documentation: https://docs.aws.amazon.com/config/latest/developerguide/WhatIsConfig.html -->
     <rule id="80450" level="0">


### PR DESCRIPTION
Hello team,

This PR adds rules for AWS WAF. Fixes #686 

The summary of the rules added is the following:

- Rule 80440: Catch all WAF events (level 0)
- Rule 80441: WAF events Allowed (level 0)
- Rule 80442: WAF events Blocked (level 3)
- Rule 80443: Multiple WAF events Blocked (level 10, frequency 8, same source IP)

Note: These rules won't trigger an alert when the request is ALLOWED (not Blocked by default or by any ruleGroup) or COUNTED.