### PR TITLE
make -f and --force-update bypass rule branch version enforcement

### DIFF
--- a/update_ruleset
+++ b/update_ruleset
@@ -576,7 +576,8 @@ def usage():
     Additional Params:
     \t-f, --force-update  Force the update of the ruleset even if there are no changes, and even if the requested ruleset
     \t                    branch (like 4.0) differs from the major/minor release of this instance of Wazuh Manager (like 3.13).
-    \t                    By default, the ruleset is updated isthe new/changed decoders/rules/rootchecks.
+    \t                    By default, the ruleset is only updated if there is something new available, and  the target branch
+    \t                    matches the version of the Wazuh manager.
     \t-s, --source        Select ruleset source path (instead of download it).
     \t-j, --json          JSON output. It should be used with '-s' argument.
     \t-d, --debug         Debug mode.

--- a/update_ruleset
+++ b/update_ruleset
@@ -489,7 +489,7 @@ def main():
         status['new_version'] = get_new_ruleset(arguments['source'], arguments['url'], arguments['branch-name'])
         # Compare major
         old_version = ossec_version.replace('"', '')
-        if not same_major_minor(old_version, status['new_version']):
+        if not same_major_minor(old_version, status['new_version']) and not arguments['force']:
             copy(ossec_ruleset_version_path + '-old', ossec_ruleset_version_path)
             copy(ossec_update_script + '-old', ossec_update_script, 0o750)
             os.remove(ossec_update_script + '-old')
@@ -574,7 +574,9 @@ def usage():
     \t-b , --backups      Restore last backup.
 
     Additional Params:
-    \t-f, --force-update  Force to update the ruleset. By default, only it is updated the new/changed decoders/rules/rootchecks.
+    \t-f, --force-update  Force the update of the ruleset even if there are no changes, and even if the requested ruleset
+    \t                    branch (like 4.0) differs from the major/minor release of this instance of Wazuh Manager (like 3.13).
+    \t                    By default, the ruleset is updated isthe new/changed decoders/rules/rootchecks.
     \t-s, --source        Select ruleset source path (instead of download it).
     \t-j, --json          JSON output. It should be used with '-s' argument.
     \t-d, --debug         Debug mode.

--- a/update_ruleset
+++ b/update_ruleset
@@ -576,7 +576,7 @@ def usage():
     Additional Params:
     \t-f, --force-update  Force the update of the ruleset even if there are no changes, and even if the requested ruleset
     \t                    branch (like 4.0) differs from the major/minor release of this instance of Wazuh Manager (like 3.13).
-    \t                    By default, the ruleset is only updated if there is something new available, and  the target branch
+    \t                    By default, the ruleset is only updated if there is something new available, and the target branch
     \t                    matches the version of the Wazuh manager.
     \t-s, --source        Select ruleset source path (instead of download it).
     \t-j, --json          JSON output. It should be used with '-s' argument.


### PR DESCRIPTION
Presently **update_ruleset** forbids pulling in any branch of the ruleset other than the one that corresponds to the running version of Wazuh Manager, even if **-f** or **--force-update** is specified.  It is important that we allow users to at least attempt to roll back their Wazuh ruleset to the branch they were successfully using previous to upgrading their Wazuh Manager. 
Only in a rare case would a new Wazuh version fail to be backwards compatible with the previous branch of the ruleset.  With the ability to force a downgrade to a previous branch of the ruleset, the end user who is having possibly ruleset related problems upon upgrading their Wazuh Manager, can diagnostically roll back their ruleset to see if their problem go away.  In the rare event of a previous branch being incompatible with the running Wazuh Manager such that the ruleset fails to load, the end user only needs to run a plain call to **/var/ossec/bin/update_ruleset** to restore it to the ruleset branch aligned with their Wazuh Manager.