### PR TITLE
Fix syslog.ini test

### DIFF
--- a/tools/rules-testing/tests/syslog.ini
+++ b/tools/rules-testing/tests/syslog.ini
@@ -5,7 +5,7 @@ rule = 2944
 alert = 1
 decoder =
 
-[Uninteresting nouveau error.]
+[Uninteresting nouveau error 2.]
 log 1 fail = Jul 18 09:21:57 localhost kernel: nouveau E[  PGRAPH][0000:0f:00.0]  DATA_ERROR
 
 rule = 2944
@@ -13,8 +13,7 @@ alert = 1
 decoder =
 
 [Incorrect chain/target/match.]
-log 3 fail = Jul 18 10:51:43 localhost NetworkManager[1366]: <warn> (enp1s0) firewall zone remove failed: (32) COMMAND_FAILED: '/sbin/iptables -D INPUT_ZONES -t filter -i enp1s0 -g IN_public' failed: ipta
-bles: No chain/target/match by that name.
+log 3 fail = Jul 18 10:51:43 localhost NetworkManager[1366]: <warn> (enp1s0) firewall zone remove failed: (32) COMMAND_FAILED: '/sbin/iptables -D INPUT_ZONES -t filter -i enp1s0 -g IN_public' failed: iptables: No chain/target/match by that name.
 
 rule = 2941
 alert = 3


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh-ruleset/issues/763

Hi team!
This PR solves the false positive while testing syslog.ini test set

```
root@30-u20-manager:~/repos/wazuh-ruleset/tools/rules-testing# ./runtests.py 
- [ File = ./tests/syslog.ini ] ---------
......
```

Regards.