### PR TITLE
Remove leading zeroes from rule ids

### DIFF
--- a/rules/0010-rules_config.xml
+++ b/rules/0010-rules_config.xml
@@ -8,49 +8,49 @@
 -->
 
 <group name="syslog,">
-  <rule id="01" level="0" noalert="1">
+  <rule id="1" level="0" noalert="1">
     <category>syslog</category>
     <description>Generic template for all syslog rules.</description>
   </rule>
 </group>
 
 <group name="firewall,">
-  <rule id="02" level="0" noalert="1">
+  <rule id="2" level="0" noalert="1">
     <category>firewall</category>
     <description>Generic template for all firewall rules.</description>
   </rule>
 </group>
 
 <group name="ids,">
-  <rule id="03" level="0" noalert="1">
+  <rule id="3" level="0" noalert="1">
     <category>ids</category>
     <description>Generic template for all ids rules.</description>
   </rule>
 </group>
 
 <group name="web-log,">
-  <rule id="04" level="0" noalert="1">
+  <rule id="4" level="0" noalert="1">
     <category>web-log</category>
     <description>Generic template for all web rules.</description>
   </rule>
 </group>
 
 <group name="squid,">
-  <rule id="05" level="0" noalert="1">
+  <rule id="5" level="0" noalert="1">
     <category>squid</category>
     <description>Generic template for all web proxy rules.</description>
   </rule>
 </group>
 
 <group name="windows,">
-  <rule id="06" level="0" noalert="1">
+  <rule id="6" level="0" noalert="1">
     <category>windows</category>
     <description>Generic template for all windows rules.</description>
   </rule>
 </group>
 
 <group name="ossec,">
-  <rule id="07" level="0" noalert="1">
+  <rule id="7" level="0" noalert="1">
     <category>ossec</category>
     <description>Generic template for all ossec rules.</description>
   </rule>

--- a/rules/0225-mcafee_av_rules.xml
+++ b/rules/0225-mcafee_av_rules.xml
@@ -102,7 +102,7 @@
     <group>pci_dss_5.1,pci_dss_10.6.1,pci_dss_5.2,gpg13_4.4,gpg13_4.14,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_SI.3,nist_800_53_AU.6,tsc_A1.2,tsc_CC7.2,tsc_CC7.3,</group>
   </rule>
 
-  <rule id="07512" level="7">
+  <rule id="7512" level="7">
     <if_sid>7500</if_sid>
     <match>update failed</match>
     <description>McAfee Windows AV - Virus program or DAT update failed.</description>


### PR DESCRIPTION
## Description

A user reported that some rules have a leading zero in their id, this has no impact on functionality since analysisd and active response cast the id into integers, but might mislead users into thinking id `01` is different from `1`. Additionally, the style of ids should be unified. This PR removes the leading zeroes as a result.

## Tests
The modified rules were installed in a manager that started without any problems and a couple of logs were tests on `ossec-logcollector` in order to see they were working correctly:

Rule 18101 triggers on rule 18100 which requires `category` to be windows:
```
2013 Oct 09 17:09:04 WinEvtLog: Application: INFORMATION(1): My Script: (no user): no domain: demo1.foo.example.com: test


**Phase 1: Completed pre-decoding.
       full event: '2013 Oct 09 17:09:04 WinEvtLog: Application: INFORMATION(1): My Script: (no user): no domain: demo1.foo.example.com: test'
       timestamp: '2013 Oct 09 17:09:04'
       hostname: 'server'
       program_name: 'WinEvtLog'
       log: 'Application: INFORMATION(1): My Script: (no user): no domain: demo1.foo.example.com: test'

**Phase 2: Completed decoding.
       decoder: 'windows'
       type: 'Application'
       status: 'INFORMATION'
       id: '1'
       extra_data: 'My Script'
       dstuser: '(no user)'
       system_name: 'demo1.foo.example.com'

**Phase 3: Completed filtering (rules).
       Rule id: '18101'
       Level: '0'
       Description: 'Windows informational event.'
```