### PR TITLE
Adding new UT for decoders and rules modified during Wazuh name update

### DIFF
--- a/tools/rules-testing/tests/wazuh.ini
+++ b/tools/rules-testing/tests/wazuh.ini
@@ -7,21 +7,19 @@ alert = 3
 decoder = ar_log
 
 [wazuh: active response: add firewall]
-log 2 pass = Sat May  7 03:17:27 CDT 2011 /INSTALLATION/PATH/active-response/bin/firewall-drop.sh add - 172.16.0.1 1304756247.60385 31151
+log 1 pass = Sat May  7 03:17:27 CDT 2011 /INSTALLATION/PATH/active-response/bin/firewall-drop.sh add - 172.16.0.1 1304756247.60385 31151
 rule = 601
 alert = 3
 decoder = ar_log
 
-
 [wazuh: active response: delete host]
-log 3 pass = Sat May  7 03:27:57 CDT 2011 /INSTALLATION/PATH/active-response/bin/host-deny.sh delete - 172.16.0.1 1304756247.60385 31151
+log 1 pass = Sat May  7 03:27:57 CDT 2011 /INSTALLATION/PATH/active-response/bin/host-deny.sh delete - 172.16.0.1 1304756247.60385 31151
 rule = 604
 alert = 3
 decoder = ar_log
 
-
 [wazuh: active response: delete firewall]
-log 4 pass = Sat May  7 03:27:57 CDT 2011 /INSTALLATION/PATH/active-response/bin/firewall-drop.sh delete - 172.16.0.1 1304756247.60385 31151
+log 1 pass = Sat May  7 03:27:57 CDT 2011 /INSTALLATION/PATH/active-response/bin/firewall-drop.sh delete - 172.16.0.1 1304756247.60385 31151
 
 rule = 602
 alert = 3
@@ -30,14 +28,8 @@ decoder = ar_log
 # wazuh-logcollector
 
 [wazuh-logcollector: ignore informational messages at startup]
-log 5 pass = 2015/01/29 21:09:49 wazuh-logcollector(1950): INFO: Analyzing file: '/var/log/httpd/error_log'.
-
-rule = 701
-alert = 0
-decoder = wazuh-logcollector
-
-[wazuh-logcollector: ignore informational messages at startup: legacy]
-log 6 pass = 2015/01/29 21:09:49 ossec-logcollector(1950): INFO: Analyzing file: '/var/log/httpd/error_log'.
+log 1 pass = 2015/01/29 21:09:49 wazuh-logcollector(1950): INFO: Analyzing file: '/var/log/httpd/error_log'.
+log 2 pass = 2015/01/29 21:09:49 ossec-logcollector(1950): INFO: Analyzing file: '/var/log/httpd/error_log'.
 
 rule = 701
 alert = 0
@@ -46,35 +38,23 @@ decoder = wazuh-logcollector
 # Agent's logs
 
 [wazuh: agent's logs: started]
-log 7 pass = wazuh: Agent started: 'Agent1->any'.
-
-rule = 501
-alert = 3
-decoder = wazuh
-
-[wazuh: agent's logs: legacy started]
-log 8 pass = ossec: Agent started: 'Agent1->any'.
+log 1 pass = wazuh: Agent started: 'Agent1->any'.
+log 2 pass = ossec: Agent started: 'Agent1->any'.
 
 rule = 501
 alert = 3
 decoder = wazuh
 
 [wazuh: agent's logs: disconnected]
-log 9 pass = wazuh: Agent disconnected: 'Agent1'.
-
-rule = 504
-alert = 3
-decoder = wazuh
-
-[wazuh: agent's logs: legacy disconnected]
-log 10 pass = ossec: Agent disconnected: 'Agent1'.
+log 1 pass = wazuh: Agent disconnected: 'Agent1'.
+log 2 pass = ossec: Agent disconnected: 'Agent1'.
 
 rule = 504
 alert = 3
 decoder = wazuh
 
 [wazuh: agent's logs: removed]
-log 11 pass = wazuh: Agent removed: 'Agent1'.
+log 1 pass = wazuh: Agent removed: 'Agent1'.
 
 rule = 505
 alert = 3
@@ -83,7 +63,7 @@ decoder = wazuh
 # Server's logs
 
 [wazuh: server's logs: started]
-log 12 pass = wazuh: Wazuh started.
+log 1 pass = wazuh: Wazuh started.
 
 rule = 502
 alert = 3
@@ -92,14 +72,8 @@ decoder = wazuh
 # Audit
 
 [wazuh: audit: wazuh]
-log 13 pass = wazuh: Audit: Detected rules manipulation: Audit rules removed
-
-rule = 517
-alert = 7
-decoder = wazuh
-
-[wazuh: audit: legacy]
-log 14 pass = ossec: Audit: Detected rules manipulation: Audit rules removed
+log 1 pass = wazuh: Audit: Detected rules manipulation: Audit rules removed
+log 2 pass = ossec: Audit: Detected rules manipulation: Audit rules removed
 
 rule = 517
 alert = 7
@@ -108,70 +82,45 @@ decoder = wazuh
 # Command output
 
 [wazuh: command output: wazuh]
-log 15 pass = wazuh: output: 'command output'
-
-rule = 530
-alert = 0
-decoder = wazuh
-
-[wazuh: command output: legacy]
-log 16 pass = ossec: output: 'command output'
+log 1 pass = wazuh: output: 'command output'
+log 2 pass = ossec: output: 'command output'
 
 rule = 530
 alert = 0
 decoder = wazuh
 
 [wazuh: command output: disk usage]
-log 17 pass = wazuh: output: 'df -P': /dev/loop0 8653 8453 0 100% /mnt/test
+log 1 pass = wazuh: output: 'df -P': /dev/loop0 8653 8453 0 100% /mnt/test
+log 2 pass = ossec: output: 'df -P': /dev/loop0 8653 8453 0 100% /mnt/test
 
 rule = 531
-alert = 7
-decoder = wazuh
-
-[wazuh: command output: legacy disk usage]
-log 18 pass = ossec: output: 'df -P': /dev/loop0 8653 8453 0 100% /mnt/test
-
-rule = 531
-alert = 7
-decoder = wazuh
-
-[wazuh: command output: netstat listening ports]
-log 19 pass = wazuh: output: 'netstat listening ports': tcp 0.0.0.0:8080 0.0.0.0:* 12345/process
-
-rule = 533
 alert = 7
 decoder = wazuh
 
 [wazuh: command output: legacy netstat listening ports]
-log 20 pass = ossec: output: 'netstat listening ports': tcp 0.0.0.0:8080 0.0.0.0:* 12345/process
+log 1 fail = wazuh: output: 'netstat listening ports': tcp 0.0.0.0:8080 0.0.0.0:* 12345/process
+log 2 pass = wazuh: output: 'netstat listening ports': tcp 0.0.0.0:8081 0.0.0.0:* 12345/process
+log 3 fail = wazuh: output: 'netstat listening ports': tcp 0.0.0.0:8081 0.0.0.0:* 12345/process
+log 4 pass = ossec: output: 'netstat listening ports': tcp 0.0.0.0:8081 0.0.0.0:* 12345/process
+log 5 pass = ossec: output: 'netstat listening ports': tcp 0.0.0.0:8080 0.0.0.0:* 12345/process
+log 6 fail = ossec: output: 'netstat listening ports': tcp 0.0.0.0:8080 0.0.0.0:* 12345/process
 
 rule = 533
 alert = 7
 decoder = wazuh
 
 [wazuh: command output: wazuh logged in users]
-log 21 pass = wazuh: output: 'w': reboot   system boot  3.10.0-1127.19.1 Tue Dec  1 12:09 - 21:01  (08:52)
-
-rule = 534
-alert = 1
-decoder = wazuh
-
-[wazuh: command output: legacy logged in users]
-log 22 pass = ossec: output: 'w': reboot system boot  3.10.0-1127.19.1 Wed Dec  2 20:30 - 03:34  (07:04)
+log 1 fail = ossec: output: 'w': vagrant pts/1 10.0.2.2 Wed Dec  2 03:54 - 04:00  (00:02)
+log 2 pass = wazuh: output: 'w': reboot system boot 3.10.0-1127.19.1 Tue Dec  1 13:09 - 21:10  (08:52)
+log 3 pass = ossec: output: 'w': vagrant pts/0 10.0.2.2 Wed Dec  2 03:54 - 05:00  (00:02)
 
 rule = 534
 alert = 1
 decoder = wazuh
 
 [wazuh: command output: wazuh last logged users]
-log 23 pass = wazuh: output: 'last -n 20': reboot system boot  3.10.0-1127.19.1 Wed Dec  2 20:30 - 03:34  (07:04)
-
-rule = 535
-alert = 1
-decoder = wazuh
-
-[wazuh: command output: legacy last logged users]
-log 24 pass = ossec: output: 'last -n 20': reboot   system boot  3.10.0-1127.19.1 Tue Dec  1 12:09 - 21:01  (08:52)
+log 1 pass = wazuh: output: 'last -n 20': reboot system boot 3.10.0-1127.19.1 Wed Dec  2 20:30 - 03:34  (07:04)
+log 2 pass = ossec: output: 'last -n 20': vagrant pts/1 10.0.2.2  Wed Dec  2 14:20 - 14:42  (00:21)
 
 rule = 535
 alert = 1
@@ -180,7 +129,7 @@ decoder = wazuh
 # Agentless
 
 [wazuh: agentless: wazuh]
-log 25 pass = wazuh: agentless: Change detected:
+log 1 pass = wazuh: agentless: Change detected:
 
 rule = 555
 alert = 7
@@ -189,14 +138,8 @@ decoder = wazuh
 # Queue
 
 [wazuh: queue full: wazuh]
-log 26 pass = wazuh: Real-time inotify kernel queue is full.
-
-rule = 560
-alert = 7
-decoder = wazuh
-
-[wazuh: queue full: legacy]
-log 27 pass = ossec: Real-time inotify kernel queue is full.
+log 1 pass = wazuh: Real-time inotify kernel queue is full.
+log 2 pass = ossec: Real-time inotify kernel queue is full.
 
 rule = 560
 alert = 7
@@ -205,42 +148,24 @@ decoder = wazuh
 # Files and logs
 
 [wazuh: file rotated: wazuh]
-log 28 pass = wazuh: File rotated (inode changed): '/var/log/syslog'.
-
-rule = 591
-alert = 3
-decoder = wazuh
-
-[wazuh: file rotated: legacy]
-log 29 pass = ossec: File rotated (inode changed): '/var/log/syslog'.
+log 1 pass = wazuh: File rotated (inode changed): '/var/log/syslog'.
+log 2 pass = ossec: File rotated (inode changed): '/var/log/syslog'.
 
 rule = 591
 alert = 3
 decoder = wazuh
 
 [wazuh: file reduced: wazuh]
-log 30 pass = wazuh: File size reduced (inode changed): '/var/log/syslog'.
-
-rule = 592
-alert = 8
-decoder = wazuh
-
-[wazuh: file reduced: legacy]
-log 31 pass = ossec: File size reduced (inode changed): '/var/log/syslog'.
+log 1 pass = wazuh: File size reduced (inode changed): '/var/log/syslog'.
+log 2 pass = ossec: File size reduced (inode changed): '/var/log/syslog'.
 
 rule = 592
 alert = 8
 decoder = wazuh
 
 [wazuh: log cleared: wazuh]
-log 32 pass = wazuh: Event log cleared: 'example_log'.
-
-rule = 593
-alert = 9
-decoder = wazuh
-
-[wazuh: log cleared reduced: legacy]
-log 33 pass = ossec: Event log cleared: 'example_log'.
+log 1 pass = wazuh: Event log cleared: 'example_log'.
+log 2 pass = ossec: Event log cleared: 'example_log'.
 
 rule = 593
 alert = 9
@@ -249,14 +174,8 @@ decoder = wazuh
 # Attack rules
 
 [attack rules: system users: wazuh]
-log 34 pass = Dec  1 14:11:57 localhost sudo: pam_unix(sudo:session): session opened for user wazuh by vagrant(uid=0)
-
-rule = 40101
-alert = 12
-decoder = pam
-
-[attack rules: system users: ossec]
-log 35 pass = Dec  1 14:11:57 localhost sudo: pam_unix(sudo:session): session opened for user ossec by vagrant(uid=0)
+log 1 pass = Dec  1 14:11:57 localhost sudo: pam_unix(sudo:session): session opened for user wazuh by vagrant(uid=0)
+log 2 pass = Dec  1 14:11:57 localhost sudo: pam_unix(sudo:session): session opened for user ossec by vagrant(uid=0)
 
 rule = 40101
 alert = 12
@@ -265,7 +184,7 @@ decoder = pam
 # WazuhAlert_Decoder
 
 [wazuh: plugin: wazuh]
-log 36 pass = wazuh: Alert Level: 3; Rule: 502 - Comment; Location: test_location; srcip: 0.0.0.0; user: wazuh;
+log 1 pass = wazuh: Alert Level: 3; Rule: 502 - Comment; Location: test_location; srcip: 0.0.0.0; user: wazuh;
 
 rule = 502
 alert = 3

--- a/tools/rules-testing/tests/wazuh.ini
+++ b/tools/rules-testing/tests/wazuh.ini
@@ -110,9 +110,12 @@ alert = 7
 decoder = wazuh
 
 [wazuh: command output: wazuh logged in users]
-log 1 fail = ossec: output: 'w': vagrant pts/1 10.0.2.2 Wed Dec  2 03:54 - 04:00  (00:02)
+log 1 fail = wazuh: output: 'w': vagrant pts/1 10.0.2.2 Wed Dec  2 03:54 - 04:00  (00:02)
 log 2 pass = wazuh: output: 'w': reboot system boot 3.10.0-1127.19.1 Tue Dec  1 13:09 - 21:10  (08:52)
-log 3 pass = ossec: output: 'w': vagrant pts/0 10.0.2.2 Wed Dec  2 03:54 - 05:00  (00:02)
+log 3 fail = wazuh: output: 'w': reboot system boot 3.10.0-1127.19.1 Tue Dec  1 13:09 - 21:10  (08:52)
+log 4 pass = ossec: output: 'w': reboot system boot 3.10.0-1127.19.1 Tue Dec  1 13:09 - 21:10  (08:52)
+log 5 pass = ossec: output: 'w': vagrant pts/1 10.0.2.2 Wed Dec  2 03:54 - 04:00  (00:02)
+log 6 fail = ossec: output: 'w': vagrant pts/1 10.0.2.2 Wed Dec  2 03:54 - 04:00  (00:02)
 
 rule = 534
 alert = 1

--- a/tools/rules-testing/tests/wazuh.ini
+++ b/tools/rules-testing/tests/wazuh.ini
@@ -1,3 +1,5 @@
+# Active response
+
 [wazuh: active response: add host]
 log 1 pass = Sat May  7 03:17:27 CDT 2011 /INSTALLATION/PATH/active-response/bin/host-deny.sh add - 172.16.0.1 1304756247.60385 31151
 rule = 603
@@ -25,6 +27,8 @@ rule = 602
 alert = 3
 decoder = ar_log
 
+# wazuh-logcollector
+
 [wazuh-logcollector: ignore informational messages at startup]
 log 5 pass = 2015/01/29 21:09:49 wazuh-logcollector(1950): INFO: Analyzing file: '/var/log/httpd/error_log'.
 
@@ -38,6 +42,8 @@ log 6 pass = 2015/01/29 21:09:49 ossec-logcollector(1950): INFO: Analyzing file:
 rule = 701
 alert = 0
 decoder = wazuh-logcollector
+
+# Agent's logs
 
 [wazuh: agent's logs: started]
 log 7 pass = wazuh: Agent started: 'Agent1->any'.
@@ -74,12 +80,16 @@ rule = 505
 alert = 3
 decoder = wazuh
 
+# Server's logs
+
 [wazuh: server's logs: started]
 log 12 pass = wazuh: Wazuh started.
 
 rule = 502
 alert = 3
 decoder = wazuh
+
+# Audit
 
 [wazuh: audit: wazuh]
 log 13 pass = wazuh: Audit: Detected rules manipulation: Audit rules removed
@@ -95,65 +105,168 @@ rule = 517
 alert = 7
 decoder = wazuh
 
-[wazuh: command output: wazuh]
-log 15 pass = wazuh: output: 'w'
+# Command output
 
-rule = 534
-alert = 1
+[wazuh: command output: wazuh]
+log 15 pass = wazuh: output: 'command output'
+
+rule = 530
+alert = 0
 decoder = wazuh
 
 [wazuh: command output: legacy]
-log 16 pass = ossec: output: 'w'
+log 16 pass = ossec: output: 'command output'
+
+rule = 530
+alert = 0
+decoder = wazuh
+
+[wazuh: command output: disk usage]
+log 17 pass = wazuh: output: 'df -P': /dev/loop0 8653 8453 0 100% /mnt/test
+
+rule = 531
+alert = 7
+decoder = wazuh
+
+[wazuh: command output: legacy disk usage]
+log 18 pass = ossec: output: 'df -P': /dev/loop0 8653 8453 0 100% /mnt/test
+
+rule = 531
+alert = 7
+decoder = wazuh
+
+[wazuh: command output: netstat listening ports]
+log 19 pass = wazuh: output: 'netstat listening ports': tcp 0.0.0.0:8080 0.0.0.0:* 12345/process
+
+rule = 533
+alert = 7
+decoder = wazuh
+
+[wazuh: command output: legacy netstat listening ports]
+log 20 pass = ossec: output: 'netstat listening ports': tcp 0.0.0.0:8080 0.0.0.0:* 12345/process
+
+rule = 533
+alert = 7
+decoder = wazuh
+
+[wazuh: command output: wazuh logged in users]
+log 21 pass = wazuh: output: 'w': reboot   system boot  3.10.0-1127.19.1 Tue Dec  1 12:09 - 21:01  (08:52)
 
 rule = 534
 alert = 1
 decoder = wazuh
 
+[wazuh: command output: legacy logged in users]
+log 22 pass = ossec: output: 'w': reboot system boot  3.10.0-1127.19.1 Wed Dec  2 20:30 - 03:34  (07:04)
+
+rule = 534
+alert = 1
+decoder = wazuh
+
+[wazuh: command output: wazuh last logged users]
+log 23 pass = wazuh: output: 'last -n 20': reboot system boot  3.10.0-1127.19.1 Wed Dec  2 20:30 - 03:34  (07:04)
+
+rule = 535
+alert = 1
+decoder = wazuh
+
+[wazuh: command output: legacy last logged users]
+log 24 pass = ossec: output: 'last -n 20': reboot   system boot  3.10.0-1127.19.1 Tue Dec  1 12:09 - 21:01  (08:52)
+
+rule = 535
+alert = 1
+decoder = wazuh
+
+# Agentless
+
 [wazuh: agentless: wazuh]
-log 17 pass = wazuh: agentless: Change detected:
+log 25 pass = wazuh: agentless: Change detected:
 
 rule = 555
 alert = 7
 decoder = wazuh
 
+# Queue
+
 [wazuh: queue full: wazuh]
-log 18 pass = wazuh: Real-time inotify kernel queue is full.
+log 26 pass = wazuh: Real-time inotify kernel queue is full.
 
 rule = 560
 alert = 7
 decoder = wazuh
 
 [wazuh: queue full: legacy]
-log 19 pass = ossec: Real-time inotify kernel queue is full.
+log 27 pass = ossec: Real-time inotify kernel queue is full.
 
 rule = 560
 alert = 7
 decoder = wazuh
 
+# Files and logs
+
+[wazuh: file rotated: wazuh]
+log 28 pass = wazuh: File rotated (inode changed): '/var/log/syslog'.
+
+rule = 591
+alert = 3
+decoder = wazuh
+
+[wazuh: file rotated: legacy]
+log 29 pass = ossec: File rotated (inode changed): '/var/log/syslog'.
+
+rule = 591
+alert = 3
+decoder = wazuh
+
 [wazuh: file reduced: wazuh]
-log 20 pass = wazuh: File size reduced
+log 30 pass = wazuh: File size reduced (inode changed): '/var/log/syslog'.
 
 rule = 592
 alert = 8
 decoder = wazuh
 
 [wazuh: file reduced: legacy]
-log 21 pass = ossec: File size reduced
+log 31 pass = ossec: File size reduced (inode changed): '/var/log/syslog'.
 
 rule = 592
 alert = 8
 decoder = wazuh
 
+[wazuh: log cleared: wazuh]
+log 32 pass = wazuh: Event log cleared: 'example_log'.
+
+rule = 593
+alert = 9
+decoder = wazuh
+
+[wazuh: log cleared reduced: legacy]
+log 33 pass = ossec: Event log cleared: 'example_log'.
+
+rule = 593
+alert = 9
+decoder = wazuh
+
+# Attack rules
+
 [attack rules: system users: wazuh]
-log 22 pass = Dec  1 14:11:57 localhost sudo: pam_unix(sudo:session): session opened for user wazuh by vagrant(uid=0)
+log 34 pass = Dec  1 14:11:57 localhost sudo: pam_unix(sudo:session): session opened for user wazuh by vagrant(uid=0)
 
 rule = 40101
 alert = 12
 decoder = pam
 
 [attack rules: system users: ossec]
-log 23 pass = Dec  1 14:11:57 localhost sudo: pam_unix(sudo:session): session opened for user ossec by vagrant(uid=0)
+log 35 pass = Dec  1 14:11:57 localhost sudo: pam_unix(sudo:session): session opened for user ossec by vagrant(uid=0)
 
 rule = 40101
 alert = 12
 decoder = pam
+
+# WazuhAlert_Decoder
+
+[wazuh: plugin: wazuh]
+log 36 pass = wazuh: Alert Level: 3; Rule: 502 - Comment; Location: test_location; srcip: 0.0.0.0; user: wazuh;
+
+rule = 502
+alert = 3
+decoder = wazuh


### PR DESCRIPTION
|Related issue|
|---|
|#808|

#### Description

This PR adds to **wazuh.ini** file all the test cases for the rules and decoders modified during the Epic #784.

#### Tests

- [x] The **runtests.py** script successfully completes all the tests
 