### PR TITLE
Fixing OpenVPN tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,9 +34,8 @@ Full documentation at [documentation.wazuh.com](https://documentation.wazuh.com/
 
 ## Branches
 
-* `stable` branch on correspond to the last OSSEC Ruleset stable version.
+* `stable` branch on correspond to the last ruleset stable version.
 * `master` branch contains the latest code, be aware of possible bugs on this branch.
-* `development` branch includes all the new features we are adding and testing.
 
 
 ## Contribute

--- a/tools/rules-testing/tests/openvpn_ldap.ini
+++ b/tools/rules-testing/tests/openvpn_ldap.ini
@@ -1,11 +1,11 @@
 [openvpn: LDAP Bind Failed]
-log 1 fail = Jan 28 14:25:49 VPN-SERVER-05892 openvpn: LDAP bind failed: Invalid credentials (80090308: LdapErr: DSID-55555555, comment: AcceptSecurityContext error, data 775, v3839)
+log 1 pass = Jan 28 14:25:49 VPN-SERVER-05892 openvpn: LDAP bind failed: Invalid credentials (80090308: LdapErr: DSID-55555555, comment: AcceptSecurityContext error, data 775, v3839)
 rule = 81805
 alert = 5
 decoder = openvpn
 
 [openvpn: LDAP Logon Failure]
-log 1 fail = Jan 28 14:25:49 VPN-SERVER-05892 openvpn: Incorrect password supplied for LDAP DN "CN=Harry T. Hacker,OU=business unit,OU=department,DC=domain,DC=com"
+log 1 pass = Jan 28 14:25:49 VPN-SERVER-05892 openvpn: Incorrect password supplied for LDAP DN "CN=Harry T. Hacker,OU=business unit,OU=department,DC=domain,DC=com"
 rule = 81806
 alert = 5
 decoder = openvpn


### PR DESCRIPTION
Hi team,

Rule tests introduced at https://github.com/wazuh/wazuh-ruleset/pull/550 were marked to fail instead of pass.

These tests fail as you can see here:

```
- [ File = ./tests/openvpn_ldap.ini ] ---------

------------------------------------------------------------
Failed: Exit code = 0
        Alert     = 5
        Rule      = 81805
        Decoder   = openvpn
        Section   = openvpn: LDAP Bind Failed
        line name = log 1 fail

2020/09/07 06:44:42 ossec-testrule: INFO: Started (pid: 115018).
ossec-testrule: Type one log per line.



**Phase 1: Completed pre-decoding.
       full event: 'Jan 28 14:25:49 VPN-SERVER-05892 openvpn: LDAP bind failed: Invalid credentials (80090308: LdapErr: DSID-55555555, comment: AcceptSecurityContext error, data 775, v3839)'
       timestamp: 'Jan 28 14:25:49'
       hostname: 'VPN-SERVER-05892'
       program_name: 'openvpn'
       log: 'LDAP bind failed: Invalid credentials (80090308: LdapErr: DSID-55555555, comment: AcceptSecurityContext error, data 775, v3839)'

**Phase 2: Completed decoding.
       decoder: 'openvpn'
       ldap_data.error_message: 'Invalid credentials'
       ldap_data.code: '80090308'
       ldap_data.ldaperr: 'DSID-55555555'
       ldap_data.comment: 'AcceptSecurityContext error'

**Phase 3: Completed filtering (rules).
       Rule id: '81805'
       Level: '5'
       Description: 'OpenVPN LDAP Bind Failure: Invalid credentials'
**Alert to be generated.


lf->decoder_info->name: 'openvpn'
ut_decoder_name       : 'openvpn'
0


------------------------------------------------------------
Failed: Exit code = 0
        Alert     = 5
        Rule      = 81806
        Decoder   = openvpn
        Section   = openvpn: LDAP Logon Failure
        line name = log 1 fail

2020/09/07 06:44:43 ossec-testrule: INFO: Started (pid: 115019).
ossec-testrule: Type one log per line.



**Phase 1: Completed pre-decoding.
       full event: 'Jan 28 14:25:49 VPN-SERVER-05892 openvpn: Incorrect password supplied for LDAP DN "CN=Harry T. Hacker,OU=business unit,OU=department,DC=domain,DC=com"'
       timestamp: 'Jan 28 14:25:49'
       hostname: 'VPN-SERVER-05892'
       program_name: 'openvpn'
       log: 'Incorrect password supplied for LDAP DN "CN=Harry T. Hacker,OU=business unit,OU=department,DC=domain,DC=com"'

**Phase 2: Completed decoding.
       decoder: 'openvpn'
       ldap_data.Username: 'Harry T. Hacker'
       ldap_data.Department: 'business unit'
       ldap_data.SecurityGroup: 'OU=department,DC=domain,DC=com'

**Phase 3: Completed filtering (rules).
       Rule id: '81806'
       Level: '5'
       Description: 'OpenVPN LDAP Logon Failure: Harry T. Hacker [business unit]'
**Alert to be generated.


lf->decoder_info->name: 'openvpn'
ut_decoder_name       : 'openvpn'
0
```

After the fix they pass as expected:

```
- [ File = ./tests/openvpn_ldap.ini ] ---------
..
```