### PR TITLE
Update gcp rules to look for integration: gcp

### DIFF
--- a/rules/0690-gcp_rules.xml
+++ b/rules/0690-gcp_rules.xml
@@ -12,8 +12,8 @@ ID: 65000 - 65499
     <!-- GCP wodle -->
     <rule id="65000" level="0">
         <decoded_as>json</decoded_as>
-        <field name="gcp.resource.labels.project_id">\.+</field>
-        <description>Google Cloud Pub/Sub alert</description>
+        <field name="integration">gcp</field>
+        <description>GCP alert.</description>
         <options>no_full_log</options>
     </rule>
 


### PR DESCRIPTION
Hello team,

This PR changes GCP `rule_id` 65000 to look for `integration: gcp` so the ruleset follows the same structure as the other modules (aws, virustotal, etc).

![image](https://user-images.githubusercontent.com/48716145/84673961-a500c600-af2a-11ea-886d-483c3ae4b5ed.png)

Regards,

David J. Iglesias
