### PR TITLE
Fixed srcip and dstip values in SonicWall decoder

### DIFF
--- a/decoders/0295-sonicwall_decoders.xml
+++ b/decoders/0295-sonicwall_decoders.xml
@@ -39,14 +39,32 @@
 
 <decoder name="sonicwall-fields">
   <parent>sonicwall</parent>
-  <regex offset="after_regex">src=(\d+.\d+.\d+.\d+):(\d+):\S* dst=(\d+.\d+.\d+.\d+):(\d+):\S*</regex>
-  <order>srcip, srcport ,dstip, dstport, protocol</order>
+  <regex offset="after_regex">src=(\d+.\d+.\d+.\d+):(\d+):\S*</regex>
+  <order>srcip, srcport</order>
 </decoder>
 
 <decoder name="sonicwall-fields">
   <parent>sonicwall</parent>
-  <regex offset="after_regex">src=(\d+.\d+.\d+.\d+)\S* dst=(\d+.\d+.\d+.\d+)\S*</regex>
-  <order>srcip, dstip, protocol</order>
+  <regex offset="after_regex">dst=(\d+.\d+.\d+.\d+):(\d+):\S*</regex>
+  <order>dstip, dstport</order>
+</decoder>
+
+<decoder name="sonicwall-fields">
+  <parent>sonicwall</parent>
+  <regex offset="after_regex">src=(\d+.\d+.\d+.\d+)::|src=(\d+.\d+.\d+.\d+)\s</regex>
+  <order>srcip</order>
+</decoder>
+
+<decoder name="sonicwall-fields">
+  <parent>sonicwall</parent>
+  <regex offset="after_regex">dst=(\d+.\d+.\d+.\d+)::|dst=(\d+.\d+.\d+.\d+)\s</regex>
+  <order>dstip</order>
+</decoder>
+
+<decoder name="sonicwall-fields">
+  <parent>sonicwall</parent>
+  <regex offset="after_regex">proto=(\S+)</regex>
+  <order>protocol</order>
 </decoder>
 
 


### PR DESCRIPTION
| Related issue |
| --- |
| #760 |
## Description
I have improved the decoder to get correctly the values of srcip and dstip fields. Also, the protocol field was not always decoded and is now fixed as well.

## Tests:
```
Jan  3 13:45:36 192.168.5.1 id=firewall sn=000SERIAL time="2007-01-03 14:48:06" fw=1.1.1.1 pri=6 c=262144 m=98 msg="Connection Opened" n=23419 src=2.2.2.200:36701:WAN dst=1.1.1.100:50000:WAN proto=tcp/50000


**Phase 1: Completed pre-decoding.
       full event: 'Jan  3 13:45:36 192.168.5.1 id=firewall sn=000SERIAL time="2007-01-03 14:48:06" fw=1.1.1.1 pri=6 c=262144 m=98 msg="Connection Opened" n=23419 src=2.2.2.200:36701:WAN dst=1.1.1.100:50000:WAN proto=tcp/50000'
       timestamp: 'Jan  3 13:45:36'
       hostname: '192.168.5.1'
       program_name: '(null)'
       log: 'id=firewall sn=000SERIAL time="2007-01-03 14:48:06" fw=1.1.1.1 pri=6 c=262144 m=98 msg="Connection Opened" n=23419 src=2.2.2.200:36701:WAN dst=1.1.1.100:50000:WAN proto=tcp/50000'

**Phase 2: Completed decoding.
       decoder: 'sonicwall'
       status: '6'
       action: 'Connection Opened'
       srcip: '2.2.2.200'
       srcport: '36701'
       dstip: '1.1.1.100'
       dstport: '50000'
       protocol: 'tcp/50000'

**Phase 3: Completed filtering (rules).
       Rule id: '4806'
       Level: '0'
       Description: 'SonicWall informational message.'
```
```
id=NSA3500BR sn=0017C5DFCEEC time="2019-03-14 16:37:19 UTC" fw=172.29.169.2 pri=1 c=32 m=1388 msg="IPSec VPN Decryption Failed" n=1064050271 src=37.186.204.200 dst=172.29.168.100 note="Replay check failure."


**Phase 1: Completed pre-decoding.
       full event: 'id=NSA3500BR sn=0017C5DFCEEC time="2019-03-14 16:37:19 UTC" fw=172.29.169.2 pri=1 c=32 m=1388 msg="IPSec VPN Decryption Failed" n=1064050271 src=37.186.204.200 dst=172.29.168.100 note="Replay check failure."'
       timestamp: '(null)'
       hostname: 'host'
       program_name: '(null)'
       log: 'id=NSA3500BR sn=0017C5DFCEEC time="2019-03-14 16:37:19 UTC" fw=172.29.169.2 pri=1 c=32 m=1388 msg="IPSec VPN Decryption Failed" n=1064050271 src=37.186.204.200 dst=172.29.168.100 note="Replay check failure."'

**Phase 2: Completed decoding.
       decoder: 'sonicwall'
       status: '1'
       action: 'IPSec VPN Decryption Failed'
       srcip: '37.186.204.200'
       dstip: '172.29.168.100'

**Phase 3: Completed filtering (rules).
       Rule id: '4801'
       Level: '8'
       Description: 'SonicWall critical message.'
**Alert to be generated.
```

```
id=NSA3600  sn=C0EAE4599999 time="2019-02-27 12:55:40 UTC" fw=2.228.169.242 pri=5 c=0 m=1197 msg="NAT Mapping" n=4748427 src=10.12.14.100::X0-V500 dst=217.56.236.200::X3 proto=icmp note="Source: 2.228.169.242, 63130, Destination: 217.56.236.200, 8, Protocol: 1" rule="17 (LAN->WAN)"


**Phase 1: Completed pre-decoding.
       full event: 'id=NSA3600  sn=C0EAE4599999 time="2019-02-27 12:55:40 UTC" fw=2.228.169.242 pri=5 c=0 m=1197 msg="NAT Mapping" n=4748427 src=10.12.14.100::X0-V500 dst=217.56.236.200::X3 proto=icmp note="Source: 2.228.169.242, 63130, Destination: 217.56.236.200, 8, Protocol: 1" rule="17 (LAN->WAN)"'
       timestamp: '(null)'
       hostname: 'host'
       program_name: '(null)'
       log: 'id=NSA3600  sn=C0EAE4599999 time="2019-02-27 12:55:40 UTC" fw=2.228.169.242 pri=5 c=0 m=1197 msg="NAT Mapping" n=4748427 src=10.12.14.100::X0-V500 dst=217.56.236.200::X3 proto=icmp note="Source: 2.228.169.242, 63130, Destination: 217.56.236.200, 8, Protocol: 1" rule="17 (LAN->WAN)"'

**Phase 2: Completed decoding.
       decoder: 'sonicwall'
       status: '5'
       action: 'NAT Mapping'
       srcip: '10.12.14.100'
       dstip: '217.56.236.200'
       protocol: 'icmp'

**Phase 3: Completed filtering (rules).
       Rule id: '4805'
       Level: '0'
       Description: 'SonicWall notice message.'
```

```
id=NSA2650GG sn=18B169D79980 time="2019-03-19 06:44:01 UTC" fw=83.211.91.146 pri=3 c=4 m=14 msg="Web site access denied" app=49177 appName="General HTTPS" n=856789 src=192.168.0.46:59668:X0:nb020.example.com dst=34.194.213.204:443:X1:example.com srcMac=a0:ce:c8:13:99:c5 dstMac=1a:b1:69:d7:99:80 proto=tcp/https dstname=example.com arg=/ code=49 Category="Freeware/Software Downloads"


**Phase 1: Completed pre-decoding.
       full event: 'id=NSA2650GG sn=18B169D79980 time="2019-03-19 06:44:01 UTC" fw=83.211.91.146 pri=3 c=4 m=14 msg="Web site access denied" app=49177 appName="General HTTPS" n=856789 src=192.168.0.46:59668:X0:nb020.example.com dst=34.194.213.204:443:X1:example.com srcMac=a0:ce:c8:13:99:c5 dstMac=1a:b1:69:d7:99:80 proto=tcp/https dstname=example.com arg=/ code=49 Category="Freeware/Software Downloads"'
       timestamp: '(null)'
       hostname: 'host'
       program_name: '(null)'
       log: 'id=NSA2650GG sn=18B169D79980 time="2019-03-19 06:44:01 UTC" fw=83.211.91.146 pri=3 c=4 m=14 msg="Web site access denied" app=49177 appName="General HTTPS" n=856789 src=192.168.0.46:59668:X0:nb020.example.com dst=34.194.213.204:443:X1:example.com srcMac=a0:ce:c8:13:99:c5 dstMac=1a:b1:69:d7:99:80 proto=tcp/https dstname=example.com arg=/ code=49 Category="Freeware/Software Downloads"'

**Phase 2: Completed decoding.
       decoder: 'sonicwall'
       status: '3'
       action: 'Web site access denied'
       srcip: '192.168.0.46'
       srcport: '59668'
       dstip: '34.194.213.204'
       dstport: '443'
       protocol: 'tcp/https'
       app: '49177'
       appName: 'General HTTPS'
       dstname: 'e'
       Category: 'Freeware/Software Downloads'
       id: 'NSA2650GG'
       sn: '18B169D79980'
       time: '2019-03-19 06:44:01'
       timezone: 'UTC'
       fw: '83.211.91.146'
       pri: '3'
       c: '4'
       m: '14'
       msg: 'Web site access denied'
       app: '49177'
       appName: 'General HTTPS'
       n: '856789'
       src: '192.168.0.46:59668:X0:nb020.example.com'
       dst: '34.194.213.204:443:X1:example.com'
       srcMac: 'a0:ce:c8:13:99:c5'
       dstMac: '1a:b1:69:d7:99:80'
       proto: 'tcp/https'
       dstname: 'example.com'
       arg: '/'
       code: '49'
       Category: 'Freeware/Software Downloads'

**Phase 3: Completed filtering (rules).
       Rule id: '4803'
       Level: '4'
       Description: 'SonicWall error message.'
**Alert to be generated.
```




