### PR TITLE
Change Wazuh Puppet rules to work with wazuh output logs

### DIFF
--- a/rules/0340-puppet_rules.xml
+++ b/rules/0340-puppet_rules.xml
@@ -355,7 +355,7 @@
     -->
     <rule id="80090" level="0">
         <if_sid>530</if_sid>
-        <match>^ossec: output: 'timestamp_puppet</match>
+        <match>^ossec: output: 'timestamp_puppet|^wazuh: output: 'timestamp_puppet</match>
         <description>Command check if puppet runs every 30 min or less</description>
     </rule>
 


### PR DESCRIPTION
|Related issue|
|---|
|#796|

#### Description
This PR adapts Wazuh Puppet rules to work with output logs using both **ossec** and **wazuh** tag
#### Tests
- [X] Run `/var/ossec/bin/ossec-logtest` with log `wazuh: output: 'timestamp_puppet` and check that rule **80090** is triggered.