### PR TITLE
Fix error in ssd decoder when username is one or more blank spaces

### DIFF
--- a/decoders/0310-ssh_decoders.xml
+++ b/decoders/0310-ssh_decoders.xml
@@ -127,8 +127,8 @@
 
 <decoder name="ssh-invalid-user">
   <parent>sshd</parent>
-  <prematch>^Invalid user|^Illegal user</prematch>
-  <regex offset="after_prematch">(\S+) from (\S+)</regex>
+  <prematch>^Invalid user |^Illegal user </prematch>
+  <regex offset="after_prematch">(\.*) from (\S+)</regex>
   <order>srcuser,srcip</order>
 </decoder>
 


### PR DESCRIPTION
Hi team,

This PR aims to fix an error of the [sshd decoder](https://github.com/wazuh/wazuh-ruleset/blob/master/decoders/0310-ssh_decoders.xml#L130). When `srcuser` is one or more blank spaces, it is not extracted from the log. `srcip` is not extracted as well.

The change I made has been tested under the following usernames:
- `test`.
- `test2test`.
- ` ` - one blank space.
- `     ` - 5 blank spaces.

The results have been good. All fields are extracted:

```
       log: 'Invalid user test from 11.0.0.27 port 55140'

**Phase 2: Completed decoding.
       decoder: 'sshd'
       srcuser: 'test'
       srcip: '11.0.0.27'
       srcport: '55140'
```


```
       log: 'Invalid user test2test from 11.0.0.27 port 55140'

**Phase 2: Completed decoding.
       decoder: 'sshd'
       srcuser: 'test2test'
       srcip: '11.0.0.27'
       srcport: '55140'
```


```
       log: 'Invalid user   from 11.0.0.27 port 55140'

**Phase 2: Completed decoding.
       decoder: 'sshd'
       srcuser: ' '
       srcip: '11.0.0.27'
       srcport: '55140'
```


```
       log: 'Invalid user      from 11.0.0.27 port 55140'

**Phase 2: Completed decoding.
       decoder: 'sshd'
       srcuser: '     '
       srcip: '11.0.0.27'
       srcport: '55140'
```

Regards,
Sergio.