### PR TITLE
Fix NextCloud bruteforce detection

### DIFF
--- a/rules/0630-nextcloud_rules.xml
+++ b/rules/0630-nextcloud_rules.xml
@@ -89,7 +89,7 @@
   </rule>
 
   <rule id="88203" level="10" frequency="8" timeframe="120">
-    <if_matched_sid>88202</if_matched_sid>
+    <if_matched_sid>88212</if_matched_sid>
     <description>NextCloud brute force (multiple failed logins).</description>
     <group>authentication_failures,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.14,nist_800_53_AC.7,nist_800_53_SI.4,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
     <options>no_full_log</options>


### PR DESCRIPTION
Alert 88202 is just a generic authentication attempt, while
authentication failure is 88212 and this is what we want to be
grouped in a time frame.