### PR TITLE
Remove CIS policy "Ensure XD/NX support is enabled" for SCA.

### DIFF
--- a/sca/centos/6/cis_centos6_linux.yml
+++ b/sca/centos/6/cis_centos6_linux.yml
@@ -598,22 +598,6 @@ checks:
       - 'c:sysctl fs.suid_dumpable -> r:^fs.suid_dumpable\s*=\s*0\s*$'
       - 'c:grep -Rh fs\.suid_dumpable /etc/sysctl.conf /etc/sysctl.d -> r:^\s*fs.suid_dumpable\s*=\s*0\s*$'
 
-# 1.5.2 XD/NX enabled
-  - id: 5533 
-    title: "Ensure XD/NX support is enabled"
-    description: "Recent processors in the x86 family support the ability to prevent code execution on a per memory page basis. Generically and on AMD processors, this ability is called No Execute (NX), while on Intel processors it is called Execute Disable (XD). This ability can help prevent exploitation of buffer overflow vulnerabilities and should be activated whenever possible. Extra steps must be taken to ensure that this protection is enabled, particularly on 32-bit x86 systems. Other processors, such as Itanium and POWER, have included such support since inception and the standard kernel for those platforms supports the feature."
-    rationale: "Enabling any feature that can protect against buffer overflow attacks enhances the security of the system."
-    remediation: "On 32 bit systems install a kernel with PAE support, no installation is required on 64 bit systems: If necessary configure your bootloader to load the new kernel and reboot the system. You may need to enable NX or XD support in your bios."
-    compliance:
-      - cis: ["1.5.2"]
-      - cis_csc: ["8.4"]
-      - pci_dss: ["2.2.4"]
-      - nist_800_53: ["CM.1"]
-      - tsc: ["CC5.2"]
-    condition: all
-    rules:
-      - 'c:dmesg -> r:NX \(Execute Disable\) protection: active'
-
 # 1.5.3 Enable Randomized Virtual Memory Region Placement (Scored)
   - id: 5534 
     title: "Ensure address space layout randomization (ASLR) is enabled"

--- a/sca/centos/7/cis_centos7_linux.yml
+++ b/sca/centos/7/cis_centos7_linux.yml
@@ -641,23 +641,6 @@ checks:
       - 'c:sysctl fs.suid_dumpable -> r:^\s*fs.suid_dumpable\s*=\s*0\s*$'
       - 'c:grep -Rh fs\.suid_dumpable /etc/sysctl.conf /etc/sysctl.d -> r:^\s*fs.suid_dumpable\s*=\s*0\s*$'
 
-# 1.6.2 XD/NX enabled
-  - id: 6033 
-    title: "Ensure XD/NX support is enabled"
-    description: "Recent processors in the x86 family support the ability to prevent code execution on a per memory page basis. Generically and on AMD processors, this ability is called No Execute (NX), while on Intel processors it is called Execute Disable (XD). This ability can help prevent exploitation of buffer overflow vulnerabilities and should be activated whenever possible. Extra steps must be taken to ensure that this protection is enabled, particularly on 32-bit x86 systems. Other processors, such as Itanium and POWER, have included such support since inception and the standard kernel for those platforms supports the feature."
-    rationale: "Enabling any feature that can protect against buffer overflow attacks enhances the security of the system."
-    remediation: "On 32 bit systems install a kernel with PAE support, no installation is required on 64 bit systems: If necessary configure your bootloader to load the new kernel and reboot the system. You may need to enable NX or XD support in your bios."
-    compliance:
-      - cis: ["1.6.2"]
-      - cis_csc: ["8.3"]
-      - pci_dss: ["2.2.4"]
-      - nist_800_53: ["CM.1"]
-      - tsc: ["CC5.2"]
-    condition: any
-    rules:
-      - 'c:journalctl -> r:^kernel:\s+NX \(Execute Disable\) protection: active'
-      - 'c:dmesg -> r:NX \(Execute Disable\) protection: active'
-
 # 1.6.3 Enable Randomized Virtual Memory Region Placement (Scored)
   - id: 6034 
     title: "Ensure address space layout randomization (ASLR) is enabled"

--- a/sca/debian/cis_debian10.yml
+++ b/sca/debian/cis_debian10.yml
@@ -570,21 +570,6 @@ checks:
 
 # 1.6 Additional Process Hardening
 
-  - id: 2533 
-    title: "Ensure XD/NX support is enabled"
-    description: "Recent processors in the x86 family support the ability to prevent code execution on a per memory page basis. Generically and on AMD processors, this ability is called No Execute (NX), while on Intel processors it is called Execute Disable (XD). This ability can help prevent exploitation of buffer overflow vulnerabilities and should be activated whenever possible. Extra steps must be taken to ensure that this protection is enabled, particularly on 32-bit x86 systems. Other processors, such as Itanium and POWER, have included such support since inception and the standard kernel for those platforms supports the feature."
-    rationale: "Enabling any feature that can protect against buffer overflow attacks enhances the security of the system."
-    remediation: "On 32 bit systems install a kernel with PAE support, no installation is required on 64 bit systems: If necessary configure your bootloader to load the new kernel and reboot the system. You may need to enable NX or XD support in your bios."
-    compliance:
-      - cis: ["1.6.1"]
-      - cis_csc: ["8.3"]
-      - pci_dss: ["2.2.4"]
-      - nist_800_53: ["CM.1"]
-      - tsc: ["CC5.2"]
-    condition: all
-    rules:
-      - 'c:journalctl -> r:NX \(Execute Disable\) protection: active'
-
   - id: 2534 
     title: "Ensure address space layout randomization (ASLR) is enabled"
     description: "Address space layout randomization (ASLR) is an exploit mitigation technique which randomly arranges the address space of key data areas of a process."

--- a/sca/debian/cis_debian7.yml
+++ b/sca/debian/cis_debian7.yml
@@ -409,21 +409,6 @@ checks:
       - 'c:sysctl fs.suid_dumpable -> r:=\s*0$'
       - 'c:grep -Rh ^*[[:space:]]*hard[[:space:]][[:space:]]*core[[:space:]][[:space:]]* /etc/security/limits.conf /etc/security/limits.d -> r:\s0$|\t0$'
 
-# 4.2 Enable XD/NX Support on 32-bit x86 Systems (Not Scored)
-  - id: 1026 
-    title: "Enable XD/NX Support on 32-bit x86 Systems"
-    description: "Recent processors in the x86 family support the ability to prevent code execution on a per memory page basis. Generically and on AMD processors, this ability is called No Execute (NX), while on Intel processors it is called Execute Disable (XD). This ability can help prevent exploitation of buffer overflow vulnerabilities and should be activated whenever possible. Extra steps must be taken to ensure that this protection is enabled, particularly on 32-bit x86 systems. Other processors, such as Itanium and POWER, have included such support since inception and the standard kernel for those platforms supports the feature."
-    rationale: "Enabling any feature that can protect against buffer overflow attacks enhances the security of the system."
-    remediation: "On 32 bit systems install a kernel with PAE support, no installation is required on 64 bit systems: If necessary configure your bootloader to load the new kernel and reboot the system. You may need to enable NX or XD support in your bios."
-    compliance:
-      - cis: ["4.2"]
-      - pci_dss: ["2.2.4"]
-      - nist_800_53: ["CM.1"]
-      - tsc: ["CC5.2"]
-    condition: all
-    rules:
-      - 'c:dmesg -> r:NX \(Execute Disable\) protection: active'
-
 # 4.3 Enable Randomized Virtual Memory Region Placement (Scored)
   - id: 1027 
     title: "Enable Randomized Virtual Memory Region Placement"

--- a/sca/debian/cis_debian8.yml
+++ b/sca/debian/cis_debian8.yml
@@ -486,21 +486,6 @@ checks:
       - 'c:grep -Rh fs\.suid_dumpable /etc/sysctl.conf /etc/sysctl.d -> r:=\s*\t*0$'
       - 'c:grep -Rh ^*[[:space:]]*hard[[:space:]][[:space:]]*core[[:space:]][[:space:]]* /etc/security/limits.conf /etc/security/limits.d -> r:\s*\t*0$'
 
-  - id: 1529 
-    title: "Ensure XD/NX support is enabled"
-    description: "Recent processors in the x86 family support the ability to prevent code execution on a per memory page basis. Generically and on AMD processors, this ability is called No Execute (NX), while on Intel processors it is called Execute Disable (XD). This ability can help prevent exploitation of buffer overflow vulnerabilities and should be activated whenever possible. Extra steps must be taken to ensure that this protection is enabled, particularly on 32-bit x86 systems. Other processors, such as Itanium and POWER, have included such support since inception and the standard kernel for those platforms supports the feature."
-    rationale: "Enabling any feature that can protect against buffer overflow attacks enhances the security of the system."
-    remediation: "On 32 bit systems install a kernel with PAE support, no installation is required on 64 bit systems: If necessary configure your bootloader to load the new kernel and reboot the system. You may need to enable NX or XD support in your bios."
-    compliance:
-      - cis: ["1.5.2"]
-      - cis_csc: ["8.4"]
-      - pci_dss: ["2.2.4"]
-      - nist_800_53: ["CM.1"]
-      - tsc: ["CC5.2"]
-    condition: all
-    rules:
-      - 'c:dmesg -> r:NX \(Execute Disable\) protection: active'
-
   - id: 1530 
     title: "Ensure address space layout randomization (ASLR) is enabled"
     description: "Address space layout randomization (ASLR) is an exploit mitigation technique which randomly arranges the address space of key data areas of a process."

--- a/sca/debian/cis_debian9.yml
+++ b/sca/debian/cis_debian9.yml
@@ -474,21 +474,6 @@ checks:
       - 'c:grep -Rh fs\.suid_dumpable /etc/sysctl.conf /etc/sysctl.d -> !r:^# && r:=\s*\t*0$'
       - 'c:grep -Rh ^*[[:space:]]*hard[[:space:]][[:space:]]*core[[:space:]][[:space:]]* /etc/security/limits.conf /etc/security/limits.d -> r:\s*\t*0$'
 
-  - id: 2028 
-    title: "Ensure XD/NX support is enabled"
-    description: "Recent processors in the x86 family support the ability to prevent code execution on a per memory page basis. Generically and on AMD processors, this ability is called No Execute (NX), while on Intel processors it is called Execute Disable (XD). This ability can help prevent exploitation of buffer overflow vulnerabilities and should be activated whenever possible. Extra steps must be taken to ensure that this protection is enabled, particularly on 32-bit x86 systems. Other processors, such as Itanium and POWER, have included such support since inception and the standard kernel for those platforms supports the feature."
-    rationale: "Enabling any feature that can protect against buffer overflow attacks enhances the security of the system."
-    remediation: "On 32 bit systems install a kernel with PAE support, no installation is required on 64 bit systems: If necessary configure your bootloader to load the new kernel and reboot the system. You may need to enable NX or XD support in your bios."
-    compliance:
-      - cis: ["1.5.2"]
-      - cis_csc: ["8.3"]
-      - pci_dss: ["2.2.4"]
-      - nist_800_53: ["CM.1"]
-      - tsc: ["CC5.2"]
-    condition: all
-    rules:
-      - 'c:dmesg -> r:NX \(Execute Disable\) protection: active'
-
   - id: 2029 
     title: "Ensure address space layout randomization (ASLR) is enabled"
     description: "Address space layout randomization (ASLR) is an exploit mitigation technique which randomly arranges the address space of key data areas of a process."

--- a/sca/rhel/6/cis_rhel6_linux.yml
+++ b/sca/rhel/6/cis_rhel6_linux.yml
@@ -614,22 +614,6 @@ checks:
       - 'c:sysctl fs.suid_dumpable -> r:^fs.suid_dumpable\s*=\s*0\s*$'
       - 'c:grep -Rh fs\.suid_dumpable /etc/sysctl.conf /etc/sysctl.d -> r:^\s*fs.suid_dumpable\s*=\s*0\s*$'
 
-# 1.5.2 XD/NX enabled
-  - id: 4034 
-    title: "Ensure XD/NX support is enabled"
-    description: "Recent processors in the x86 family support the ability to prevent code execution on a per memory page basis. Generically and on AMD processors, this ability is called No Execute (NX), while on Intel processors it is called Execute Disable (XD). This ability can help prevent exploitation of buffer overflow vulnerabilities and should be activated whenever possible. Extra steps must be taken to ensure that this protection is enabled, particularly on 32-bit x86 systems. Other processors, such as Itanium and POWER, have included such support since inception and the standard kernel for those platforms supports the feature."
-    rationale: "Enabling any feature that can protect against buffer overflow attacks enhances the security of the system."
-    remediation: "On 32 bit systems install a kernel with PAE support, no installation is required on 64 bit systems: If necessary configure your bootloader to load the new kernel and reboot the system. You may need to enable NX or XD support in your bios."
-    compliance:
-      - cis: ["1.5.2"]
-      - cis_csc: ["8.4"]
-      - pci_dss: ["2.2.4"]
-      - nist_800_53: ["CM.1"]
-      - tsc: ["CC5.2"]
-    condition: all
-    rules:
-      - 'c:dmesg -> r:NX \(Execute Disable\) protection: active'
-
 # 1.5.3 Enable Randomized Virtual Memory Region Placement (Scored)
   - id: 4035 
     title: "Ensure address space layout randomization (ASLR) is enabled"
@@ -3270,7 +3254,3 @@ the potential attack surface."
     condition: none
     rules:
       - 'f:/etc/passwd -> !r:^# && !r:^\s*\t*root: && r:^\w+:\w+:0:'
-
-
-
-

--- a/sca/rhel/7/cis_rhel7_linux.yml
+++ b/sca/rhel/7/cis_rhel7_linux.yml
@@ -661,23 +661,6 @@ checks:
       - 'c:sysctl fs.suid_dumpable -> r:^\s*fs.suid_dumpable\s*=\s*0\s*$'
       - 'c:grep -Rh fs\.suid_dumpable /etc/sysctl.conf /etc/sysctl.d -> r:^\s*fs.suid_dumpable\s*=\s*0\s*$'
 
-# 1.6.2 XD/NX enabled
-  - id: 4534 
-    title: "Ensure XD/NX support is enabled"
-    description: "Recent processors in the x86 family support the ability to prevent code execution on a per memory page basis. Generically and on AMD processors, this ability is called No Execute (NX), while on Intel processors it is called Execute Disable (XD). This ability can help prevent exploitation of buffer overflow vulnerabilities and should be activated whenever possible. Extra steps must be taken to ensure that this protection is enabled, particularly on 32-bit x86 systems. Other processors, such as Itanium and POWER, have included such support since inception and the standard kernel for those platforms supports the feature."
-    rationale: "Enabling any feature that can protect against buffer overflow attacks enhances the security of the system."
-    remediation: "On 32 bit systems install a kernel with PAE support, no installation is required on 64 bit systems: If necessary configure your bootloader to load the new kernel and reboot the system. You may need to enable NX or XD support in your bios."
-    compliance:
-      - cis: ["1.6.2"]
-      - cis_csc: ["8.3"]
-      - pci_dss: ["2.2.4"]
-      - nist_800_53: ["CM.1"]
-      - tsc: ["CC5.2"]
-    condition: any
-    rules:
-      - 'c:journalctl -> r:^kernel:\s+NX \(Execute Disable\) protection: active'
-      - 'c:dmesg -> r:NX \(Execute Disable\) protection: active'
-
 # 1.6.3 Enable Randomized Virtual Memory Region Placement (Scored)
   - id: 4535 
     title: "Ensure address space layout randomization (ASLR) is enabled"


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh/issues/6997|

This policy increases the memory usage of the agent as it calls `journalctl` and `dmesg`, which can produce a potentially large data output. That produces a memory usage peak and, despite that does not produce a memory leak, the memory is not guaranteed to be returned to the system.

We will work on a fix in the code of SCA, but we're temporarily disabling this check in order to prevent the agent from requiring too much memory.