### PR TITLE
Add decoders to extract the username field from failed login logs of proftpd

### DIFF
--- a/decoders/0230-proftpd_decoders.xml
+++ b/decoders/0230-proftpd_decoders.xml
@@ -17,6 +17,9 @@
   - proftpd[2344]: refused connect from 192.168.1.2 (192.168.1.2)
   - proftpd[15181]: valhalla (crawl-66-249-66-80.googlebot.com[66.249.66.80]) - Connection from crawl-66-249-66-80.googlebot.com [66.249.66.80] denied.
   - proftpd[26169] server.example.net: Fatal: unable to open incoming connection: Der Socket ist nicht verbunden
+  - proftpd[13378]: 10.22.136.85 (111.250.52.78[111.250.52.78]) - USER root (Login failed): Incorrect password
+  - proftpd[17655]: 10.22.136.85 (10.22.126.169[10.22.126.169]) - USER cronftp (Login failed): authentication via 'ssh-dss' public key failed
+  - proftpd[19969]: 10.22.136.85 (10.22.33.14[10.22.33.14]) - USER anonymous: no such user found from 10.22.33.14 [10.22.33.14] to ::ffff:10.22.136.85:21
   -->
 <decoder name="proftpd">
   <program_name>^proftpd</program_name>
@@ -31,8 +34,26 @@
   <fts>name, user, srcip, location</fts>
 </decoder>
 
-<decoder name="proftpd-ip">
+<decoder name="proftpd-fail_password">
   <parent>proftpd</parent>
-  <regex>^\S+ \(\S+[(\S+)]\)|^\S+ \(\S+[(\S+)]\)</regex>
-  <order>srcip</order>
+  <prematch> \(Login failed\): Incorrect password</prematch>
+  <regex>^\S+ \(\S+[(\S+)]\)\s*\S \w+ (\S+) </regex>
+  <regex>\(Login failed\): Incorrect password</regex>
+  <order>srcip, srcuser</order>
+</decoder>
+
+<decoder name="proftpd-fail_publickey">
+  <parent>proftpd</parent>
+  <prematch> \(Login failed\): authentication via '\S+' public key failed</prematch>
+  <regex>^\S+ \\S+[(\S+)]\)\s*\S \w+ (\S+) </regex>
+  <regex>\(Login failed\): authentication via '\S+' public key failed</regex>
+  <order>srcip, srcuser</order>
+</decoder>
+
+<decoder name="proftpd-non_existent">
+  <parent>proftpd</parent>
+  <prematch>: no such user found from </prematch>
+  <regex>^\S+ \(\S+[(\S+)]\)\s*\S \w+ (\S+): </regex>
+  <regex>no such user found from \S+ [\S+] to \S+</regex>
+  <order>srcip, srcuser</order>
 </decoder>


### PR DESCRIPTION
## ossec-logtest
```
2020/08/05 21:23:21 ossec-testrule: INFO: Started (pid: 30188).
ossec-testrule: Type one log per line.

Aug  5 20:33:46 myhost proftpd[13287]: 10.22.136.85 (10.22.33.14[10.22.33.14]) - USER anonymous: no such user found from 10.22.33.14 [10.22.33.14] to ::ffff:10.22.136.85:21


**Phase 1: Completed pre-decoding.
       full event: 'Aug  5 20:33:46 myhost proftpd[13287]: 10.22.136.85 (10.22.33.14[10.22.33.14]) - USER anonymous: no such user found from 10.22.33.14 [10.22.33.14] to ::ffff:10.22.136.85:21'
       timestamp: 'Aug  5 20:33:46'
       hostname: 'myhost'
       program_name: 'proftpd'
       log: '10.22.136.85 (10.22.33.14[10.22.33.14]) - USER anonymous: no such user found from 10.22.33.14 [10.22.33.14] to ::ffff:10.22.136.85:21'

**Phase 2: Completed decoding.
       decoder: 'proftpd'
       srcip: '10.22.33.14'
       srcuser: 'anonymous'

**Phase 3: Completed filtering (rules).
       Rule id: '11203'
       Level: '5'
       Description: 'proftpd: Attempt to login using a non-existent user.'




Aug  5 20:34:54 myhost proftpd[13378]: 10.22.136.85 (222.186.52.78[222.186.52.78]) - USER root (Login failed): Incorrect password


**Phase 1: Completed pre-decoding.
       full event: 'Aug  5 20:34:54 myhost proftpd[13378]: 10.22.136.85 (222.186.52.78[222.186.52.78]) - USER root (Login failed): Incorrect password'
       timestamp: 'Aug  5 20:34:54'
       hostname: 'myhost'
       program_name: 'proftpd'
       log: '10.22.136.85 (222.186.52.78[222.186.52.78]) - USER root (Login failed): Incorrect password'

**Phase 2: Completed decoding.
       decoder: 'proftpd'
       srcip: '222.186.52.78'
       dstuser: 'root'

**Phase 3: Completed filtering (rules).
       Rule id: '11204'
       Level: '5'
       Description: 'proftpd: Login failed accessing the FTP server'
**Alert to be generated.




Aug  5 21:14:18 myhost proftpd[17655]: 10.22.136.85 (10.22.126.169[10.22.126.169]) - USER cronftp (Login failed): authentication via 'ssh-dss' public key failed


**Phase 1: Completed pre-decoding.
       full event: 'Aug  5 21:14:18 myhost proftpd[17655]: 10.22.136.85 (10.22.126.169[10.22.126.169]) - USER cronftp (Login failed): authentication via 'ssh-dss' public key failed'
       timestamp: 'Aug  5 21:14:18'
       hostname: 'myhost'
       program_name: 'proftpd'
       log: '10.22.136.85 (10.22.126.169[10.22.126.169]) - USER cronftp (Login failed): authentication via 'ssh-dss' public key failed'

**Phase 2: Completed decoding.
       decoder: 'proftpd'
       srcip: '10.22.126.169'
       srcuser: 'cronftp'

**Phase 3: Completed filtering (rules).
       Rule id: '11204'
       Level: '5'
       Description: 'proftpd: Login failed accessing the FTP server'
```