### PR TITLE
 Add new Event IDs for virus/tamper matches

### DIFF
--- a/rules/0120-symantec-av_rules.xml
+++ b/rules/0120-symantec-av_rules.xml
@@ -21,7 +21,7 @@
 
   <rule id="7310" level="9">
     <if_sid>7300, 7301</if_sid>
-    <id>^5$|^17$</id>
+    <id>^5$|^17$|^51$|^45$</id>
     <group>virus,pci_dss_5.1,pci_dss_5.2,pci_dss_11.4,gpg13_4.2,gdpr_IV_35.7.d,nist_800_53_SI.3,nist_800_53_SI.4,tsc_A1.2,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
     <description>Symantec-AV: Virus detected.</description>
   </rule>


### PR DESCRIPTION
Example logs...

2020 Jul 01 14:29:17 WinEvtLog: Application: ERROR(51): Symantec AntiVirus: SYSTEM: NT AUTHORITY: agent123:       Security Risk Found! signature123 in File: c:\windows\system32\windowspowershell\v1.0\powershell.exe by: scan scan.  Action: .  Action Description: Access Denied

2020 Jul 01 14:08:20 WinEvtLog: Application: INFORMATION(45): Symantec AntiVirus: SYSTEM: NT AUTHORITY: agent123:       Scan type: Tamper Protection Scan  Event: Tamper Protection Detection  Security risk detected: C:\PROGRAM FILES (X86)\THING\THING.EXE  File: C:\Program Files (x86)\Symantec\Symantec Endpoint Protection\14.0.3897.1101.105\Bin\ccSvcHst.exe  Location: C:\Program Files (x86)\Symantec\Symantec Endpoint Protection\14.0.3897.1101.105\Bin  Computer: AGENT123  User: SYSTEM  Action taken: Access denied  Date found: 01 July 2020  14:08:20