### PR TITLE
runtest.py adaptation to wazuh-logtest

### DIFF
--- a/tools/rules-testing/tests/syslog.ini
+++ b/tools/rules-testing/tests/syslog.ini
@@ -5,7 +5,7 @@ rule = 2944
 alert = 1
 decoder =
 
-[Uninteresting nouveau error.]
+[Uninteresting nouveau error 2.]
 log 1 fail = Jul 18 09:21:57 localhost kernel: nouveau E[  PGRAPH][0000:0f:00.0]  DATA_ERROR
 
 rule = 2944
@@ -13,8 +13,7 @@ alert = 1
 decoder =
 
 [Incorrect chain/target/match.]
-log 3 fail = Jul 18 10:51:43 localhost NetworkManager[1366]: <warn> (enp1s0) firewall zone remove failed: (32) COMMAND_FAILED: '/sbin/iptables -D INPUT_ZONES -t filter -i enp1s0 -g IN_public' failed: ipta
-bles: No chain/target/match by that name.
+log 3 fail = Jul 18 10:51:43 localhost NetworkManager[1366]: <warn> (enp1s0) firewall zone remove failed: (32) COMMAND_FAILED: '/sbin/iptables -D INPUT_ZONES -t filter -i enp1s0 -g IN_public' failed: iptables: No chain/target/match by that name.
 
 rule = 2941
 alert = 3


### PR DESCRIPTION
|Related issue|
|---|
|[763](https://github.com/wazuh/wazuh-ruleset/issues/763)|

Hi team!

This PR aims to adapt runtest.py to wazuh-logtest. Those changes are

- [X] Change path from ossec-logtest to wazuh-logtest
- [X] Remove deprecated command line parameters
- [X] Remove dead code product of removing such options (command line parameters)
- [X] Add option to test custom rules/decoders (wazuh-manager need to restart)
## Checks
- [X] Run OK using[ wazuh-logtest.py PR](https://github.com/wazuh/wazuh/issues/5440)
- [X] PEP8

Regards, 