### PR TITLE
Add Maltrail decoder

### DIFF
--- a/decoders/0510-maltrail_decoders.xml
+++ b/decoders/0510-maltrail_decoders.xml
@@ -1,0 +1,24 @@
+<!--
+  -  Maltrail decoder
+  -  Author: Michael Muenz, Julián Morales
+  -  Updated by Wazuh, Inc.
+  -  Copyright (C) 2015-2020, Wazuh Inc.
+  -  Copyright (C) 2009 Trend Micro Inc.
+  -  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2.
+-->
+
+<!--
+  - Will extract the srcip, srcport, dstip and dstport and also trail and category.
+  - Examples: Dec 23 14:55:34 OPNsense.localdomain CEF: 0|Maltrail|sensor|0.26.1|2020-12-23|long domain (suspicious)
+    |0|src=172.24.68.133 spt=55989 dst=8.8.8.8 dpt=53 trail=(q6pmisvlqpgxptq1s6psghvyoqali.uribl).rspamd.com ref=(heuristic)
+-->
+  
+<decoder name="CEF">
+      <program_name>^CEF$</program_name>
+</decoder>
+
+<decoder name="Maltrail">
+      <parent>CEF</parent>
+      <regex>(\w+)\|(\w+)\|(\w+)\|(\.+)\|(\d+-\d+-\d+)\|(\.+)\|(\d+)\|src=(\d+.\d+.\d+.\d+) spt=(\d+) dst=(\d+.\d+.\d+.\d+) dpt=(\d+) trail=(\.+) ref=(\.+)</regex>
+      <order>code, application, type, version, date, category, code_2, srcip, srcport, dstip, dstport, trail, ref</order>
+</decoder>


### PR DESCRIPTION
Hi,

this is a decoder for popular OSS maltrail https://github.com/stamparm/maltrail which is a malicious traffic analyser and can work as sensor and/or server. In addition it offers syslog output.

This decoder was done with help of Julián Morales here:
https://wazuh.slack.com/archives/C0A933R8E/p1608733841319200

Me and maltrail community would love to see this integrated in default installation. 