### PR TITLE
Update 0350-amazon_rules.xml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,13 @@ All notable changes to this project will be documented in this file.
 ### Added
 
 - Let the Ruleset update tool to bypass the version check with the force option. ([#773](https://github.com/wazuh/wazuh-ruleset/pull/773))
-- Added new child rules for AWS ConfigHistory rules. ([#775](https://github.com/wazuh/wazuh-ruleset/pull/775))
+
+## [v4.0.2]
+
+### Added
+
+- Added new AWS Config-History rules to make it more granular by including every item status supported ([#775](https://github.com/wazuh/wazuh-ruleset/pull/775))
+
 
 ## [v4.0.1]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to this project will be documented in this file.
 ### Added
 
 - Let the Ruleset update tool to bypass the version check with the force option. ([#773](https://github.com/wazuh/wazuh-ruleset/pull/773))
-
+- Added new child rules for AWS ConfigHistory rules. ([#775](https://github.com/wazuh/wazuh-ruleset/pull/775))
 
 ## [v4.0.1]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,12 +6,8 @@ All notable changes to this project will be documented in this file.
 ### Added
 
 - Let the Ruleset update tool to bypass the version check with the force option. ([#773](https://github.com/wazuh/wazuh-ruleset/pull/773))
-
-## [v4.0.2]
-
-### Added
-
 - Added new AWS Config-History rules to make it more granular by including every item status supported ([#775](https://github.com/wazuh/wazuh-ruleset/pull/775))
+
 
 
 ## [v4.0.1]

--- a/rules/0350-amazon_rules.xml
+++ b/rules/0350-amazon_rules.xml
@@ -300,12 +300,45 @@ ID: 80200 - 80499
     </rule>
 
     <!-- Config history -->
-    <rule id="80453" level="3">
+    <rule id="80453" level="0">
         <if_sid>80451</if_sid>
+        <field name="aws.configurationItemStatus">OK</field>
         <description>AWS Config - History [$(aws.awsAccountId) $(aws.awsRegion)] [$(aws.resourceType)]: $(aws.resourceId) ($(aws.configurationItemStatus))</description>
         <group>aws_config,aws_config_history,</group>
         <options>no_full_log</options>
     </rule>
+  
+    <rule id="80454" level="3">
+        <if_sid>80451</if_sid>
+        <field name="aws.configurationItemStatus">ResourceDiscovered</field>
+        <description>The resource was newly discovered. AWS Config - History:  [$(aws.awsAccountId) $(aws.awsRegion)] [$(aws.resourceType)]: $(aws.resourceId) ($(aws.configurationItemStatus))</description>
+        <group>aws_config,aws_config_history,</group>
+        <options>no_full_log</options>
+    </rule>
+  
+	  <rule id="80455" level="3">
+        <if_sid>80451</if_sid>
+	      <field name="aws.configurationItemStatus">ResourceNotRecorded</field>
+        <description>The resource was discovered but its configuration was not recorded since the recorder excludes the recording of resources of this type. AWS Config - History:  [$(aws.awsAccountId) $(aws.awsRegion)] [$(aws.resourceType)]: $(aws.resourceId) ($(aws.configurationItemStatus))</description>
+        <group>aws_config,aws_config_history,</group>
+        <options>no_full_log</options>
+    </rule>
+  
+	  <rule id="80456" level="3">
+        <if_sid>80451</if_sid>
+	      <field name="aws.configurationItemStatus">ResourceDeleted</field>
+        <description>The resource was deleted. AWS Config - History:  [$(aws.awsAccountId) $(aws.awsRegion)] [$(aws.resourceType)]: $(aws.resourceId) ($(aws.configurationItemStatus))</description>
+        <group>aws_config,aws_config_history,</group>
+        <options>no_full_log</options>
+    </rule>
+  
+	   <rule id="80457" level="3">
+        <if_sid>80451</if_sid>
+	       <field name="aws.configurationItemStatus">ResourceDeletedNotRecorded</field>
+        <description>The resource was deleted but its configuration was not recorded since the recorder excludes the recording of resources of this type. AWS Config - History:  [$(aws.awsAccountId) $(aws.awsRegion)] [$(aws.resourceType)]: $(aws.resourceId) ($(aws.configurationItemStatus))</description>
+        <group>aws_config,aws_config_history,</group>
+        <options>no_full_log</options>
+    </rule> 
 
     <!-- Config Snapshot -->
     <rule id="80475" level="3">

--- a/rules/0350-amazon_rules.xml
+++ b/rules/0350-amazon_rules.xml
@@ -316,25 +316,25 @@ ID: 80200 - 80499
         <options>no_full_log</options>
     </rule>
   
-	  <rule id="80455" level="3">
+    <rule id="80455" level="3">
         <if_sid>80451</if_sid>
-	      <field name="aws.configurationItemStatus">ResourceNotRecorded</field>
+        <field name="aws.configurationItemStatus">ResourceNotRecorded</field>
         <description>The resource was discovered but its configuration was not recorded since the recorder excludes the recording of resources of this type. AWS Config - History:  [$(aws.awsAccountId) $(aws.awsRegion)] [$(aws.resourceType)]: $(aws.resourceId) ($(aws.configurationItemStatus))</description>
         <group>aws_config,aws_config_history,</group>
         <options>no_full_log</options>
     </rule>
   
-	  <rule id="80456" level="3">
+    <rule id="80456" level="3">
         <if_sid>80451</if_sid>
-	      <field name="aws.configurationItemStatus">ResourceDeleted</field>
+        <field name="aws.configurationItemStatus">ResourceDeleted</field>
         <description>The resource was deleted. AWS Config - History:  [$(aws.awsAccountId) $(aws.awsRegion)] [$(aws.resourceType)]: $(aws.resourceId) ($(aws.configurationItemStatus))</description>
         <group>aws_config,aws_config_history,</group>
         <options>no_full_log</options>
     </rule>
   
-	   <rule id="80457" level="3">
+    <rule id="80457" level="3">
         <if_sid>80451</if_sid>
-	       <field name="aws.configurationItemStatus">ResourceDeletedNotRecorded</field>
+        <field name="aws.configurationItemStatus">ResourceDeletedNotRecorded</field>
         <description>The resource was deleted but its configuration was not recorded since the recorder excludes the recording of resources of this type. AWS Config - History:  [$(aws.awsAccountId) $(aws.awsRegion)] [$(aws.resourceType)]: $(aws.resourceId) ($(aws.configurationItemStatus))</description>
         <group>aws_config,aws_config_history,</group>
         <options>no_full_log</options>


### PR DESCRIPTION
Hi team, 

The purpose of this PR is to update the `ConfigHistory` rules. The rule 80453 can flood the Wazuh if the AWS Config is enabled. For this reason, I have silent this rule when the `aws.configurationItemStatus` field has the value `OK`.  And created 4 new child rules that will be triggered once the specific status appears.

The valid values for `aws.configurationItemStatus` are:
`OK` – The resource configuration has been updated
`ResourceDiscovered` – The resource was newly discovered
`ResourceNotRecorded` – The resource was discovered but its configuration was not recorded since the recorder excludes the recording of resources of this type
`ResourceDeleted` – The resource was deleted
`ResourceDeletedNotRecorded` – The resource was deleted but its configuration was not recorded since the recorder excludes the recording of resources of this type

As I have mentioned above when it is `OK` the rule will be silenced (level = 0) for the rest I have set the level to 3 as of now. 

Kind regards,
Bin. 