### PR TITLE
Removed alert_by_email option from default ruleset

### DIFF
--- a/rules/0235-vmware_rules.xml
+++ b/rules/0235-vmware_rules.xml
@@ -127,7 +127,6 @@
     <match>-> VM_STATE_RECONFIGURING</match>
     <description>Virtual machine being reconfigured.</description>
     <group>config_changed,pci_dss_10.2.7,gpg13_4.13,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.14,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
-    <options>alert_by_email</options>
   </rule>
 
 

--- a/rules/0265-php_rules.xml
+++ b/rules/0265-php_rules.xml
@@ -68,7 +68,6 @@
     <if_sid>31410</if_sid>
     <match>Failed opening|failed to open stream</match>
     <description>PHP internal error (missing file).</description>
-    <options>alert_by_email</options>
     <group>attack,pci_dss_6.5,gpg13_4.3,gdpr_IV_35.7.d,nist_800_53_SA.11,tsc_CC6.6,tsc_CC7.1,tsc_CC8.1,</group>
   </rule>
 
@@ -76,7 +75,6 @@
     <if_sid>31410</if_sid>
     <match>bytes written, possibly out of free disk space in</match>
     <description>PHP internal error (server out of space).</description>
-    <options>alert_by_email</options>
     <mitre>
       <id>T1488</id>
     </mitre>
@@ -98,7 +96,6 @@ d 'includes/SkinTemplate.php'
     <if_sid>31420</if_sid>
     <match>Failed opening required |Call to undefined function </match>
     <description>PHP internal error (missing file or function).</description>
-    <options>alert_by_email</options>
     <group>pci_dss_6.5,pci_dss_6.5.5,pci_dss_10.6.1,gpg13_4.3,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_SA.11,nist_800_53_AU.6,tsc_CC6.6,tsc_CC7.1,tsc_CC8.1,tsc_CC7.2,tsc_CC7.3,</group>
   </rule>
 
@@ -108,7 +105,6 @@ d 'includes/SkinTemplate.php'
   <rule id="31430" level="5">
     <if_sid>31403, 31406</if_sid>
     <description>PHP Parse error.</description>
-    <options>alert_by_email</options>
     <group>pci_dss_6.5,pci_dss_6.5.5,pci_dss_10.6.1,gpg13_4.3,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_SA.11,nist_800_53_AU.6,tsc_CC6.6,tsc_CC7.1,tsc_CC8.1,tsc_CC7.2,tsc_CC7.3,</group>
   </rule>
 

--- a/rules/0580-win-security_rules.xml
+++ b/rules/0580-win-security_rules.xml
@@ -212,7 +212,6 @@
 
   <rule id="60119" level="3">
     <if_sid>60106</if_sid>
-    <options>alert_by_email</options>
     <if_fts />
     <description>First time this user logged in this system</description>
     <options>no_full_log</options>

--- a/rules/0585-win-application_rules.xml
+++ b/rules/0585-win-application_rules.xml
@@ -103,7 +103,6 @@
   <rule id="60611" level="3">
     <if_sid>60609</if_sid>
     <field name="win.system.eventID">^11724$|^1034$</field>
-    <options>alert_by_email</options>
     <description>Application Uninstalled $(win.eventdata.data)</description>
     <options>no_full_log</options>
   </rule>
@@ -111,7 +110,6 @@
   <rule id="60612" level="3">
     <if_sid>60609</if_sid>
     <field name="win.system.eventID">^11707$|^1033$</field>
-    <options>alert_by_email</options>
     <description>Application Installed $(win.eventdata.data)</description>
     <options>no_full_log</options>
   </rule>

--- a/rules/0605-win-mcafee_rules.xml
+++ b/rules/0605-win-mcafee_rules.xml
@@ -134,7 +134,6 @@
   <rule id="62616" level="5">
     <if_sid>62607</if_sid>
     <field name="win.system.message">contains the EICAR test file</field>
-    <options>alert_by_email</options>
     <description>McAfee Windows AV - EICAR test file detected</description>
   </rule>
 

--- a/rules/0615-win-ms-se_rules.xml
+++ b/rules/0615-win-ms-se_rules.xml
@@ -150,7 +150,6 @@
   <rule id="63616" level="5">
     <if_sid>63604,63605</if_sid>
     <field name="win.system.message">\.*DOS/EICAR_Test_File</field>
-    <options>alert_by_email</options>
     <description>Microsoft Security Essentials - EICAR test file detected</description>
     <options>no_full_log</options>
   </rule>


### PR DESCRIPTION
This pull request addresses the removel of the alert_by_email option that is present on some of the default rules, as per requested in https://github.com/wazuh/wazuh/issues/8191