### PR TITLE
Update 0280-attack_rules.xml

### DIFF
--- a/rules/0280-attack_rules.xml
+++ b/rules/0280-attack_rules.xml
@@ -59,6 +59,7 @@
   </rule>
 
   <rule id="40106" level="12">
+    <program_name>yppasswd</program_name>
     <match>@@@@@@@@@@@@@@@@@@@@@@@@@</match>
     <description>Buffer overflow attempt (probably on yppasswd).</description>
     <mitre>


### PR DESCRIPTION
the rule 40106 was too generic,
may be a good idea to match the regex only with log where the program name is yppassword