### PR TITLE
Add renamed rules and decoders to deprecated lists of update_ruleset

### DIFF
--- a/update_ruleset
+++ b/update_ruleset
@@ -696,8 +696,8 @@ if __name__ == "__main__":
 
     deprecated = {'rules': ['0355-amazon-ec2_rules.xml', '0370-amazon-iam_rules.xml', '0465-amazon-s3_rules.xml',
                             '0470-suricata_rules.xml', '0520-vulnerability-detector.xml',
-                            '0565-ms_ipsec_rules_json.xml'],
-                  'decoders': ['0020-amazon_decoders.xml', '0005-json_decoders.xml']}
+                            '0565-ms_ipsec_rules_json.xml', '0015-ossec_rules.xml', '0016-wazuh_rules.xml'],
+                  'decoders': ['0020-amazon_decoders.xml', '0005-json_decoders.xml', '0200-ossec_decoders.xml']}
 
     if arguments['json']:
         logger = RulesetLogger(tag="Wazuh-Ruleset", filename=wazuh_ruleset_log, flag=RulesetLogger.O_FILE,


### PR DESCRIPTION
|Related issue|
|---|
|#806|

#### Description
This PR adds the renamed rules and decoders (**0015-ossec_rules.xml**, **0016-wazuh_rules.xml** and **200-ossec_decoders.xml**) to the deprecated lists of **update_ruleset** script to be deleted during a ruleset update.

#### Tests
- [x] Run **update_ruleset** and check that these files are delete.