### PR TITLE
Add wazuh user name to SYS_USERS list

### DIFF
--- a/rules/0280-attack_rules.xml
+++ b/rules/0280-attack_rules.xml
@@ -8,7 +8,7 @@
 -->
 
 <!-- System users. They should never log in to the system -->
-<var name="SYS_USERS">^apache$|^mysql$|^www$|^nobody$|^nogroup$|^portmap$|^named$|^rpc$|^mail$|^ftp$|^shutdown$|^halt$|^daemon$|^bin$|^postfix$|^shell$|^info$|^guest$|^psql$|^user$|^users$|^console$|^uucp$|^lp$|^sync$|^sshd$|^cdrom$|^ossec$</var>
+<var name="SYS_USERS">^apache$|^mysql$|^www$|^nobody$|^nogroup$|^portmap$|^named$|^rpc$|^mail$|^ftp$|^shutdown$|^halt$|^daemon$|^bin$|^postfix$|^shell$|^info$|^guest$|^psql$|^user$|^users$|^console$|^uucp$|^lp$|^sync$|^sshd$|^cdrom$|^ossec$|^wazuh$</var>
 
 <!-- Attack signatures -->
 <group name="syslog,attacks,">


### PR DESCRIPTION
|Related issue|
|---|
|#789|

#### Description
This PR adds **wazuh** user name in the **SYS_USERS** list to be used by alerts that trigger when System users, that shouldn't log in, do it.

#### Tests
- [x] Run `/var/ossec/bin/ossec-logtest` with log `Nov 26 22:19:03 localhost su: pam_unix(su:session): session opened for user wazuh by vagrant(uid=0)` and check that rule **40101** is triggered.