### PR TITLE
Add watchguard firebox support

### DIFF
--- a/decoders/0510-watchguard-firebox_decoders.xml
+++ b/decoders/0510-watchguard-firebox_decoders.xml
@@ -384,6 +384,7 @@ Apr 15 12:18:24 FW-125852 FVE1001001001 firewall: msg_id="3000-0150" Deny 1-Trus
 # Traffic connection terminated
 Apr 15 12:18:24 FW-125852 FVE1001001001 firewall: msg_id="3000-0151" Allow 1-Trusted 0-External tcp 10.0.1.2 220.181.90.24 53018 80 app_id="63" app_cat_id="18" app_ctl_disp="2" duration="80" sent_bytes="652" rcvd_bytes="423" (HTTP-00)
 Apr 15 12:18:24 FW-125852 FVE1001001001 firewall: msg_id="3000-0151" Allow Firebox Iface_Bouygues icmp 89.87.170.163 8.8.4.4 duration="30" sent_bytes="48" rcvd_bytes="48"  (Any From Firebox-00)
+
 # Hostile traffic
 May 28 06:58:26 FW-123346 FVE1010101001 firewall: msg_id="3000-0173" Deny 0-External Firebox 52 tcp 20 127 206.190.60.138 10.0.0.1 62443 80 offset 8 S 832026162 win 8192 blocked sites (Internal Policy)
 
@@ -566,9 +567,9 @@ Mar 21 15:48:45 FW-125852 FVE1001001001 wgcgi[29063]: SSL VPN user testuser@Fire
 </decoder>
 
 <decoder name="watchguard-firebox-auth-info">
-  <parent>watchguard-firebox-auth</parent>
+  <parent>watchguard-firebox-auth</parent> <!-- NOOK -->
   <regex type="pcre2" offset="after_parent">msg_id="[0-9a-fA-F]{4}-[0-9a-fA-F]{4}"\s(Authentication of)?\s?(.*\s[Uu]ser)\s\[?(\S+)\]?\s</regex>
-  <order>extra_data, data, srcuser</order>
+  <order>extra_data, account_type, srcuser</order>
 </decoder>
 
 <decoder name="watchguard-firebox-auth-info">
@@ -580,14 +581,20 @@ Mar 21 15:48:45 FW-125852 FVE1001001001 wgcgi[29063]: SSL VPN user testuser@Fire
 <decoder name="watchguard-firebox-auth-info">
   <parent>watchguard-firebox-auth</parent>
   <regex type="pcre2" offset="after_parent">(logged in)</regex>
-  <order>status</order>
+  <order>action</order>
+</decoder>
+
+<decoder name="watchguard-firebox-auth-info">
+  <parent>watchguard-firebox-auth</parent>
+  <regex type="pcre2" offset="after_parent">(rejected)</regex>
+  <order>action</order>
 </decoder>
 
 <!-- Special case for wgcgi auth where no msg id is given... Thanks WG -->
 <decoder name="watchguard-firebox-auth-info">
   <parent>watchguard-firebox-auth</parent>
-  <regex type="pcre2" offset="after_parent">^(SSL VPN) user.*</regex>
-  <order>id</order>
+  <regex type="pcre2" offset="after_parent">^(SSL VPN) user\s(\S+)\s</regex>
+  <order>id, srcuser</order>
 </decoder>
 
 <!-- SECURITY EVENTS DECODER -->

--- a/decoders/0510-watchguard-firebox_decoders.xml
+++ b/decoders/0510-watchguard-firebox_decoders.xml
@@ -567,9 +567,9 @@ Mar 21 15:48:45 FW-125852 FVE1001001001 wgcgi[29063]: SSL VPN user testuser@Fire
 </decoder>
 
 <decoder name="watchguard-firebox-auth-info">
-  <parent>watchguard-firebox-auth</parent> <!-- NOOK -->
-  <regex type="pcre2" offset="after_parent">msg_id="[0-9a-fA-F]{4}-[0-9a-fA-F]{4}"\s(Authentication of)?\s?(.*\s[Uu]ser)\s\[?(\S+)\]?\s</regex>
-  <order>extra_data, account_type, srcuser</order>
+  <parent>watchguard-firebox-auth</parent>
+  <regex type="pcre2" offset="after_parent">msg_id="[0-9a-fA-F]{4}-[0-9a-fA-F]{4}"(?:\sAuthentication of)?\s(.*?\s[Uu]ser)\s\[?([^\[\]\s]+)</regex>
+  <order>account_type, srcuser</order>
 </decoder>
 
 <decoder name="watchguard-firebox-auth-info">

--- a/decoders/0510-watchguard-firebox_decoders.xml
+++ b/decoders/0510-watchguard-firebox_decoders.xml
@@ -5,13 +5,17 @@
   -  Copyright (C) 2021, FMI Groupe, Wazuh Inc.
   -  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2.
 
--  Created by ph3nix.
-
-   Changelog   
+   Changelog
+   2021/07/08 - Orsiris de Jong - Added IGMP protocol to protocol list
+                                - Added generic traffic decoder as last resort
+								- Added security event (SIGD) decoder
+   2021/07/06 - Orsiris de Jong - Added Link Monitor external interface detection
+                                - Fix firewall / proxy rules (missing srcport and dstport, bogus protocol detection)
+                                - Fix SSL VPN authentication via wgcgi has no msg_id
    2021/06/10 - Orsiris de Jong - Switched to sibling decoders
                                   - Added IPv4 and IPv6 specific regexes (kept separate because it's already confusing, and IPv6 may contain IPv4 mapped addresses)
                                   - IPv4 REGEX is pretty generic
-                                  - IPv6 REGEX is my own variant of https://stackoverflow.com/a/17871737/2635443
+                                  - IPv6 REGEX is my own (shorter) variant of https://stackoverflow.com/a/17871737/2635443
                                   - Port REGEX just allows 0-65535 ports
                                   - Protocol REGEX is just a plain list of possible protocols found in these logs
                                   - geo_src and geo_dst REGEX just allow a 3 character (ISO 3166-1 alpha-3) country detection
@@ -22,7 +26,7 @@
                                 - Added various load balance probe, layer 2 looping decoders
                                 - Added packet filter and proxy traffic decoders
                                 - Added unhandled traffic decoders
-                                - Switched authentication to sibling decoders
+                                - Switched to sibling decoders usage
                                 
    2021/04/21 - ph3nix          - Initial release
                                 - Authentication detection, VPN authentication, VPN traffic and generic traffic
@@ -32,16 +36,17 @@ Watchguard firewall serial numbers are:
 - D0F = T10/T15 appliances
 - D02 = T35/T40/T55 appliances
 
+Watchguard event catalog https://www.watchguard.com/help/docs/fireware/12/en-US/log_catalog/Log-Catalog_v12_7.pdf
+
 -->
 
 <!-- FIREWALL DECODER -->
 <decoder name="watchguard-firebox-firewall">
-  <prematch type="pcre2">(FVE\w+|D0F\w+|D02\w+) firewall: </prematch>
-  <type>firewall</type>
+  <prematch type="pcre2">(FVE\w+|D0F\w+|D02\w+)\s(\(\S+\))?\s?firewall: </prematch>
 </decoder>
 
 <!--
-Apr 15 14:40:22 FW-125852 FVE1032175935 firewall: msg_id="XXXX-XXXX"
+Apr 15 14:40:22 FW-125852 FVE1001001001 firewall: msg_id="XXXX-XXXX"
 -->
 <decoder name="watchguard-firebox-firewall-info">
   <parent>watchguard-firebox-firewall</parent>
@@ -109,9 +114,6 @@ May 28 06:58:26 FW-123346 FVE1010101001 firewall: msg_id="3000-0169" IP spoofing
   <order>dstip</order>
 </decoder>
 
-<!--
-May 28 06:58:26 FW-123346 FVE1010101001 firewall: msg_id="0F01-0015" APT threat notified. Details='Policy Name: HTTPS-proxy-00 Reason: high APT threat detected Task_UUID: d09445005c3f4a9a9bb78c8cb34edc2a Source IP: 10.0.1.2 Source Port: 43130 Destination IP: 67.228.175.200 Destination Port: 443 Proxy Type: HTTP Proxy Host: analysis.lastline.com Path: /docs/lastline-demo-sample.exe'
--->
 <!-- IPv4 -->
 <decoder name="watchguard-firebox-firewall-info">
   <parent>watchguard-firebox-firewall</parent>
@@ -190,7 +192,7 @@ May 28 06:58:26 FW-123346 FVE1010101001 firewall: msg_id="3000-0172" Blocked por
 
 <decoder name="watchguard-firebox-firewall-info">
   <parent>watchguard-firebox-firewall</parent>
-  <regex type="pcre2" offset="after_parent">.*(SYN|syn|TCP|tcp|UDP|udp|ICMP|icmp|[Ii][Pp][Ss][Ee][Cc]|[Ii][Kk][Ee])|http|HTTP|https|HTTPS|smtp|SMTP|dns|DNS.*</regex>
+  <regex type="pcre2" offset="after_parent">.*(SYN|syn|TCP|tcp|UDP|udp|ICMP|icmp|IGMP|igmp|[Ii][Pp][Ss][Ee][Cc]|[Ii][Kk][Ee])|http|HTTP|https|HTTPS|smtp|SMTP|IMAP|imap|dns|DNS.*</regex>
   <order>protocol</order>
 </decoder>
 
@@ -214,8 +216,8 @@ May 28 06:58:26 FW-123346 FVE1010101001 firewall: msg_id="3000-0172" Blocked por
 
 
 <!--
-Apr 15 14:40:22 FW-125852 FVE1032175935 firewall: msg_id="3000-0027" Firewall is starting up
-Apr 15 14:40:22 FW-125852 FVE1032175935 firewall: msg_id="3000-0028" Firewall is shutting down 
+Apr 15 14:40:22 FW-125852 FVE1001001001 firewall: msg_id="3000-0027" Firewall is starting up
+Apr 15 14:40:22 FW-125852 FVE1001001001 firewall: msg_id="3000-0028" Firewall is shutting down 
 -->
 <decoder name="watchguard-firebox-firewall-info">
   <parent>watchguard-firebox-firewall</parent>
@@ -224,7 +226,7 @@ Apr 15 14:40:22 FW-125852 FVE1032175935 firewall: msg_id="3000-0028" Firewall is
 </decoder>
 
 <!--
-Apr 15 14:40:22 FW-125852 FVE1032175935 firewall: msg_id="3000-003A" Unable to read the feature keys, some features may be unavailable
+Apr 15 14:40:22 FW-125852 FVE1001001001 firewall: msg_id="3000-003A" Unable to read the feature keys, some features may be unavailable
 -->
 <decoder name="watchguard-firebox-firewall-info">
   <parent>watchguard-firebox-firewall</parent>
@@ -249,7 +251,7 @@ May 28 06:58:26 FW-123346 FVE1010101001 firewall: msg_id="3000-0162" SYN flood a
 </decoder>
 
 <!--
-Apr 15 14:40:22 FW-125852 FVE1032175935 firewall: msg_id="3000-0029" IP address 192.168.111.254 will not be added to the blocked sites list because it is exempt
+Apr 15 14:40:22 FW-125852 FVE1001001001 firewall: msg_id="3000-0029" IP address 192.168.111.254 will not be added to the blocked sites list because it is exempt
 -->
 <decoder name="watchguard-firebox-firewall-info">
   <parent>watchguard-firebox-firewall</parent>
@@ -258,7 +260,7 @@ Apr 15 14:40:22 FW-125852 FVE1032175935 firewall: msg_id="3000-0029" IP address 
 </decoder>
 
 <!--
-Apr 15 14:40:22 FW-125852 FVE1032175935 firewall: msg_id="3000-0040" Idle timeout has occurred for blocked site 192.168.111.10
+Apr 15 14:40:22 FW-125852 FVE1001001001 firewall: msg_id="3000-0040" Idle timeout has occurred for blocked site 192.168.111.10
 -->
 <decoder name="watchguard-firebox-firewall-info">
   <parent>watchguard-firebox-firewall</parent>
@@ -267,8 +269,8 @@ Apr 15 14:40:22 FW-125852 FVE1032175935 firewall: msg_id="3000-0040" Idle timeou
 </decoder>
 
 <!--
-Apr 15 14:40:22 FW-125852 FVE1032175935 firewall: msg_id="3000-00C9" TCP probe packets timeout, Load Balance Server 10.10.10.100 is offline.
-Apr 15 14:40:22 FW-125852 FVE1032175935 firewall: msg_id="3000-00CB" ICMP probe packets timeout, Load Balance Server 10.10.10.100 is offline.
+Apr 15 14:40:22 FW-125852 FVE1001001001 firewall: msg_id="3000-00C9" TCP probe packets timeout, Load Balance Server 10.10.10.100 is offline.
+Apr 15 14:40:22 FW-125852 FVE1001001001 firewall: msg_id="3000-00CB" ICMP probe packets timeout, Load Balance Server 10.10.10.100 is offline.
 -->
 <decoder name="watchguard-firebox-firewall-info">
   <parent>watchguard-firebox-firewall</parent>
@@ -283,12 +285,12 @@ Apr 15 14:40:22 FW-125852 FVE1032175935 firewall: msg_id="3000-00CB" ICMP probe 
 </decoder>
 
 <!--
-Apr 15 14:40:22 FW-125852 FVE1032175935 firewall: msg_id="3000-0004" The Application Control feature has expired.
-Apr 15 14:40:22 FW-125852 FVE1032175935 firewall: msg_id="3000-0005" The IPS feature has expired.
+Apr 15 14:40:22 FW-125852 FVE1001001001 firewall: msg_id="3000-0004" The Application Control feature has expired.
+Apr 15 14:40:22 FW-125852 FVE1001001001 firewall: msg_id="3000-0005" The IPS feature has expired.
 -->
 <decoder name="watchguard-firebox-firewall-info">
   <parent>watchguard-firebox-firewall</parent>
-  <regex type="pcre2" offset="after_parent">"(.*feature has expired).*</regex>
+  <regex type="pcre2" offset="after_parent">msg_id="[0-9a-fA-F]{4}-[0-9a-fA-F]{4}"\s+(.*feature has expired).*</regex>
   <order>reason</order>
 </decoder>
 
@@ -316,8 +318,8 @@ May 28 06:58:26 FW-123346 FVE1010101001 firewall: msg_id="4900-0001" [Link Monit
 -->
 <decoder name="watchguard-firebox-firewall-info">
   <parent>watchguard-firebox-firewall</parent>
-  <regex type="pcre2" offset="after_parent">domain name\s(\S+)</regex>
-  <order>dst</order>
+  <regex type="pcre2" offset="after_parent">\[.*\]\s(\S+).*domain name\s(\S+)</regex>
+  <order>src, dst</order>
 </decoder>
 
 <!--
@@ -326,9 +328,16 @@ May 28 06:58:26 FW-123346 FVE1010101001 firewall: msg_id="4900-0003" [Link Monit
 -->
 <decoder name="watchguard-firebox-firewall-info">
   <parent>watchguard-firebox-firewall</parent>
-  <regex type="pcre2" offset="after_parent">from.*?host\s(\S+)\sport\s(\d+)</regex>
-  <order>dstip, dstport</order>
+  <regex type="pcre2" offset="after_parent">received\son\s(\S+)\sfrom.*?host\s(\S+)\sport\s(\d+)</regex>
+  <order>src, dstip, dstport</order>
 </decoder>
+
+<decoder name="watchguard-firebox-firewall-info">
+  <parent>watchguard-firebox-firewall</parent>
+  <regex type="pcre2" offset="after_parent">\[.*\]\s(\S+)\sinterface\s(.*)</regex>
+  <order>src, reason</order>
+</decoder>
+
 
 <decoder name="watchguard-firebox-firewall-info">
   <parent>watchguard-firebox-firewall</parent>
@@ -346,8 +355,8 @@ May 28 06:58:26 FW-123346 FVE1010101001 firewall: msg_id="0F01-0015" APT threat 
 </decoder>
 
 <!--
-Apr 15 14:40:22 FW-125852 FVE1032175935 firewall: msg_id="3000-012E" Cannot relearn system MAC address, possible loop or MAC spoofing, ip=192.168.111.10, mac=00:50:da:c7:90:5d, interface=5
-Apr 15 14:40:22 FW-125852 FVE1032175935 firewall: msg_id="3000-012C" ARP spoofing attack detected, ip=192.168.111.10, mac=00:50:da:c7:90:5d, interface=5
+Apr 15 14:40:22 FW-125852 FVE1001001001 firewall: msg_id="3000-012E" Cannot relearn system MAC address, possible loop or MAC spoofing, ip=192.168.111.10, mac=00:50:da:c7:90:5d, interface=5
+Apr 15 14:40:22 FW-125852 FVE1001001001 firewall: msg_id="3000-012C" ARP spoofing attack detected, ip=192.168.111.10, mac=00:50:da:c7:90:5d, interface=5
 -->
 <decoder name="watchguard-firebox-firewall-info">
   <parent>watchguard-firebox-firewall</parent>
@@ -356,18 +365,32 @@ Apr 15 14:40:22 FW-125852 FVE1032175935 firewall: msg_id="3000-012C" ARP spoofin
 </decoder>
 
 <!--
-GENERIC TRAFFIC RULES
+GENERIC TRAFFIC FROM PACKET FILTER
 
-PACKET FILTER tcp
+# Normal traffic rules
+Mar 21 23:37:51 FW-125852 FVE1001001001 firewall: msg_id="3000-0148" Allow Trusted Firebox 90 icmp 20 128 192.168.100.99 192.168.100.254 8 0 id=1 seq=8  (Ping-00)
+Mar 21 23:43:20 FW-125852 FVE1001001001 firewall: msg_id="3000-0148" Allow Firebox External 91 udp 20 64 10.0.1.2 213.133.99.99 47189 53  (Any From Firebox-00)
+Apr 15 12:10:53 FW-125852 FVE1001001001 firewall: msg_id="3000-0148" Allow Trusted External 76 udp 20 63 192.168.100.250 162.159.200.123 48216 123  (Outgoing-00)
+Apr 15 12:18:24 FW-125852 FVE1001001001 firewall: msg_id="3000-0148" Allow Trusted External 52 tcp 20 127 192.168.100.99 216.58.212.131 50173 80 offset 8 S 237777105 win 61690  (Outgoing-00)
+May 17 09:52:27 FW-152458 FVE1001001001 firewall: msg_id="3000-0148" Deny Trusted External 76 udp 20 63 192.168.85.101 78.47.158.133 50595 123  geo_dst="DEU"  (Unhandled Internal Packet-00)
+May 17 09:52:27 FW-152458 FVE1001001001 firewall: msg_id="3000-0148" Deny External Firebox 36 igmp 24 1 0.0.0.0 224.0.0.1  (Unhandled External Packet-00)
 
+# App Control
+Apr 15 12:18:24 FW-125852 FVE1001001001 firewall: msg_id="3000-0149" Allow 1-Trusted 0-External 40 tcp 20 127 10.0.1.2 206.190.60.138 53008 80 offset 5 AF 3212213617 win 257 app_name="World Wide Web HTTP" cat_name="Network Protocols" app_beh_name="connect" app_id="63" app_cat_id="18" app_ctl_disp="2" sig_vers="18.123" msg="Application identified" (HTTP-00)
+
+# IPS Traffic detected 
+Apr 15 12:18:24 FW-125852 FVE1001001001 firewall: msg_id="3000-0150" Deny 1-Trusted 0-External 1440 tcp 20 61 10.0.1.2 192.168.130.126 55810 80 offset 5A 447868619 win 54 signature_name="EXPLOIT Apple QuickTime FLIC Animation file buffer overflow -1-2" signature_cat="Misc" signature_id="1112464" severity="4" sig_vers="18.124" msg="IPS detected" (HTTP-00)
+
+# Traffic connection terminated
+Apr 15 12:18:24 FW-125852 FVE1001001001 firewall: msg_id="3000-0151" Allow 1-Trusted 0-External tcp 10.0.1.2 220.181.90.24 53018 80 app_id="63" app_cat_id="18" app_ctl_disp="2" duration="80" sent_bytes="652" rcvd_bytes="423" (HTTP-00)
+Apr 15 12:18:24 FW-125852 FVE1001001001 firewall: msg_id="3000-0151" Allow Firebox Iface_Bouygues icmp 89.87.170.163 8.8.4.4 duration="30" sent_bytes="48" rcvd_bytes="48"  (Any From Firebox-00)
+# Hostile traffic
 May 28 06:58:26 FW-123346 FVE1010101001 firewall: msg_id="3000-0173" Deny 0-External Firebox 52 tcp 20 127 206.190.60.138 10.0.0.1 62443 80 offset 8 S 832026162 win 8192 blocked sites (Internal Policy)
-==action ${inif} ${outif} ${ip_pkt_len} ${protocol} ${iph_len} ${TTL} {${src_ip}|${src_user}} {${dst_ip|${dst_user}} [${tcp_info}] [${udp_info}] [${icmp_info}]
-Mar 21 23:37:51 FW-125852 FVE1032175935 firewall: msg_id="3000-0148" Allow Trusted Firebox 90 icmp 20 128 192.168.100.99 192.168.100.254 8 0 id=1 seq=8  (Ping-00)
-Mar 21 23:43:20 FW-125852 FVE1032175935 firewall: msg_id="3000-0148" Allow Firebox External 91 udp 20 64 10.0.1.2 213.133.99.99 47189 53  (Any From Firebox-00)
-Apr 15 12:10:53 FW-125852 FVE1032175935 firewall: msg_id="3000-0148" Allow Trusted External 76 udp 20 63 192.168.100.250 162.159.200.123 48216 123  (Outgoing-00)
-Apr 15 12:18:24 FW-125852 FVE1032175935 firewall: msg_id="3000-0148" Allow Trusted External 52 tcp 20 127 192.168.100.99 216.58.212.131 50173 80 offset 8 S 237777105 win 61690  (Outgoing-00)
 
-HTTP PROXY FILTER
+HTTP PROXY FILTER (rules 1xFF-0001 > 2xFF-0007)
+May 28 06:58:26 FW-123346 FVE1010101001 firewall: msg_id="1AFF-0001" Deny 1-Trusted 6-Ext-access tcp 10.0.1.2 192.168.53.82 60654 80 msg="ProxyDeny: HTTP server response timeout" (HTTP-proxy-00)
+
+
 May 28 06:58:26 FW-123346 FVE1010101001 firewall: msg_id="1AFF-0025" Deny 1-Trusted 0-External tcp 10.0.1.2 107.20.162.187 55531 80 msg="ProxyDeny: HTTP header IPS match" proxy_act="HTTP-Client.1" signature_id="1055396" severity="5" signature_name="WEB Cross-site Scripting-9" signature_cat="Web Attack" sig_vers="18.001" host="intext.nav-links.com" path="/util/intexteval.pl?action=startup" (HTTP-proxy-00)
 
 May 28 06:58:26 FW-123346 FVE1010101001 firewall: msg_id="1AFF-0029" Allow 1-Trusted 0-External tcp 10.0.1.2 8.25.35.115 51859 80 msg="ProxyAllow: HTTP AV scanning error" proxy_act="HTTP-Client.3" error="avg scanner is not created" host="api.yontoo.com" path="/LoadJS.ashx" (HTTP-proxy-00)
@@ -380,18 +403,26 @@ May 28 06:58:26 FW-123346 FVE1010101001 firewall: msg_id="22FF-000E" Allow 1-Tru
 
 May 28 06:58:26 FW-123346 FVE1010101001 firewall: msg_id="28FF-0005" Deny 1-Trusted 0-External udp 10.0.1.3 192.168.53.143 5060 5060 msg="ProxyDeny: SIP codec" proxy_act="SIP-Client.1" codec="speex" (SIPALG-00)
 
+May 28 06:58:26 FW-123346 FVE1010101001 firewall: msg_id="0F01-0015" APT threat notified. Details='Policy Name: HTTPS-proxy-00 Reason: high APT threat detected Task_UUID: d09445005c3f4a9a9bb78c8cb34edc2a Source IP: 10.0.1.2 Source Port: 43130 Destination IP: 67.228.175.200 Destination Port: 443 Proxy Type: HTTP Proxy Host: analysis.lastline.com Path: /docs/lastline-demo-sample.exe'
 
+May 28 06:58:26 FW-123346 FVE1010101001 firewall: msg_id="1AFF-0025" Deny 1-Trusted 0-External tcp 10.0.1.2 107.20.162.187 55531 80 msg="ProxyDeny: HTTP header IPS match" proxy_act="HTTP-Client.1" signature_id="1055396" severity="5" signature_name="WEB Cross-site Scripting-9" signature_cat="Web Attack" sig_vers="18.001" host="intext.nav-links.com" path="/util/intexteval.pl?action=startup" (HTTP-proxy-00)
+
+May 28 06:58:26 FW-123346 FVE1010101001 firewall: msg_id="1AFF-0026" Deny 4-Trusted-1 0-External tcp 192.168.53.92 188.40.238.252 45617 443 msg="ProxyDeny: HTTP body IPS match" proxy_act="HTTP-Client.4" signature_id="1051723" severity="5" signature_name="Virus Eicar test string" signature_cat="Virus/Worm" sig_vers="18.001" host="secure.eicar.org" path="/eicar.com.txt" src_user="testuser@test.net" (HTTPS-proxy-00)
+
+May 28 06:58:26 FW-123346 FVE1010101001 firewall: msg_id="1AFF-0028" Deny 2-Internal-traffic 4-External-traffic tcp 10.0.1.8 192.168.53.92 57525 80 msg="ProxyDrop: HTTP Virus found" proxy_act="HTTP-Client.1" virus="EICAR_ Test" host="192.168.53.92" path="/viruses/eicar.com" (HTTP-proxy-00)
+
+May 28 06:58:26 FW-123346 FVE1010101001 firewall: msg_id="2DFF-0007" Deny 1-Trusted 0-External tcp 10.0.1.2 54.173.101.99 60180 23 msg="ProxyAllow: IP DNSWatch content filtered domain" proxy_act="TCP-UDP-Proxy.Standard.1" Protocol="telnet" geo_dst="USA" (TCP-UDP-proxy-00)
 -->
 
 <decoder name="watchguard-firebox-firewall-info">
   <parent>watchguard-firebox-firewall</parent>
-  <regex type="pcre2" offset="after_parent">.*\((.*?)\)$</regex>
+  <regex type="pcre2" offset="after_parent">msg="(.*?)"</regex>
   <order>reason</order>
 </decoder>
 
 <decoder name="watchguard-firebox-firewall-info">
   <parent>watchguard-firebox-firewall</parent>
-  <regex type="pcre2" offset="after_parent">msg="(.*?)"</regex>
+  <regex type="pcre2" offset="after_parent">.*\((.*?)\)$</regex>
   <order>reason</order>
 </decoder>
 
@@ -413,28 +444,49 @@ May 28 06:58:26 FW-123346 FVE1010101001 firewall: msg_id="28FF-0005" Deny 1-Trus
   <order>srcuser</order>
 </decoder>
 
+<decoder name="watchguard-firebox-firewall-info">
+  <parent>watchguard-firebox-firewall</parent>
+  <regex type="pcre2" offset="after_parent">src_user="(.*?)"</regex>
+  <order>srcuser</order>
+</decoder>
+
+
 <!-- PACKET FILTER LOGS -->
 <decoder name="watchguard-firebox-firewall-info">
   <parent>watchguard-firebox-firewall</parent>
-  <regex type="pcre2" offset="after_parent">(Deny|Allow)\s(\S+)\s(\S+)\s(\d+)\s(\w+)\s(\d+)\s(\d+)\s(\S+)\s(\S+)</regex>
+  <regex type="pcre2" offset="after_parent">([Dd]eny|[Aa]llow)\s(\S+)\s(\S+)\s(\d+)\s(\w+)\s(\d+)\s(\d+)\s(\S+)\s(\S+)\s([1-5][0-9]{4}|6[0-4][0-9]{3}|65[0-4][0-9]{2}|655[0-2][0-9]|6553[0-5]|[0-9]{1,4})\s([1-5][0-9]{4}|6[0-4][0-9]{3}|65[0-4][0-9]{2}|655[0-2][0-9]|6553[0-5]|[0-9]{1,4})\s</regex>
   <order>action, src, dst, packetlen, protocol, iphlen, ttl, srcip, dstip, srcport, dstport</order>
 </decoder>
 
-<!-- PROXY LOGS -->
+<!-- traffic connection terminated filter when not using tcp -->
 <decoder name="watchguard-firebox-firewall-info">
   <parent>watchguard-firebox-firewall</parent>
-  <regex type="pcre2" offset="after_parent">(Deny|Allow)\s(\S+)\s(\S+)\s(\w+)\s(\S+)\s(\S+)\s(\d+)\s(\d+)</regex>
+  <regex type="pcre2" offset="after_parent">([Dd]eny|[Aa]llow)\s(\S+)\s(\S+)\s(\w+)\s(\S+)\s(\S+)\sduration="(\d+)\"</regex>
+  <order>action, src, dst, protocol, srcip, dstip, duration</order>
+</decoder>  
+
+<!-- PROXY LOGS -->
+<!-- Also works with "traffic connection terminated" packet filter when using tcp -->
+<decoder name="watchguard-firebox-firewall-info">
+  <parent>watchguard-firebox-firewall</parent>
+  <regex type="pcre2" offset="after_parent">([Dd]eny|[Aa]llow)\s(\S+)\s(\S+)\s(\w+)\s(\S+)\s(\S+)\s([1-5][0-9]{4}|6[0-4][0-9]{3}|65[0-4][0-9]{2}|655[0-2][0-9]|6553[0-5]|[0-9]{1,4})\s([1-5][0-9]{4}|6[0-4][0-9]{3}|65[0-4][0-9]{2}|655[0-2][0-9]|6553[0-5]|[0-9]{1,4})\s</regex>
   <order>action, src, dst, protocol, srcip, dstip, srcport, dstport</order>
 </decoder>
 
+<!-- Generic catch all traffic decoder -->
+<decoder name="watchguard-firebox-firewall-info">
+  <parent>watchguard-firebox-firewall</parent>
+  <regex type="pcre2" offset="after_parent">([Dd]eny|[Aa]llow)\s(\S+)\s(\S+)\s(\d+)\s(\w+)\s(\d+)\s(\d+)\s(\S+)\s(\S+)\s</regex>
+  <order>action, src, dst, packetlen, protocol, iphlen, ttl, srcip, dstip</order>
+</decoder>
 
 <!-- AUTHENTICATION DECODER -->
 <decoder name="watchguard-firebox-auth">
-  <prematch type="pcre2">(FVE\w+|D0F\w+|D02\w+) (admd|wgagent|sessiond|sslvpn|wgcgi)\[\w+\]: </prematch>
+  <prematch type="pcre2">(FVE\w+|D0F\w+|D02\w+)\s(\(\S+\))?\s?(admd|wgagent|sessiond|sslvpn|wgcgi)\[\w+\]: </prematch>
 </decoder>
 
 <!--
-Apr 15 14:40:22 FW-125852 FVE1032175935 firewall: msg_id="XXXX-XXXX"
+Apr 15 14:40:22 FW-125852 FVE1001001001 firewall: msg_id="XXXX-XXXX"
 -->
 
 <decoder name="watchguard-firebox-auth-info">
@@ -446,14 +498,14 @@ Apr 15 14:40:22 FW-125852 FVE1032175935 firewall: msg_id="XXXX-XXXX"
 <!--
 User authentication failed
 Feb 25 15:33:44 FW-125852 FVE1000000000 admd[2060]: msg_id="1100-0005" Authentication of Admin user [admin@Firebox-DB] from 192.168.100.100 was rejected, password is incorrect
-Mar 21 15:48:45 FW-125852 D0200904665CC admd[2107]: msg_id="1100-0005" Authentication of Firewall user [testuser@Firebox-DB] from 192.168.100.99 was rejected, password is incorrect
-Mar 21 15:48:45 FW-125852 FVE1032175935 admd[2107]: msg_id="1100-0005" Authentication of Firewall user [testuser@Firebox-DB] from fe80::20c:29ff:fe59:7afa was rejected, password is incorrect
+Mar 21 15:48:45 FW-125852 D020010010010 admd[2107]: msg_id="1100-0005" Authentication of Firewall user [testuser@Firebox-DB] from 192.168.100.99 was rejected, password is incorrect
+Mar 21 15:48:45 FW-125852 FVE1001001001 admd[2107]: msg_id="1100-0005" Authentication of Firewall user [testuser@Firebox-DB] from fe80::20c:29ff:fe59:7afa was rejected, password is incorrect
 Watchguard syntax: Authentication of %s user [%s@%s] from %s rejected, %s
 
 WebUI&WSM authentification failed
-Mar 21 14:11:32 FW-125852 FVE1032175935 wgagent[2159]: msg_id="5000-0001" WebUI User azerty@Firebox-DB from 10.0.0.2 log in attempt was rejected - invalid credentials.
-Mar 22 00:01:07 FW-125852 FVE1032175935 wgagent[2159]: msg_id="5000-0001" WSM User status@Firebox-DB from 192.168.100.99 log in attempt was rejected - invalid credentials.
-Mar 22 00:01:07 FW-125852 FVE1032175935 wgagent[2159]: msg_id="5000-0001" WSM User status@Firebox-DB from fe80::20c:29ff:fe59:7afa log in attempt was rejected - invalid credentials.
+Mar 21 14:11:32 FW-125852 FVE1001001001 wgagent[2159]: msg_id="5000-0001" WebUI User azerty@Firebox-DB from 10.0.0.2 log in attempt was rejected - invalid credentials.
+Mar 22 00:01:07 FW-125852 FVE1001001001 wgagent[2159]: msg_id="5000-0001" WSM User status@Firebox-DB from 192.168.100.99 log in attempt was rejected - invalid credentials.
+Mar 22 00:01:07 FW-125852 FVE1001001001 wgagent[2159]: msg_id="5000-0001" WSM User status@Firebox-DB from fe80::20c:29ff:fe59:7afa log in attempt was rejected - invalid credentials.
 Watchguard syntax: WebUI User %s@%s from %s log in attempt was rejected - %s
 
 User authentication success
@@ -462,13 +514,13 @@ Feb 25 16:06:07 FW-125852 FVE1000000000 sessiond[2102]: msg_id="3E00-0002" Manag
 Watchguard syntax: %s %s%s%s from %s logged in
 
 VPN User authentication success
-Mar 21 15:28:27 FW-125852 FVE1032175935 sslvpn[2154]: msg_id="2500-0000" Mobile VPN with SSL user testuser logged in. Virtual IP address is 192.168.25.2. Real IP address is 192.168.100.99
-Mar 21 15:28:27 FW-125852 FVE1032175935 sslvpn[2154]: msg_id="2500-0000" Mobile VPN with SSL user testuser logged in. Virtual IP address is ac::d0:::1. Real IP address is fe80::20c:29ff:fe59:7afa
-Mar 21 15:28:27 FW-125852 FVE1032175935 sslvpn[2154]: msg_id="2500-0000" Mobile VPN with SSL user testuser logged in. Virtual IP address is fe80::20c:29ff:fe59:7afa. Real IP address is ac::d0:::1
+Mar 21 15:28:27 FW-125852 FVE1001001001 sslvpn[2154]: msg_id="2500-0000" Mobile VPN with SSL user testuser logged in. Virtual IP address is 192.168.25.2. Real IP address is 192.168.100.99
+Mar 21 15:28:27 FW-125852 FVE1001001001 sslvpn[2154]: msg_id="2500-0000" Mobile VPN with SSL user testuser logged in. Virtual IP address is ac::d0:::1. Real IP address is fe80::20c:29ff:fe59:7afa
+Mar 21 15:28:27 FW-125852 FVE1001001001 sslvpn[2154]: msg_id="2500-0000" Mobile VPN with SSL user testuser logged in. Virtual IP address is fe80::20c:29ff:fe59:7afa. Real IP address is ac::d0:::1
 Watchguard syntax: Mobile VPN with SSL user %s logged in. Virtual IP address is %s. Real IP address is %s.
 
 VPN User authentication failed
-Mar 21 15:48:45 FW-125852 FVE1032175935 wgcgi[29063]: SSL VPN user testuser@Firebox-DB from 192.168.100.99 was rejected - Unspecified.
+Mar 21 15:48:45 FW-125852 FVE1001001001 wgcgi[29063]: SSL VPN user testuser@Firebox-DB from 192.168.100.99 was rejected - Unspecified.
 -->
 
 <!-- IPv4 -->
@@ -530,4 +582,29 @@ Mar 21 15:48:45 FW-125852 FVE1032175935 wgcgi[29063]: SSL VPN user testuser@Fire
   <regex type="pcre2" offset="after_parent">(logged in)</regex>
   <order>status</order>
 </decoder>
+
+<!-- Special case for wgcgi auth where no msg id is given... Thanks WG -->
+<decoder name="watchguard-firebox-auth-info">
+  <parent>watchguard-firebox-auth</parent>
+  <regex type="pcre2" offset="after_parent">^(SSL VPN) user.*</regex>
+  <order>id</order>
+</decoder>
+
+<!-- SECURITY EVENTS DECODER -->
+<!-- Thanks to WG security event msg_ids don't follow a easy to find logic
+
+2021 Jul 08 11:32:28 FW-200275->192.168.1.254 Jul  8 11:32:00 FW-200275 D020010010010 (2021-07-08T09:32:00) sigd[14182]: msg_id="2E02-0006" Process crashed
+2021 Jul 08 11:32:28 FW-200275->192.168.1.254 Jul  8 11:32:00 FW-200275 D020010010010 (2021-07-08T09:32:00) sigd[14182]: msg_id="2E02-0065" Scheduled IPS update started
+2021 Jul 08 11:32:29 FW-200275->192.168.1.254 Jul  8 11:32:01 FW-200275 D020010010010 (2021-07-08T09:32:01) sigd[14182]: msg_id="2E02-0069" Device already has the latest IPS signature version (4.1176)
+-->
+<decoder name="watchguard-firebox-sigd">
+  <prematch type="pcre2">(FVE\w+|D0F\w+|D02\w+)\s(\(\S+\))?\s?sigd\[\w+\]: </prematch>
+</decoder>
+
+<decoder name="watchguard-firebox-sigd-info">
+  <parent>watchguard-firebox-sigd</parent>
+  <regex type="pcre2" offset="after_parent">msg_id="([0-9a-fA-F]{4}-[0-9a-fA-F]{4})" (.*)</regex>
+  <order>id, reason</order>
+</decoder>
+
 

--- a/decoders/0510-watchguard-firebox_decoders.xml
+++ b/decoders/0510-watchguard-firebox_decoders.xml
@@ -382,9 +382,10 @@ Apr 15 12:18:24 FW-125852 FVE1001001001 firewall: msg_id="3000-0149" Allow 1-Tru
 Apr 15 12:18:24 FW-125852 FVE1001001001 firewall: msg_id="3000-0150" Deny 1-Trusted 0-External 1440 tcp 20 61 10.0.1.2 192.168.130.126 55810 80 offset 5A 447868619 win 54 signature_name="EXPLOIT Apple QuickTime FLIC Animation file buffer overflow -1-2" signature_cat="Misc" signature_id="1112464" severity="4" sig_vers="18.124" msg="IPS detected" (HTTP-00)
 
 # Traffic connection terminated
-Apr 15 12:18:24 FW-125852 FVE1001001001 firewall: msg_id="3000-0151" Allow 1-Trusted 0-External tcp 10.0.1.2 220.181.90.24 53018 80 app_id="63" app_cat_id="18" app_ctl_disp="2" duration="80" sent_bytes="652" rcvd_bytes="423" (HTTP-00)
+Apr 15 12:18:24 FW-125852 FVE1001001001 firewall: msg_id="3000-0151" Allow 1-Trusted 0-External tcp 10.0.1.2 192.168.0.1 53018 80 app_id="63" app_cat_id="18" app_ctl_disp="2" duration="80" sent_bytes="652" rcvd_bytes="423" (HTTP-00)
 Apr 15 12:18:24 FW-125852 FVE1001001001 firewall: msg_id="3000-0151" Allow Firebox Iface_Bouygues icmp 89.87.170.163 8.8.4.4 duration="30" sent_bytes="48" rcvd_bytes="48"  (Any From Firebox-00)
-
+Apr 15 12:18:24 FW-125852 FVE1001001001 firewall: msg_id="3000-0151" Allow 1-Trusted 0-External tcp 10.0.1.2 192.168.0.1 53018 80 app_id="63" app_cat_id="18" app_ctl_disp="2" duration="80" sent_bytes="652" rcvd_bytes="423" (HTTP-00)
+Sep  3 10:39:59 FireboxV_CLIENT FVE1001001001 (2021-09-03T08:39:59) firewall: msg_id="3000-0151" Allow SITE BO Trusted tcp 192.168.95.223 192.168.90.153 38430 11194 duration="121" sent_bytes="60" rcvd_bytes="0"  (BOVPN-Allow.in-00)
 # Hostile traffic
 May 28 06:58:26 FW-123346 FVE1010101001 firewall: msg_id="3000-0173" Deny 0-External Firebox 52 tcp 20 127 206.190.60.138 10.0.0.1 62443 80 offset 8 S 832026162 win 8192 blocked sites (Internal Policy)
 
@@ -459,12 +460,13 @@ May 28 06:58:26 FW-123346 FVE1010101001 firewall: msg_id="2DFF-0007" Deny 1-Trus
   <order>action, src, dst, packetlen, protocol, iphlen, ttl, srcip, dstip, srcport, dstport</order>
 </decoder>
 
-<!-- traffic connection terminated filter when not using tcp -->
+<!-- traffic connection terminated filter when not using tcp
+This one is tricky since source might be something with a space, so we drop src and dst to be sure to catch this one-->
 <decoder name="watchguard-firebox-firewall-info">
   <parent>watchguard-firebox-firewall</parent>
-  <regex type="pcre2" offset="after_parent">([Dd]eny|[Aa]llow)\s(\S+)\s(\S+)\s(\w+)\s(\S+)\s(\S+)\sduration="(\d+)\"</regex>
-  <order>action, src, dst, protocol, srcip, dstip, duration</order>
-</decoder>  
+  <regex type="pcre2" offset="after_parent">([Dd]eny|[Aa]llow).*(SYN|syn|TCP|tcp|UDP|udp|ICMP|icmp|IGMP|igmp|[Ii][Pp][Ss][Ee][Cc]|[Ii][Kk][Ee]|http|HTTP|https|HTTPS|smtp|SMTP|IMAP|imap|dns|DNS)\s(\S+)\s(\S+)\s.*duration="(\d+)\"</regex>
+  <order>action, protocol, srcip, dstip, duration</order>
+</decoder>
 
 <!-- PROXY LOGS -->
 <!-- Also works with "traffic connection terminated" packet filter when using tcp -->

--- a/decoders/0510-watchguard-firebox_decoders.xml
+++ b/decoders/0510-watchguard-firebox_decoders.xml
@@ -1,0 +1,533 @@
+  
+<!--
+  -  Decoders for watchguard-firebox
+  -  Created by FMI Groupe (ph3nix, Orsiris de Jong) for Wazuh, Inc.
+  -  Copyright (C) 2021, FMI Groupe, Wazuh Inc.
+  -  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2.
+
+-  Created by ph3nix.
+
+   Changelog   
+   2021/06/10 - Orsiris de Jong - Switched to sibling decoders
+                                  - Added IPv4 and IPv6 specific regexes (kept separate because it's already confusing, and IPv6 may contain IPv4 mapped addresses)
+                                  - IPv4 REGEX is pretty generic
+                                  - IPv6 REGEX is my own variant of https://stackoverflow.com/a/17871737/2635443
+                                  - Port REGEX just allows 0-65535 ports
+                                  - Protocol REGEX is just a plain list of possible protocols found in these logs
+                                  - geo_src and geo_dst REGEX just allow a 3 character (ISO 3166-1 alpha-3) country detection
+                                  - msg_id REGEX allows hexa digits in XXXX-XXXX form
+                                - Added startup/shutdown / feature key detection
+                                - Added various APT blocker, Intrusion detection and antivirus messages decoders
+                                - Added various attack decoders for port scans, flooding, DoS, MAC spoofing
+                                - Added various load balance probe, layer 2 looping decoders
+                                - Added packet filter and proxy traffic decoders
+                                - Added unhandled traffic decoders
+                                - Switched authentication to sibling decoders
+                                
+   2021/04/21 - ph3nix          - Initial release
+                                - Authentication detection, VPN authentication, VPN traffic and generic traffic
+
+Watchguard firewall serial numbers are:
+- FVE = Virtual appliances
+- D0F = T10/T15 appliances
+- D02 = T35/T40/T55 appliances
+
+-->
+
+<!-- FIREWALL DECODER -->
+<decoder name="watchguard-firebox-firewall">
+  <prematch type="pcre2">(FVE\w+|D0F\w+|D02\w+) firewall: </prematch>
+  <type>firewall</type>
+</decoder>
+
+<!--
+Apr 15 14:40:22 FW-125852 FVE1032175935 firewall: msg_id="XXXX-XXXX"
+-->
+<decoder name="watchguard-firebox-firewall-info">
+  <parent>watchguard-firebox-firewall</parent>
+  <regex type="pcre2" offset="after_parent">msg_id="([0-9a-fA-F]{4}-[0-9a-fA-F]{4})"</regex>
+  <order>id</order>
+</decoder>
+
+<!--
+May 28 06:58:26 FW-123346 FVE1010101001 firewall: msg_id="3000-0159" PORT scan attack against 32.21.56.8 from 12.34.23.67 detected.
+May 28 06:58:26 FW-123346 FVE1010101001 firewall: msg_id="3000-0162" SYN flood attack against 2001:0db8:85a3:08d3:1319:8a2e:0370:7344 from FF01::101 detected. 100 SYN packets dropped since last alarm.
+May 28 06:58:26 FW-123346 FVE1010101001 firewall: msg_id="3000-0160" DDOS against server 10.0.1.34 detected.
+May 28 06:58:26 FW-123346 FVE1010101001 firewall: msg_id="3000-0161" DDOS from client 10.0.1.34 detected.
+-->
+
+<decoder name="watchguard-firebox-firewall-info">
+  <parent>watchguard-firebox-firewall</parent>
+  <regex type="pcre2" offset="after_parent">^\s([Dd]eny|[Aa]llow)</regex>
+  <order>action</order>
+</decoder>
+
+<!-- IPv4 -->
+<decoder name="watchguard-firebox-firewall-info">
+  <parent>watchguard-firebox-firewall</parent>
+  <regex type="pcre2" offset="after_parent">from\s(client)?\s?((25[0-5]|2[0-4][0-9]|1?[0-9][0-9]{1,2})(\.(25[0-5]|2[0-4][0-9]|1?[0-9]{1,2})){3})</regex>
+  <order>src, srcip</order>
+</decoder>
+
+<!-- IPv6 -->
+<decoder name="watchguard-firebox-firewall-info">
+  <parent>watchguard-firebox-firewall</parent>
+  <regex type="pcre2">from\s(client)?\s?(([0-9a-fA-F]{1,4}:){1,4}:((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])|[Ff][Ee]80:(:[0-9a-fA-F]{0,4}){0,4}%[0-9a-zA-Z]{1,}|([0-9a-fA-F]{1,4}:){1,2}(:[0-9a-fA-F]{1,4}){1,5}|([0-9a-fA-F]{1,4}:){1,3}(:[0-9a-fA-F]{1,4}){1,4}|[0-9a-fA-F]{1,4}:((:[0-9a-fA-F]{1,4}){1,6})|([0-9a-fA-F]{1,4}:){1,4}(:[0-9a-fA-F]{1,4}){1,3}|([0-9a-fA-F]{1,4}:){1,5}(:[0-9a-fA-F]{1,4}){1,2}|([0-9a-fA-F]{1,4}:){1,6}:[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,7}:|([0-9a-fA-F]{1,4}:){7,7}[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,4}:((25[0-5]|2[0-4][0-9]|1{0,1}[0-9]{0,1}[0-9])\.{3,3})(25[0-5]|2[0-4][0-9]|1{0,1}[0-9]{0,1}[0-9])|::(ffff(:0{1,4}){0,1}:){0,1}((25[0-5]|2[0-4][0-9]|1{0,1}[0-9]{0,1}[0-9])\.{3,3})(25[0-5]|2[0-4][0-9]|1{0,1}[0-9]{0,1}[0-9])|:((:[0-9a-fA-F]{1,4}){1,7}|:))</regex>
+  <order>src, srcip</order>
+</decoder>
+
+<!-- IPv4 -->
+<decoder name="watchguard-firebox-firewall-info">
+  <parent>watchguard-firebox-firewall</parent>
+  <regex type="pcre2" offset="after_parent">against\s(server)?\s?((25[0-5]|2[0-4][0-9]|1?[0-9][0-9]{1,2})(\.(25[0-5]|2[0-4][0-9]|1?[0-9]{1,2})){3})</regex>
+  <order>dst, dstip</order>
+</decoder>
+
+<!-- IPv6 -->
+<decoder name="watchguard-firebox-firewall-info">
+  <parent>watchguard-firebox-firewall</parent>
+  <regex type="pcre2" offset="after_parent">against\s(server)?\s?(([0-9a-fA-F]{1,4}:){1,4}:((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])|[Ff][Ee]80:(:[0-9a-fA-F]{0,4}){0,4}%[0-9a-zA-Z]{1,}|([0-9a-fA-F]{1,4}:){1,2}(:[0-9a-fA-F]{1,4}){1,5}|([0-9a-fA-F]{1,4}:){1,3}(:[0-9a-fA-F]{1,4}){1,4}|[0-9a-fA-F]{1,4}:((:[0-9a-fA-F]{1,4}){1,6})|([0-9a-fA-F]{1,4}:){1,4}(:[0-9a-fA-F]{1,4}){1,3}|([0-9a-fA-F]{1,4}:){1,5}(:[0-9a-fA-F]{1,4}){1,2}|([0-9a-fA-F]{1,4}:){1,6}:[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,7}:|([0-9a-fA-F]{1,4}:){7,7}[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,4}:((25[0-5]|2[0-4][0-9]|1{0,1}[0-9]{0,1}[0-9])\.{3,3})(25[0-5]|2[0-4][0-9]|1{0,1}[0-9]{0,1}[0-9])|::(ffff(:0{1,4}){0,1}:){0,1}((25[0-5]|2[0-4][0-9]|1{0,1}[0-9]{0,1}[0-9])\.{3,3})(25[0-5]|2[0-4][0-9]|1{0,1}[0-9]{0,1}[0-9])|:((:[0-9a-fA-F]{1,4}){1,7}|:))</regex>
+  <order>dst, dstip</order>
+</decoder>
+
+<!--
+May 28 06:58:26 FW-123346 FVE1010101001 firewall: msg_id="3000-0168" Blocked site: Traffic detected from 10.0.1.2 to 61.231.45.165.
+May 28 06:58:26 FW-123346 FVE1010101001 firewall: msg_id="3000-0169" IP spoofing: Traffic detected from 10.0.1.2 to 43.123.12.26.
+-->
+
+<!-- IPv4 -->
+<decoder name="watchguard-firebox-firewall-info">
+  <parent>watchguard-firebox-firewall</parent>
+  <regex type="pcre2" offset="after_parent">from\s\S+\sto\s((25[0-5]|2[0-4][0-9]|1?[0-9][0-9]{1,2})(\.(25[0-5]|2[0-4][0-9]|1?[0-9]{1,2})){3})</regex>
+  <order>dstip</order>
+</decoder>
+
+<!-- IPv6 -->
+<decoder name="watchguard-firebox-firewall-info">
+  <parent>watchguard-firebox-firewall</parent>
+  <regex type="pcre2" offset="after_parent">from\s\S+\sto\s(([0-9a-fA-F]{1,4}:){1,4}:((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])|[Ff][Ee]80:(:[0-9a-fA-F]{0,4}){0,4}%[0-9a-zA-Z]{1,}|([0-9a-fA-F]{1,4}:){1,2}(:[0-9a-fA-F]{1,4}){1,5}|([0-9a-fA-F]{1,4}:){1,3}(:[0-9a-fA-F]{1,4}){1,4}|[0-9a-fA-F]{1,4}:((:[0-9a-fA-F]{1,4}){1,6})|([0-9a-fA-F]{1,4}:){1,4}(:[0-9a-fA-F]{1,4}){1,3}|([0-9a-fA-F]{1,4}:){1,5}(:[0-9a-fA-F]{1,4}){1,2}|([0-9a-fA-F]{1,4}:){1,6}:[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,7}:|([0-9a-fA-F]{1,4}:){7,7}[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,4}:((25[0-5]|2[0-4][0-9]|1{0,1}[0-9]{0,1}[0-9])\.{3,3})(25[0-5]|2[0-4][0-9]|1{0,1}[0-9]{0,1}[0-9])|::(ffff(:0{1,4}){0,1}:){0,1}((25[0-5]|2[0-4][0-9]|1{0,1}[0-9]{0,1}[0-9])\.{3,3})(25[0-5]|2[0-4][0-9]|1{0,1}[0-9]{0,1}[0-9])|:((:[0-9a-fA-F]{1,4}){1,7}|:))</regex>
+  <order>dstip</order>
+</decoder>
+
+<!--
+May 28 06:58:26 FW-123346 FVE1010101001 firewall: msg_id="0F01-0015" APT threat notified. Details='Policy Name: HTTPS-proxy-00 Reason: high APT threat detected Task_UUID: d09445005c3f4a9a9bb78c8cb34edc2a Source IP: 10.0.1.2 Source Port: 43130 Destination IP: 67.228.175.200 Destination Port: 443 Proxy Type: HTTP Proxy Host: analysis.lastline.com Path: /docs/lastline-demo-sample.exe'
+-->
+<!-- IPv4 -->
+<decoder name="watchguard-firebox-firewall-info">
+  <parent>watchguard-firebox-firewall</parent>
+  <regex type="pcre2" offset="after_parent">[Ss]ource [Ii][Pp]:\s((25[0-5]|2[0-4][0-9]|1?[0-9][0-9]{1,2})(\.(25[0-5]|2[0-4][0-9]|1?[0-9]{1,2})){3})</regex>
+  <order>srcip</order>
+</decoder>
+
+<!-- IPv6 -->
+<decoder name="watchguard-firebox-firewall-info">
+  <parent>watchguard-firebox-firewall</parent>
+  <regex type="pcre2" offset="after_parent">[Ss]ource [Ii]p:\s(([0-9a-fA-F]{1,4}:){1,4}:((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])|[Ff][Ee]80:(:[0-9a-fA-F]{0,4}){0,4}%[0-9a-zA-Z]{1,}|([0-9a-fA-F]{1,4}:){1,2}(:[0-9a-fA-F]{1,4}){1,5}|([0-9a-fA-F]{1,4}:){1,3}(:[0-9a-fA-F]{1,4}){1,4}|[0-9a-fA-F]{1,4}:((:[0-9a-fA-F]{1,4}){1,6})|([0-9a-fA-F]{1,4}:){1,4}(:[0-9a-fA-F]{1,4}){1,3}|([0-9a-fA-F]{1,4}:){1,5}(:[0-9a-fA-F]{1,4}){1,2}|([0-9a-fA-F]{1,4}:){1,6}:[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,7}:|([0-9a-fA-F]{1,4}:){7,7}[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,4}:((25[0-5]|2[0-4][0-9]|1{0,1}[0-9]{0,1}[0-9])\.{3,3})(25[0-5]|2[0-4][0-9]|1{0,1}[0-9]{0,1}[0-9])|::(ffff(:0{1,4}){0,1}:){0,1}((25[0-5]|2[0-4][0-9]|1{0,1}[0-9]{0,1}[0-9])\.{3,3})(25[0-5]|2[0-4][0-9]|1{0,1}[0-9]{0,1}[0-9])|:((:[0-9a-fA-F]{1,4}){1,7}|:))</regex>
+  <order>srcip</order>
+</decoder>
+
+<!-- IPv4 -->
+<decoder name="watchguard-firebox-firewall-info">
+  <parent>watchguard-firebox-firewall</parent>
+  <regex type="pcre2" offset="after_parent">[Dd]estination [Ii][Pp]:\s((25[0-5]|2[0-4][0-9]|1?[0-9][0-9]{1,2})(\.(25[0-5]|2[0-4][0-9]|1?[0-9]{1,2})){3})</regex>
+  <order>dstip</order>
+</decoder>
+
+<!-- IPv6 -->
+<decoder name="watchguard-firebox-firewall-info">
+  <parent>watchguard-firebox-firewall</parent>
+  <regex type="pcre2" offset="after_parent">[Dd]estination [Ii]p:\s(([0-9a-fA-F]{1,4}:){1,4}:((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])|[Ff][Ee]80:(:[0-9a-fA-F]{0,4}){0,4}%[0-9a-zA-Z]{1,}|([0-9a-fA-F]{1,4}:){1,2}(:[0-9a-fA-F]{1,4}){1,5}|([0-9a-fA-F]{1,4}:){1,3}(:[0-9a-fA-F]{1,4}){1,4}|[0-9a-fA-F]{1,4}:((:[0-9a-fA-F]{1,4}){1,6})|([0-9a-fA-F]{1,4}:){1,4}(:[0-9a-fA-F]{1,4}){1,3}|([0-9a-fA-F]{1,4}:){1,5}(:[0-9a-fA-F]{1,4}){1,2}|([0-9a-fA-F]{1,4}:){1,6}:[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,7}:|([0-9a-fA-F]{1,4}:){7,7}[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,4}:((25[0-5]|2[0-4][0-9]|1{0,1}[0-9]{0,1}[0-9])\.{3,3})(25[0-5]|2[0-4][0-9]|1{0,1}[0-9]{0,1}[0-9])|::(ffff(:0{1,4}){0,1}:){0,1}((25[0-5]|2[0-4][0-9]|1{0,1}[0-9]{0,1}[0-9])\.{3,3})(25[0-5]|2[0-4][0-9]|1{0,1}[0-9]{0,1}[0-9])|:((:[0-9a-fA-F]{1,4}){1,7}|:))</regex>
+  <order>dstip</order>
+</decoder>
+
+<!-- IPv4 -->
+<decoder name="watchguard-firebox-firewall-info">
+  <parent>watchguard-firebox-firewall</parent>
+  <regex type="pcre2" offset="after_parent">ip=((25[0-5]|2[0-4][0-9]|1?[0-9][0-9]{1,2})(\.(25[0-5]|2[0-4][0-9]|1?[0-9]{1,2})){3})</regex>
+  <order>srcip</order>
+</decoder>
+
+<!-- IPv6 -->
+<decoder name="watchguard-firebox-firewall-info">
+  <parent>watchguard-firebox-firewall</parent>
+  <regex type="pcre2" offset="after_parent">ip=(([0-9a-fA-F]{1,4}:){1,4}:((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])|[Ff][Ee]80:(:[0-9a-fA-F]{0,4}){0,4}%[0-9a-zA-Z]{1,}|([0-9a-fA-F]{1,4}:){1,2}(:[0-9a-fA-F]{1,4}){1,5}|([0-9a-fA-F]{1,4}:){1,3}(:[0-9a-fA-F]{1,4}){1,4}|[0-9a-fA-F]{1,4}:((:[0-9a-fA-F]{1,4}){1,6})|([0-9a-fA-F]{1,4}:){1,4}(:[0-9a-fA-F]{1,4}){1,3}|([0-9a-fA-F]{1,4}:){1,5}(:[0-9a-fA-F]{1,4}){1,2}|([0-9a-fA-F]{1,4}:){1,6}:[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,7}:|([0-9a-fA-F]{1,4}:){7,7}[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,4}:((25[0-5]|2[0-4][0-9]|1{0,1}[0-9]{0,1}[0-9])\.{3,3})(25[0-5]|2[0-4][0-9]|1{0,1}[0-9]{0,1}[0-9])|::(ffff(:0{1,4}){0,1}:){0,1}((25[0-5]|2[0-4][0-9]|1{0,1}[0-9]{0,1}[0-9])\.{3,3})(25[0-5]|2[0-4][0-9]|1{0,1}[0-9]{0,1}[0-9])|:((:[0-9a-fA-F]{1,4}){1,7}|:))</regex>
+  <order>srcip</order>
+</decoder>
+
+<decoder name="watchguard-firebox-firewall-info">
+  <parent>watchguard-firebox-firewall</parent>
+  <regex type="pcre2" offset="after_parent">[Ss]ource [Pp]ort:\s([1-5][0-9]{4}|6[0-4][0-9]{3}|65[0-4][0-9]{2}|655[0-2][0-9]|6553[0-5]|[0-9]{1,4})\s?</regex>
+  <order>srcport</order>
+</decoder>
+
+<decoder name="watchguard-firebox-firewall-info">
+  <parent>watchguard-firebox-firewall</parent>
+  <regex type="pcre2" offset="after_parent">[Dd]estination [Pp]ort:\s([1-5][0-9]{4}|6[0-4][0-9]{3}|65[0-4][0-9]{2}|655[0-2][0-9]|6553[0-5]|[0-9]{1,4})\s?</regex>
+  <order>dstport</order>
+</decoder>
+
+<decoder name="watchguard-firebox-firewall-info">
+  <parent>watchguard-firebox-firewall</parent>
+  <regex type="pcre2" offset="after_parent">mac=([0-9A-Fa-f]{2}:[0-9A-Fa-f]{2}:[0-9A-Fa-f]{2}:[0-9A-Fa-f]{2}:[0-9A-Fa-f]{2}:[0-9A-Fa-f]{2})</regex>
+  <order>mac</order>
+</decoder>
+
+<decoder name="watchguard-firebox-firewall-info">
+  <parent>watchguard-firebox-firewall</parent>
+  <regex type="pcre2" offset="after_parent">interface=(\S+)</regex>
+  <order>src</order>
+</decoder>
+
+
+<!--
+May 28 06:58:26 FW-123346 FVE1010101001 firewall: msg_id="3000-0172" Blocked port: Traffic detected from 10.0.1.2 to 61.231.45.165 on port 513.
+-->
+<decoder name="watchguard-firebox-firewall-info">
+  <parent>watchguard-firebox-firewall</parent>
+  <regex type="pcre2" offset="after_parent">to\s\S+\son\sport\s([0-9]{1,4}|[1-5][0-9]{4}|6[0-4][0-9]{3}|65[0-4][0-9]{2}|655[0-2][0-9]|6553[0-5])\s?</regex>
+  <order>dstport</order>
+</decoder>
+
+<decoder name="watchguard-firebox-firewall-info">
+  <parent>watchguard-firebox-firewall</parent>
+  <regex type="pcre2" offset="after_parent">.*(SYN|syn|TCP|tcp|UDP|udp|ICMP|icmp|[Ii][Pp][Ss][Ee][Cc]|[Ii][Kk][Ee])|http|HTTP|https|HTTPS|smtp|SMTP|dns|DNS.*</regex>
+  <order>protocol</order>
+</decoder>
+
+<decoder name="watchguard-firebox-firewall-info">
+  <parent>watchguard-firebox-firewall</parent>
+  <regex type="pcre2" offset="after_parent">geo_src="([a-zA-Z]{3})"</regex>
+  <order>geosrc</order>
+</decoder>
+
+<decoder name="watchguard-firebox-firewall-info">
+  <parent>watchguard-firebox-firewall</parent>
+  <regex type="pcre2" offset="after_parent">geo_dst="([a-zA-Z]{3})"</regex>
+  <order>geodst</order>
+</decoder>
+
+<decoder name="watchguard-firebox-firewall-info">
+  <parent>watchguard-firebox-firewall</parent>
+  <regex type="pcre2" offset="after_parent">msg_id="[0-9a-fA-F]{4}-[0-9a-fA-F]{4}" (DDOS)</regex>
+  <order>reason</order>
+</decoder>
+
+
+<!--
+Apr 15 14:40:22 FW-125852 FVE1032175935 firewall: msg_id="3000-0027" Firewall is starting up
+Apr 15 14:40:22 FW-125852 FVE1032175935 firewall: msg_id="3000-0028" Firewall is shutting down 
+-->
+<decoder name="watchguard-firebox-firewall-info">
+  <parent>watchguard-firebox-firewall</parent>
+  <regex type="pcre2" offset="after_parent">.*([Ff]irewall is\s.*)\s?</regex>
+  <order>reason</order>
+</decoder>
+
+<!--
+Apr 15 14:40:22 FW-125852 FVE1032175935 firewall: msg_id="3000-003A" Unable to read the feature keys, some features may be unavailable
+-->
+<decoder name="watchguard-firebox-firewall-info">
+  <parent>watchguard-firebox-firewall</parent>
+  <regex type="pcre2" offset="after_parent">(Unable to read the feature keys)</regex>
+  <order>reason</order>
+</decoder>
+
+<!--
+May 28 06:58:26 FW-123346 FVE1010101001 firewall: msg_id="3000-0159" PORT scan attack against 192.168.20.2 from 123.146.23.149 detected. (port_scan_dos)
+May 28 06:58:26 FW-123346 FVE1010101001 firewall: msg_id="3000-0162" SYN flood attack against 2001:0db8:85a3:08d3:1319:8a2e:0370:7344 from FF01::101 detected. 100 SYN packets dropped since last alarm
+-->
+<decoder name="watchguard-firebox-firewall-info">
+  <parent>watchguard-firebox-firewall</parent>
+  <regex type="pcre2" offset="after_parent">msg_id="[0-9a-fA-F]{4}-[0-9a-fA-F]{4}" (.*? attack) against</regex>
+  <order>reason</order>
+</decoder>
+
+<decoder name="watchguard-firebox-firewall-info">
+  <parent>watchguard-firebox-firewall</parent>
+  <regex type="pcre2" offset="after_parent">msg_id="[0-9a-fA-F]{4}-[0-9a-fA-F]{4}" (.*? attack) against</regex>
+  <order>reason</order>
+</decoder>
+
+<!--
+Apr 15 14:40:22 FW-125852 FVE1032175935 firewall: msg_id="3000-0029" IP address 192.168.111.254 will not be added to the blocked sites list because it is exempt
+-->
+<decoder name="watchguard-firebox-firewall-info">
+  <parent>watchguard-firebox-firewall</parent>
+  <regex type="pcre2" offset="after_parent">IP address (\S+).*exempt</regex>
+  <order>srcip</order>
+</decoder>
+
+<!--
+Apr 15 14:40:22 FW-125852 FVE1032175935 firewall: msg_id="3000-0040" Idle timeout has occurred for blocked site 192.168.111.10
+-->
+<decoder name="watchguard-firebox-firewall-info">
+  <parent>watchguard-firebox-firewall</parent>
+  <regex type="pcre2" offset="after_parent">Idle timeout has occurred for blocked site\s(\S+)</regex>
+  <order>srcip</order>
+</decoder>
+
+<!--
+Apr 15 14:40:22 FW-125852 FVE1032175935 firewall: msg_id="3000-00C9" TCP probe packets timeout, Load Balance Server 10.10.10.100 is offline.
+Apr 15 14:40:22 FW-125852 FVE1032175935 firewall: msg_id="3000-00CB" ICMP probe packets timeout, Load Balance Server 10.10.10.100 is offline.
+-->
+<decoder name="watchguard-firebox-firewall-info">
+  <parent>watchguard-firebox-firewall</parent>
+  <regex type="pcre2" offset="after_parent">probe packets.*Load Balance Server (\S+)</regex>
+  <order>dstip</order>
+</decoder>
+
+<decoder name="watchguard-firebox-firewall-info">
+  <parent>watchguard-firebox-firewall</parent>
+  <regex type="pcre2" offset="after_parent">.*(timeout).*</regex>
+  <order>reason</order>
+</decoder>
+
+<!--
+Apr 15 14:40:22 FW-125852 FVE1032175935 firewall: msg_id="3000-0004" The Application Control feature has expired.
+Apr 15 14:40:22 FW-125852 FVE1032175935 firewall: msg_id="3000-0005" The IPS feature has expired.
+-->
+<decoder name="watchguard-firebox-firewall-info">
+  <parent>watchguard-firebox-firewall</parent>
+  <regex type="pcre2" offset="after_parent">"(.*feature has expired).*</regex>
+  <order>reason</order>
+</decoder>
+
+<!--
+May 28 06:58:26 FW-123346 FVE1010101001 firewall: msg_id="3001-1001" Temporarily blocking host 120.220.13.183 (reason = Port scan attack)
+May 28 06:58:26 FW-123346 FVE1010101001 firewall: msg_id="3001-1001" Temporarily blocking host 198.13.111.226 (reason = autoblock by policy)
+-->
+<decoder name="watchguard-firebox-firewall-info">
+  <parent>watchguard-firebox-firewall</parent>
+  <regex type="pcre2" offset="after_parent">.*blocking host (\S+)</regex>
+  <order>srcip</order>
+</decoder>
+
+<!--
+May 28 06:58:26 FW-123346 FVE1010101001 firewall: msg_id="3001-1002" The Temporary Blocked Sites list is full (capacity=1000). The oldest entry 10.0.5.96 was removed.
+-->
+<decoder name="watchguard-firebox-firewall-info">
+  <parent>watchguard-firebox-firewall</parent>
+  <regex type="pcre2" offset="after_parent">.*entry\s(\S+)\swas removed</regex>
+  <order>srcip</order>
+</decoder>
+
+<!--
+May 28 06:58:26 FW-123346 FVE1010101001 firewall: msg_id="4900-0001" [Link Monitor] External unable to resolve domain name www.example.com
+-->
+<decoder name="watchguard-firebox-firewall-info">
+  <parent>watchguard-firebox-firewall</parent>
+  <regex type="pcre2" offset="after_parent">domain name\s(\S+)</regex>
+  <order>dst</order>
+</decoder>
+
+<!--
+May 28 06:58:26 FW-123346 FVE1010101001 firewall: msg_id="4900-0002" [Link Monitor] No response received on External from TCP host 192.168.1.218 port 9999
+May 28 06:58:26 FW-123346 FVE1010101001 firewall: msg_id="4900-0003" [Link Monitor] External interface failed because a probe to the target host failed
+-->
+<decoder name="watchguard-firebox-firewall-info">
+  <parent>watchguard-firebox-firewall</parent>
+  <regex type="pcre2" offset="after_parent">from.*?host\s(\S+)\sport\s(\d+)</regex>
+  <order>dstip, dstport</order>
+</decoder>
+
+<decoder name="watchguard-firebox-firewall-info">
+  <parent>watchguard-firebox-firewall</parent>
+  <regex type="pcre2" offset="after_parent">msg_id="[0-9a-fA-F]{4}-[0-9a-fA-F]{4}" \[.*\]</regex>
+  <order>reason</order>
+</decoder>
+
+<!--
+May 28 06:58:26 FW-123346 FVE1010101001 firewall: msg_id="0F01-0015" APT threat notified. Details='Policy Name: HTTPS-proxy-00 Reason: high APT threat detected Task_UUID: d09445005c3f4a9a9bb78c8cb34edc2a Source IP: 10.0.1.2 Source Port: 43130 Destination IP: 67.228.175.200 Destination Port: 443 Proxy Type: HTTP Proxy Host: analysis.lastline.com Path: /docs/lastline-demo-sample.exe'
+-->
+<decoder name="watchguard-firebox-firewall-info">
+  <parent>watchguard-firebox-firewall</parent>
+  <regex type="pcre2" offset="after_parent">(APT threat.*)\..*Details='(.*?)'</regex>
+  <order>reason, data</order>
+</decoder>
+
+<!--
+Apr 15 14:40:22 FW-125852 FVE1032175935 firewall: msg_id="3000-012E" Cannot relearn system MAC address, possible loop or MAC spoofing, ip=192.168.111.10, mac=00:50:da:c7:90:5d, interface=5
+Apr 15 14:40:22 FW-125852 FVE1032175935 firewall: msg_id="3000-012C" ARP spoofing attack detected, ip=192.168.111.10, mac=00:50:da:c7:90:5d, interface=5
+-->
+<decoder name="watchguard-firebox-firewall-info">
+  <parent>watchguard-firebox-firewall</parent>
+  <regex type="pcre2" offset="after_parent">.*ip=(\S+),\s+,\sinterface=(\S+)</regex>
+  <order>srcip, srcmac, src</order>
+</decoder>
+
+<!--
+GENERIC TRAFFIC RULES
+
+PACKET FILTER tcp
+
+May 28 06:58:26 FW-123346 FVE1010101001 firewall: msg_id="3000-0173" Deny 0-External Firebox 52 tcp 20 127 206.190.60.138 10.0.0.1 62443 80 offset 8 S 832026162 win 8192 blocked sites (Internal Policy)
+==action ${inif} ${outif} ${ip_pkt_len} ${protocol} ${iph_len} ${TTL} {${src_ip}|${src_user}} {${dst_ip|${dst_user}} [${tcp_info}] [${udp_info}] [${icmp_info}]
+Mar 21 23:37:51 FW-125852 FVE1032175935 firewall: msg_id="3000-0148" Allow Trusted Firebox 90 icmp 20 128 192.168.100.99 192.168.100.254 8 0 id=1 seq=8  (Ping-00)
+Mar 21 23:43:20 FW-125852 FVE1032175935 firewall: msg_id="3000-0148" Allow Firebox External 91 udp 20 64 10.0.1.2 213.133.99.99 47189 53  (Any From Firebox-00)
+Apr 15 12:10:53 FW-125852 FVE1032175935 firewall: msg_id="3000-0148" Allow Trusted External 76 udp 20 63 192.168.100.250 162.159.200.123 48216 123  (Outgoing-00)
+Apr 15 12:18:24 FW-125852 FVE1032175935 firewall: msg_id="3000-0148" Allow Trusted External 52 tcp 20 127 192.168.100.99 216.58.212.131 50173 80 offset 8 S 237777105 win 61690  (Outgoing-00)
+
+HTTP PROXY FILTER
+May 28 06:58:26 FW-123346 FVE1010101001 firewall: msg_id="1AFF-0025" Deny 1-Trusted 0-External tcp 10.0.1.2 107.20.162.187 55531 80 msg="ProxyDeny: HTTP header IPS match" proxy_act="HTTP-Client.1" signature_id="1055396" severity="5" signature_name="WEB Cross-site Scripting-9" signature_cat="Web Attack" sig_vers="18.001" host="intext.nav-links.com" path="/util/intexteval.pl?action=startup" (HTTP-proxy-00)
+
+May 28 06:58:26 FW-123346 FVE1010101001 firewall: msg_id="1AFF-0029" Allow 1-Trusted 0-External tcp 10.0.1.2 8.25.35.115 51859 80 msg="ProxyAllow: HTTP AV scanning error" proxy_act="HTTP-Client.3" error="avg scanner is not created" host="api.yontoo.com" path="/LoadJS.ashx" (HTTP-proxy-00)
+
+May 28 06:58:26 FW-123346 FVE1010101001 firewall: msg_id="1CFF-0013" Allow 0-External 1-Trusted tcp 11.11.11.2 11.11.11.5 20 43974 msg="ProxyAllow: FTP DLP object unscannable" proxy_act="FTP-Client.3" ctl_ src="11.11.11.2:5120" ctl_dst="10.0.1.49:47553" dlp_sensor="test" error="unscannable object (File was encrypted)" authenticated_user="testuser" file="test.zip" (FTP-proxy-00)
+
+May 28 06:58:26 FW-123346 FVE1010101001 firewall: msg_id="1CFF-0014" Allow 0-External 1-Trusted tcp 11.11.11.2 11.11.11.5 20 43813 msg="ProxyAllow: FTP DLP object too large" proxy_act="FTP-Client.3" error="DLP scan limit (5242880) exceeded" (FTP-proxy-00)
+
+May 28 06:58:26 FW-123346 FVE1010101001 firewall: msg_id="22FF-000E" Allow 1-Trusted 0-External tcp 10.0.1.3 100.100.100.3 60275 143 msg="ProxyReplace: IMAP Classified as suspect SPAM" proxy_act="IMAPClient.Standard.1" mbx="INBOX" user="wg" (IMAP-proxy-00)
+
+May 28 06:58:26 FW-123346 FVE1010101001 firewall: msg_id="28FF-0005" Deny 1-Trusted 0-External udp 10.0.1.3 192.168.53.143 5060 5060 msg="ProxyDeny: SIP codec" proxy_act="SIP-Client.1" codec="speex" (SIPALG-00)
+
+
+-->
+
+<decoder name="watchguard-firebox-firewall-info">
+  <parent>watchguard-firebox-firewall</parent>
+  <regex type="pcre2" offset="after_parent">.*\((.*?)\)$</regex>
+  <order>reason</order>
+</decoder>
+
+<decoder name="watchguard-firebox-firewall-info">
+  <parent>watchguard-firebox-firewall</parent>
+  <regex type="pcre2" offset="after_parent">msg="(.*?)"</regex>
+  <order>reason</order>
+</decoder>
+
+<decoder name="watchguard-firebox-firewall-info">
+  <parent>watchguard-firebox-firewall</parent>
+  <regex type="pcre2" offset="after_parent">signature_cat="(.*?)"</regex>
+  <order>extra_data</order>
+</decoder>
+
+<decoder name="watchguard-firebox-firewall-info">
+  <parent>watchguard-firebox-firewall</parent>
+  <regex type="pcre2" offset="after_parent">error="(.*?)"</regex>
+  <order>extra_data</order>
+</decoder>
+
+<decoder name="watchguard-firebox-firewall-info">
+  <parent>watchguard-firebox-firewall</parent>
+  <regex type="pcre2" offset="after_parent">authenticated_user="(.*?)"</regex>
+  <order>srcuser</order>
+</decoder>
+
+<!-- PACKET FILTER LOGS -->
+<decoder name="watchguard-firebox-firewall-info">
+  <parent>watchguard-firebox-firewall</parent>
+  <regex type="pcre2" offset="after_parent">(Deny|Allow)\s(\S+)\s(\S+)\s(\d+)\s(\w+)\s(\d+)\s(\d+)\s(\S+)\s(\S+)</regex>
+  <order>action, src, dst, packetlen, protocol, iphlen, ttl, srcip, dstip, srcport, dstport</order>
+</decoder>
+
+<!-- PROXY LOGS -->
+<decoder name="watchguard-firebox-firewall-info">
+  <parent>watchguard-firebox-firewall</parent>
+  <regex type="pcre2" offset="after_parent">(Deny|Allow)\s(\S+)\s(\S+)\s(\w+)\s(\S+)\s(\S+)\s(\d+)\s(\d+)</regex>
+  <order>action, src, dst, protocol, srcip, dstip, srcport, dstport</order>
+</decoder>
+
+
+<!-- AUTHENTICATION DECODER -->
+<decoder name="watchguard-firebox-auth">
+  <prematch type="pcre2">(FVE\w+|D0F\w+|D02\w+) (admd|wgagent|sessiond|sslvpn|wgcgi)\[\w+\]: </prematch>
+</decoder>
+
+<!--
+Apr 15 14:40:22 FW-125852 FVE1032175935 firewall: msg_id="XXXX-XXXX"
+-->
+
+<decoder name="watchguard-firebox-auth-info">
+  <parent>watchguard-firebox-auth</parent>
+  <regex type="pcre2" offset="after_parent">msg_id="([0-9a-fA-F]{4}-[0-9a-fA-F]{4})"</regex>
+  <order>id</order>
+</decoder>
+
+<!--
+User authentication failed
+Feb 25 15:33:44 FW-125852 FVE1000000000 admd[2060]: msg_id="1100-0005" Authentication of Admin user [admin@Firebox-DB] from 192.168.100.100 was rejected, password is incorrect
+Mar 21 15:48:45 FW-125852 D0200904665CC admd[2107]: msg_id="1100-0005" Authentication of Firewall user [testuser@Firebox-DB] from 192.168.100.99 was rejected, password is incorrect
+Mar 21 15:48:45 FW-125852 FVE1032175935 admd[2107]: msg_id="1100-0005" Authentication of Firewall user [testuser@Firebox-DB] from fe80::20c:29ff:fe59:7afa was rejected, password is incorrect
+Watchguard syntax: Authentication of %s user [%s@%s] from %s rejected, %s
+
+WebUI&WSM authentification failed
+Mar 21 14:11:32 FW-125852 FVE1032175935 wgagent[2159]: msg_id="5000-0001" WebUI User azerty@Firebox-DB from 10.0.0.2 log in attempt was rejected - invalid credentials.
+Mar 22 00:01:07 FW-125852 FVE1032175935 wgagent[2159]: msg_id="5000-0001" WSM User status@Firebox-DB from 192.168.100.99 log in attempt was rejected - invalid credentials.
+Mar 22 00:01:07 FW-125852 FVE1032175935 wgagent[2159]: msg_id="5000-0001" WSM User status@Firebox-DB from fe80::20c:29ff:fe59:7afa log in attempt was rejected - invalid credentials.
+Watchguard syntax: WebUI User %s@%s from %s log in attempt was rejected - %s
+
+User authentication success
+Feb 25 16:06:07 FW-125852 FVE1000000000 sessiond[2102]: msg_id="3E00-0002" Management user admin@Firebox-DB from 192.168.100.100 logged in
+Feb 25 16:06:07 FW-125852 FVE1000000000 sessiond[2102]: msg_id="3E00-0002" Management user admin@Firebox-DB from fe80::20c:29ff:fe59:7afa logged in
+Watchguard syntax: %s %s%s%s from %s logged in
+
+VPN User authentication success
+Mar 21 15:28:27 FW-125852 FVE1032175935 sslvpn[2154]: msg_id="2500-0000" Mobile VPN with SSL user testuser logged in. Virtual IP address is 192.168.25.2. Real IP address is 192.168.100.99
+Mar 21 15:28:27 FW-125852 FVE1032175935 sslvpn[2154]: msg_id="2500-0000" Mobile VPN with SSL user testuser logged in. Virtual IP address is ac::d0:::1. Real IP address is fe80::20c:29ff:fe59:7afa
+Mar 21 15:28:27 FW-125852 FVE1032175935 sslvpn[2154]: msg_id="2500-0000" Mobile VPN with SSL user testuser logged in. Virtual IP address is fe80::20c:29ff:fe59:7afa. Real IP address is ac::d0:::1
+Watchguard syntax: Mobile VPN with SSL user %s logged in. Virtual IP address is %s. Real IP address is %s.
+
+VPN User authentication failed
+Mar 21 15:48:45 FW-125852 FVE1032175935 wgcgi[29063]: SSL VPN user testuser@Firebox-DB from 192.168.100.99 was rejected - Unspecified.
+-->
+
+<!-- IPv4 -->
+<decoder name="watchguard-firebox-auth-info">
+  <parent>watchguard-firebox-auth</parent>
+  <regex type="pcre2" offset="after_parent">from\s((25[0-5]|2[0-4][0-9]|1?[0-9][0-9]{1,2})(\.(25[0-5]|2[0-4][0-9]|1?[0-9]{1,2})){3})</regex>
+  <order>srcip</order>
+</decoder>
+
+<!-- IPv6 -->
+<decoder name="watchguard-firebox-auth-info">
+  <parent>watchguard-firebox-auth</parent>
+  <regex type="pcre2">from\s?(([0-9a-fA-F]{1,4}:){1,4}:((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])|[Ff][Ee]80:(:[0-9a-fA-F]{0,4}){0,4}%[0-9a-zA-Z]{1,}|([0-9a-fA-F]{1,4}:){1,2}(:[0-9a-fA-F]{1,4}){1,5}|([0-9a-fA-F]{1,4}:){1,3}(:[0-9a-fA-F]{1,4}){1,4}|[0-9a-fA-F]{1,4}:((:[0-9a-fA-F]{1,4}){1,6})|([0-9a-fA-F]{1,4}:){1,4}(:[0-9a-fA-F]{1,4}){1,3}|([0-9a-fA-F]{1,4}:){1,5}(:[0-9a-fA-F]{1,4}){1,2}|([0-9a-fA-F]{1,4}:){1,6}:[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,7}:|([0-9a-fA-F]{1,4}:){7,7}[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,4}:((25[0-5]|2[0-4][0-9]|1{0,1}[0-9]{0,1}[0-9])\.{3,3})(25[0-5]|2[0-4][0-9]|1{0,1}[0-9]{0,1}[0-9])|::(ffff(:0{1,4}){0,1}:){0,1}((25[0-5]|2[0-4][0-9]|1{0,1}[0-9]{0,1}[0-9])\.{3,3})(25[0-5]|2[0-4][0-9]|1{0,1}[0-9]{0,1}[0-9])|:((:[0-9a-fA-F]{1,4}){1,7}|:))</regex>
+  <order>srcip</order>
+</decoder>
+
+<!-- IPv4 -->
+<decoder name="watchguard-firebox-auth-info">
+  <parent>watchguard-firebox-auth</parent>
+  <regex type="pcre2" offset="after_parent">Virtual IP address is\s((25[0-5]|2[0-4][0-9]|1?[0-9][0-9]{1,2})(\.(25[0-5]|2[0-4][0-9]|1?[0-9]{1,2})){3})</regex>
+  <order>dstip</order>
+</decoder>
+
+<!-- IPv6 -->
+<decoder name="watchguard-firebox-auth-info">
+  <parent>watchguard-firebox-auth</parent>
+  <regex type="pcre2">Virtual IP address is\s?(([0-9a-fA-F]{1,4}:){1,4}:((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])|[Ff][Ee]80:(:[0-9a-fA-F]{0,4}){0,4}%[0-9a-zA-Z]{1,}|([0-9a-fA-F]{1,4}:){1,2}(:[0-9a-fA-F]{1,4}){1,5}|([0-9a-fA-F]{1,4}:){1,3}(:[0-9a-fA-F]{1,4}){1,4}|[0-9a-fA-F]{1,4}:((:[0-9a-fA-F]{1,4}){1,6})|([0-9a-fA-F]{1,4}:){1,4}(:[0-9a-fA-F]{1,4}){1,3}|([0-9a-fA-F]{1,4}:){1,5}(:[0-9a-fA-F]{1,4}){1,2}|([0-9a-fA-F]{1,4}:){1,6}:[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,7}:|([0-9a-fA-F]{1,4}:){7,7}[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,4}:((25[0-5]|2[0-4][0-9]|1{0,1}[0-9]{0,1}[0-9])\.{3,3})(25[0-5]|2[0-4][0-9]|1{0,1}[0-9]{0,1}[0-9])|::(ffff(:0{1,4}){0,1}:){0,1}((25[0-5]|2[0-4][0-9]|1{0,1}[0-9]{0,1}[0-9])\.{3,3})(25[0-5]|2[0-4][0-9]|1{0,1}[0-9]{0,1}[0-9])|:((:[0-9a-fA-F]{1,4}){1,7}|:))</regex>
+  <order>dstip</order>
+</decoder>
+
+<!-- IPv4 -->
+<decoder name="watchguard-firebox-auth-info">
+  <parent>watchguard-firebox-auth</parent>
+  <regex type="pcre2" offset="after_parent">Real IP address is\s((25[0-5]|2[0-4][0-9]|1?[0-9][0-9]{1,2})(\.(25[0-5]|2[0-4][0-9]|1?[0-9]{1,2})){3})</regex>
+  <order>srcip</order>
+</decoder>
+
+<!-- IPv6 -->
+<decoder name="watchguard-firebox-auth-info">
+  <parent>watchguard-firebox-auth</parent>
+  <regex type="pcre2">Real IP address is\s?(([0-9a-fA-F]{1,4}:){1,4}:((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])|[Ff][Ee]80:(:[0-9a-fA-F]{0,4}){0,4}%[0-9a-zA-Z]{1,}|([0-9a-fA-F]{1,4}:){1,2}(:[0-9a-fA-F]{1,4}){1,5}|([0-9a-fA-F]{1,4}:){1,3}(:[0-9a-fA-F]{1,4}){1,4}|[0-9a-fA-F]{1,4}:((:[0-9a-fA-F]{1,4}){1,6})|([0-9a-fA-F]{1,4}:){1,4}(:[0-9a-fA-F]{1,4}){1,3}|([0-9a-fA-F]{1,4}:){1,5}(:[0-9a-fA-F]{1,4}){1,2}|([0-9a-fA-F]{1,4}:){1,6}:[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,7}:|([0-9a-fA-F]{1,4}:){7,7}[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,4}:((25[0-5]|2[0-4][0-9]|1{0,1}[0-9]{0,1}[0-9])\.{3,3})(25[0-5]|2[0-4][0-9]|1{0,1}[0-9]{0,1}[0-9])|::(ffff(:0{1,4}){0,1}:){0,1}((25[0-5]|2[0-4][0-9]|1{0,1}[0-9]{0,1}[0-9])\.{3,3})(25[0-5]|2[0-4][0-9]|1{0,1}[0-9]{0,1}[0-9])|:((:[0-9a-fA-F]{1,4}){1,7}|:))</regex>
+  <order>srcip</order>
+</decoder>
+
+<decoder name="watchguard-firebox-auth-info">
+  <parent>watchguard-firebox-auth</parent>
+  <regex type="pcre2" offset="after_parent">msg_id="[0-9a-fA-F]{4}-[0-9a-fA-F]{4}"\s(Authentication of)?\s?(.*\s[Uu]ser)\s\[?(\S+)\]?\s</regex>
+  <order>extra_data, data, srcuser</order>
+</decoder>
+
+<decoder name="watchguard-firebox-auth-info">
+  <parent>watchguard-firebox-auth</parent>
+  <regex type="pcre2" offset="after_parent">was (rejected),?\s?-?\s?(.*)</regex>
+  <order>action, reason</order>
+</decoder>
+
+<decoder name="watchguard-firebox-auth-info">
+  <parent>watchguard-firebox-auth</parent>
+  <regex type="pcre2" offset="after_parent">(logged in)</regex>
+  <order>status</order>
+</decoder>
+

--- a/rules/0710-watchguard-firebox-rules.xml
+++ b/rules/0710-watchguard-firebox-rules.xml
@@ -1,0 +1,561 @@
+<!--
+  -  Decoders for watchguard-firebox
+  -  Created by FMI Groupe (ph3nix, Orsiris de Jong) for Wazuh, Inc.
+  -  Copyright (C) 2021, FMI Groupe, Wazuh Inc.
+  -  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2.
+
+   Changelog
+   2021/07/08 - Orsiris de Jong - Added security event rules
+   2021/07/05 - Orsiris de Jong - Added various correlation rules
+                                - Added possible traffic and proxy rules
+   2021/06/10 - Orsiris de Jong - Added various attack rules (port scan, ddos, ids, flooding, spoofing)
+                                - Added possible tunnel attack rules high ICMP, DNS & NTP payloads
+                                - Added multiple attack grouping
+                                
+   2021/04/21 - ph3nix          - Initial release
+                                - Authentication, VPN and traffic rules
+-->
+
+<group name="syslog,firewall,watchguard,watchguard-fw">
+  <rule id="110000" level="0">
+    <decoded_as>watchguard-firebox-firewall</decoded_as>
+    <description>Grouping of Watchguard Firebox authentication rules</description>
+  </rule>
+  
+  <!-- ## BASIC RULES ## -->
+  
+  <!-- startup / shutdown rules -->
+  <rule id="110001" level="3">
+    <if_sid>110000</if_sid>
+    <id type="pcre2">3000-002[7|8]</id>
+    <description>Watchguard: $(reason)</description>
+  </rule>
+ 
+  <!-- licence / features missing or malfunction-->
+  <rule id="110002" level="12">
+    <if_sid>110000</if_sid>
+     <id type="pcre2">(3000-000[4|5])|3000-003A</id>
+    <description>Watchguard: $(reason)</description>
+  </rule>
+  
+  <!-- ## ATTACK DETECTION RULES ## -->
+  
+  <!-- Port scan & Syn flood -->
+  <rule id="110011" level="9">
+    <if_sid>110000</if_sid>
+    <id type="pcre2">3000-0(159|162)</id>
+    <description>Watchguard: $(reason) detected from $(srcip) to $(dstip)</description>
+    <group>port_scan</group>
+  </rule>
+  
+  <!-- DDoS to -->
+  <rule id="110012" level="9">
+    <if_sid>110000</if_sid>
+    <id>3000-0160</id>
+    <description>Watchguard: $(reason) detected against $(dstip)</description>
+    <group>ddos</group>
+  </rule>
+  
+  <!-- DDoS from -->
+  <rule id="110013" level="9">
+    <if_sid>110000</if_sid>
+    <id>3000-0161</id>
+    <description>Watchguard: $(reason) detected from $(dstip)</description>
+    <group>ddos</group>
+  </rule>
+  
+  <!-- Unwanted traffic rules -->
+  <rule id="110014" level="9">
+    <if_sid>110000</if_sid>
+    <id>3000-0168</id>
+    <description>Watchguard: Blocked site: Traffic detected from $(srcip) to $(dstip)</description>
+    <group>unwanted_traffic,access_denied,pci_dss_10.2.4,pci_dss_11.4,gpg13_4.12,gdpr_IV_35.7.d,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
+  </rule>
+  
+  <rule id="110015" level="10" frequency="10" timeframe="240" ignore="90">
+    <if_matched_sid>110014</if_matched_sid>
+    <same_srcip />
+    <description>Watchguard: Blocked site: Recidiving traffic received from $(srcip)</description>
+    <group>unwanted_traffic,access_denied,pci_dss_10.2.4,pci_dss_11.4,gpg13_4.12,gdpr_IV_35.7.d,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
+  </rule>
+  
+  <rule id="110016" level="9">
+    <if_sid>110000</if_sid>
+    <id>3000-0169</id>
+    <description>Watchguard: IP spoofing: Traffic detected from $(srcip) to $(dstip)</description>
+    <group>unwanted_traffic,access_denied,pci_dss_10.2.4,pci_dss_11.4,gpg13_4.12,gdpr_IV_35.7.d,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
+  </rule>
+  
+  <rule id="110017" level="10" frequency="10" timeframe="240" ignore="90">
+    <if_matched_sid>110016</if_matched_sid>
+    <same_srcip />
+    <description>Watchguard: IP spoofing: Recidiving traffic received from $(srcip)</description>
+    <group>unwanted_traffic,access_denied,pci_dss_10.2.4,pci_dss_11.4,gpg13_4.12,gdpr_IV_35.7.d,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
+  </rule>
+  
+  <rule id="110018" level="9">
+    <if_sid>110000</if_sid>
+    <id>3000-0172</id>
+    <description>Watchguard: Blocked port: Traffic detected from $(srcip) to $(dstip) on port $(dstport)</description>
+    <group>unwanted_traffic,access_denied,pci_dss_10.2.4,pci_dss_11.4,gpg13_4.12,gdpr_IV_35.7.d,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
+  </rule>
+  
+  <rule id="110019" level="10" frequency="10" timeframe="240" ignore="90">
+    <if_matched_sid>110018</if_matched_sid>
+    <same_srcip />
+    <description>Watchguard: Blocked port: Recidiving traffic received from $(srcip)</description>
+    <group>unwanted_traffic,access_denied,pci_dss_10.2.4,pci_dss_11.4,gpg13_4.12,gdpr_IV_35.7.d,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
+  </rule>
+  
+  <!-- correlation rule for unwanted traffic -->
+  <rule id="110020" level="14" frequency="10" timeframe="240" ignore="90">
+    <if_matched_group>unwanted_traffic</if_matched_group>
+    <description>Watchguard: Multiple unwanted traffic received. Possible attack ongoing</description>
+    <group>unwanted_traffic,access_denied,pci_dss_10.2.4,pci_dss_11.4,gpg13_4.12,gdpr_IV_35.7.d,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
+  </rule>
+  
+  <rule id="110021" level="10">
+    <if_sid>110000</if_sid>
+    <id>3000-012C</id>
+    <description>Watchguard: ARP spoofing attack detected, ip=$(srcip), mac=$(srcmac), interface=$(src)</description>
+    <group>spoofing,pci_dss_10.6.1,gpg13_4.12,gdpr_IV_35.7.d,tsc_CC7.2,tsc_CC7.3,</group>
+  </rule>
+  
+  <rule id="110022" level="14">
+    <if_matched_sid>110021</if_matched_sid>
+    <description>Watchguard: Multiple ARP spoofing attacks detected. Possible attack ongoing</description>
+    <group>spoofing,pci_dss_10.6.1,gpg13_4.12,gdpr_IV_35.7.d,tsc_CC7.2,tsc_CC7.3,</group>
+  </rule>
+  
+  <rule id="110023" level="9">
+    <if_sid>110000</if_sid>
+    <id>3000-012E</id>
+    <description>Watchguard: Cannot relearn system MAC address, possible loop or MAC spoofing, ip=$(srcip), mac=$(srcmac), interface=$(src)</description>
+    <group>spoofing,pci_dss_10.6.1,gpg13_4.12,gdpr_IV_35.7.d,tsc_CC7.2,tsc_CC7.3,</group>
+  </rule>
+  
+  <rule id="110024" level="14">
+    <if_matched_sid>110023</if_matched_sid>
+    <description>Watchguard: Multiple possible loops or MAC spoofing. Possible attack ongoing</description>
+    <group>spoofing,pci_dss_10.6.1,gpg13_4.12,gdpr_IV_35.7.d,tsc_CC7.2,tsc_CC7.3,</group>
+  </rule>
+  
+  <!-- ## DIAGNOSTIC RULES ## -->
+  <rule id="110040" level="6">
+    <if_sid>110000</if_sid>
+    <id type="pcre2">3000-00C[9|B]</id>
+    <description>Watchguard: Load Balance Server $(dstip) is offline, protocol $(protocol)</description>
+	<group>service_availability,pci_dss_10.6.1,gpg13_4.12,gdpr_IV_35.7.d,tsc_CC7.2,tsc_CC7.3,</group>
+  </rule>
+
+  <rule id="110041" level="7">
+    <if_sid>110000</if_sid>
+    <id type="pcre2">4900-0001</id>
+    <description>Watchguard: Link Monitor: $(src) unable to resolve domain name $(dst)</description>
+	<group>service_availability,pci_dss_10.6.1,gpg13_4.12,gdpr_IV_35.7.d,tsc_CC7.2,tsc_CC7.3,</group>
+  </rule>
+  
+  <rule id="110042" level="7">
+    <if_sid>110000</if_sid>
+    <id type="pcre2">4900-0002</id>
+    <description>Watchguard: Link Monitor: No response received on $(src) from $(protocol) host $(dstip) $(dstport)</description>
+	<group>service_availability,pci_dss_10.6.1,gpg13_4.12,gdpr_IV_35.7.d,tsc_CC7.2,tsc_CC7.3,</group>
+  </rule>
+  
+  <rule id="110043" level="7">
+    <if_sid>110000</if_sid>
+    <id type="pcre2">4900-0003</id>
+    <description>Watchguard: Link Monitor: $(src) interface $(reason)</description>
+	<group>service_availability,pci_dss_10.6.1,gpg13_4.12,gdpr_IV_35.7.d,tsc_CC7.2,tsc_CC7.3,</group>
+  </rule>
+  
+  <!-- ## BLOCKED SITE NORMAL OPERATIONS ## -->
+  <rule id="110050" level="3">
+    <if_sid>110000</if_sid>
+    <id>3000-0029</id>
+    <description>Watchguard: $(srcip) will not be added to the blocked sites list because it is exempt</description>
+  </rule>
+  
+  <rule id="110051" level="3">
+    <if_sid>110000</if_sid>
+    <id>3000-0040</id>
+    <description>Watchguard: Idle timeout has occurred for blocked site $(srcip)</description>
+  </rule>
+ 
+  <rule id="110052" level="12">
+    <if_sid>110000</if_sid>
+    <id>3000-1002</id>
+    <description>Watchguard: The Temporary Blocked Sites list is full (capacity=1000). The oldest entry $(srcip) was removed</description>
+	<group>unwanted_traffic,access_denied,pci_dss_10.2.4,pci_dss_11.4,gpg13_4.12,gdpr_IV_35.7.d,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
+  </rule>
+  
+  <rule id="110053" level="14" frequency="10" timeframe="240" ignore="90">
+    <if_matched_sid>110052</if_matched_sid>
+    <description>Watchguard: The Temporary Blocked Sites list cannot hold all the blocked sites. Probable DDoS attack ongoing</description>
+	<group>unwanted_traffic,access_denied,pci_dss_10.2.4,pci_dss_11.4,gpg13_4.12,gdpr_IV_35.7.d,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
+    <group>ddos</group>
+  </rule>
+ 
+  <rule id="110054" level="12">
+    <if_sid>110000</if_sid>
+    <id>3001-1001</id>
+    <description>Watchguard: Temporarily blocking host $(srcip) - $(reason)</description>
+	<group>unwanted_traffic,access_denied,pci_dss_10.2.4,pci_dss_11.4,gpg13_4.12,gdpr_IV_35.7.d,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
+  </rule>
+  
+  <rule id="110055" level="14" frequency="10" timeframe="240" ignore="90">
+    <if_matched_sid>110054</if_matched_sid>
+    <description>Watchguard: Multiple blocked hosts in short timespan. Probable DDoS attack ongoing</description>
+	<group>unwanted_traffic,access_denied,pci_dss_10.2.4,pci_dss_11.4,gpg13_4.12,gdpr_IV_35.7.d,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
+    <group>ddos</group>
+  </rule>
+  
+  <rule id="110056" level="3">
+    <if_sid>110000</if_sid>
+    <id>3001-1002</id>
+    <description>Watchguard: Removing temporarily blocked host $(srcip) from list</description>
+  </rule>
+  
+  <!-- ## PACKET FILTER RULES ## -->
+  
+  <!-- For the sake of disk space, we will match Allow packets with level 0 -->
+  
+  <!-- Normal allowed traffic -->
+  <rule id="110060" level="0">
+    <if_sid>110000</if_sid>
+    <id>3000-0148</id>
+    <action type="pcre2">[Aa]llow</action>
+    <description>Watchguard: firewall: $(action) $(src) $(dst) packetlen=$(packetlen) $(protocol) iphlen=$(iphlen) ttl=$(ttl) from $(srcip):$(srcport) to $(dstip):$(dstport) - $(reason)</description>
+    <group>packet_filter</group>
+  </rule>
+  
+  <!-- layer 2 denied traffic / don't bother to keep, so set level=0 -->
+  <rule id="110061" level="0">
+    <if_sid>110000</if_sid>
+    <id>3000-0148</id>
+    <action type="pcre2">[Dd]eny</action>
+    <match type="pcre2">0.0.0.0\s0.0.0.0\s0\s0</match>
+    <description>Watchguard: firewall: Layer2 $(action) $(src) $(dst) packetlen=$(packetlen) $(protocol) iphlen=$(iphlen) ttl=$(ttl) from $(srcip):$(srcport) to $(dstip):$(dstport) - $(reason)</description>
+    <group>packet_filter</group>
+  </rule>
+ 
+  <!-- Normal denied traffic -->
+  <rule id="110062" level="3">
+    <if_sid>110000</if_sid>
+    <id>3000-0148</id>
+    <action type="pcre2">[Dd]eny</action>
+    <description>Watchguard: firewall: $(action) $(src) $(dst) packetlen=$(packetlen) $(protocol) iphlen=$(iphlen) ttl=$(ttl) from $(srcip):$(srcport) to $(dstip):$(dstport) - $(reason)</description>
+    <group>packet_filter,packet_filter_deny</group>
+  </rule>
+  
+    <!-- allowed App Control -->
+  <rule id="110063" level="0">
+    <if_sid>110000</if_sid>
+    <id>3000-0149</id>
+    <action type="pcre2">[Aa]llow</action>
+    <description>Watchguard: App control: $(action) $(src) $(dst) packetlen=$(packetlen) $(protocol) iphlen=$(iphlen) ttl=$(ttl) from $(srcip):$(srcport) to $(dstip):$(dstport) - $(reason)</description>
+    <group>packet_filter,app_control</group>
+  </rule>
+  
+    <!--denied  App Control -->
+  <rule id="110064" level="3">
+    <if_sid>110000</if_sid>
+    <id>3000-0149</id>
+    <action type="pcre2">[Dd]eny</action>
+    <description>Watchguard: App control: $(action) $(src) $(dst) packetlen=$(packetlen) $(protocol) iphlen=$(iphlen) ttl=$(ttl) from $(srcip):$(srcport) to $(dstip):$(dstport) - $(reason)</description>
+    <group>packet_filter,packet_filter_deny,app_control</group>
+  </rule>
+  
+  <!-- allowed IPS Traffic -->
+  <rule id="110065" level="0">
+    <if_sid>110000</if_sid>
+    <id>3000-0150</id>
+    <action type="pcre2">[Aa]llow</action>
+    <description>Watchguard: App control: $(action) $(src) $(dst) packetlen=$(packetlen) $(protocol) iphlen=$(iphlen) ttl=$(ttl) from $(srcip):$(srcport) to $(dstip):$(dstport) - $(reason)</description>
+    <group>packet_filter,ips</group>
+  </rule>
+  
+  <!-- denied IPS Traffic -->
+  <rule id="110066" level="3">
+    <if_sid>110000</if_sid>
+    <id>3000-0150</id>
+    <action type="pcre2">[Dd]eny</action>
+    <description>Watchguard: App control: $(action) $(src) $(dst) packetlen=$(packetlen) $(protocol) iphlen=$(iphlen) ttl=$(ttl) from $(srcip):$(srcport) to $(dstip):$(dstport) - $(reason)</description>
+    <group>packet_filter,packet_filter_deny,ips</group>
+  </rule>
+  
+  <!-- Multiple denied generic traffic -->
+  <rule id="110067" level="13" frequency="5" timeframe="300">
+    <if_matched_group>packet_filter_deny</if_matched_group>
+    <same_srcip />
+    <description>Watchguard: firewall: Multiple denied traffic from same source $(srcip)</description>
+    <group>firewall</group>
+  </rule>
+  
+  <!-- Traffic connection terminated, very verbose, hence level=0 -->
+  <rule id="110068" level="0">
+    <if_sid>110000</if_sid>
+    <id>3000-0151</id>
+    <description>Watchguard: firewall: Traffic connection terminated: $(action) $(src) $(dst)  $(protocol) from $(srcip):$(srcport) to $(dstip):$(dstport) - $(reason)</description>
+    <group>firewall</group>
+  </rule>
+  
+  <!-- Hostile traffic -->
+  <rule id="110069" level="9">
+    <if_sid>110000</if_sid>
+    <id>3000-0178</id>
+    <description>Watchguard: firewall: Hostile traffic $(action) $(src) $(dst) packetlen=$(packetlen) $(protocol) iphlen=$(iphlen) ttl=$(ttl) from $(srcip):$(srcport) to $(dstip):$(dstport) - $(reason)</description>
+    <group>firewall</group>
+  </rule>
+  
+  <!-- Multiple hostile traffic -->
+  <rule id="110070" level="13" frequency="10" timeframe="240" ignore="90">
+    <if_matched_sid>110069</if_matched_sid>
+    <same_srcip />
+    <description>Watchguard: firewall: Multiple hostile traffic from same source</description>
+    <group>firewall</group>
+  </rule>
+  
+  <!-- ICMP hidden tunnel detection when too much packets are larger than standard ICMP packet size
+
+  Generic ping max packet size
+  PING = 56 + 40 + 8 = 104
+   Default LINUX size + IPv6 Header + ICMP Header
+
+2021 Mar 21 22:01:42 FW-125852->192.168.100.254 Mar 21 23:01:42 FW-125852 FVE1032175935 firewall: msg_id="3000-0148" Allow Trusted Firebox 1300 icmp 20 128 192.168.100.99 192.168.100.254 8 0 id=1 seq=2  (Ping-00)
+2021 Mar 21 22:01:42 FW-125852->192.168.100.254 Mar 21 23:01:42 FW-125852 FVE1032175935 firewall: msg_id="3000-0148" Allow Trusted Firebox 60 icmp 20 128 192.168.100.99 192.168.100.254 8 0 id=1 seq=2  (Ping-00)
+-->
+  <rule id="110080" level="4">
+    <if_matched_sid>110060</if_matched_sid>
+	<protocol>icmp</protocol>
+    <field name="packetlen" type="pcre2">([0-9]{4,}|[1-9]0[5-9]|1[1-9][0-9]|[2-9][0-9]{2})</field>
+	<description>Watchguard: firewall: $(action) from $(srcip) to $(dstip) using protocol $(protocol) packet size is bigger than usual: $(packetlen)</description>
+  </rule>
+  
+  <rule id="110081" level="14" frequency="10" timeframe="240" ignore="90">
+    <if_matched_sid>110080</if_matched_sid>
+	<same_srcip />
+	<description>Watchguard: firewall: Possible $(protocol) tunnel attack from $(srcip) on interface $(src) to $(dstip) on interface $(dst)</description>
+	<group>hidden_tunnel,pci_dss_10.6.1,pci_dss_11.4,gpg13_4.12,gdpr_IV_35.7.d,tsc_CC7.2,tsc_CC7.3,tsc_CC6.1,tsc_CC6.8,</group>
+  </rule>
+  
+   <!--DNS hidden tunnel detection when too much packets are larger than standard DNS request size
+  
+DNS Nom de domaine < 63 caractères 
+Taille de la requête IPv4 = 112
+IPv4 + IPv6 = 112 + 20 = 132
+(63 letters).(63 letters).(63 letters).(62 letters) = 260 IPv4 (FQDN max length)
+https://devblogs.microsoft.com/oldnewthing/20120412-00/?p=7873
+
+Mar 21 23:43:20 FW-125852 FVE1032175935 firewall: msg_id="3000-0148" Allow Firebox External 156 udp 20 64 10.0.1.2 213.133.99.99 47189 53  (Any From Firebox-00)
+Mar 21 23:47:28 FW-125852 FVE1032175935 firewall: msg_id="3000-0148" Allow Firebox External 60 udp 20 64 fe80::20c:29ff:fe59:7afa ac::d0:::1 47189 53  (Any From Firebox-00)
+-->
+
+  <rule id="110082" level="4">
+    <if_matched_sid>110060</if_matched_sid>
+	<protocol>dns</protocol>
+    <field name="packetlen" type="pcre2">([0-9]{4,}|[1-9]3[3-9]|1[4-9][0-9]|[2-9][0-9]{2})</field>
+	<description>Watchguard: firewall: $(action) from $(srcip) to $(dstip) using protocol $(protocol) packet size is bigger than usual: $(packetlen)</description>
+  </rule>
+  
+  <rule id="110083" level="14" frequency="10" timeframe="240" ignore="90">
+    <if_matched_sid>110082</if_matched_sid>
+	<same_srcip />
+	<description>Watchguard: firewall: Possible $(protocol) tunnel attack from $(srcip) on interface $(src) to $(dstip) on interface $(dst)</description>
+	<group>hidden_tunnel,pci_dss_10.6.1,pci_dss_11.4,gpg13_4.12,gdpr_IV_35.7.d,tsc_CC7.2,tsc_CC7.3,tsc_CC6.1,tsc_CC6.8,</group>
+  </rule>
+
+  <!--NTP hidden tunnel detection when too much packets are larger than standard NTP packet size
+
+NTP Taille de la requête = 76
+Taille de la requête + Entête IPv6 = 96
+
+Apr 15 12:10:53 FW-125852 FVE1032175935 firewall: msg_id="3000-0148" Allow Trusted External 76 udp 20 63 192.168.100.250 162.159.200.123 48216 123  (Outgoing-00)
+Apr 15 12:10:53 FW-125852 FVE1032175935 firewall: msg_id="3000-0148" Allow Trusted External 76 udp 20 63 fe80::20c:29ff:fe59:7afa ac::d0:::1 48216 123  (Outgoing-00)
+-->
+
+  <rule id="110084" level="4">
+    <if_matched_sid>110060</if_matched_sid>
+	<protocol>ntp</protocol>
+    <field name="packetlen" type="pcre2">([1-9][0-9]{2,}|[2-9][0-9]|1[0-9])[0-9]{1}|([9-9][7-9])</field>
+	<description>Watchguard: firewall: $(action) from $(srcip) to $(dstip) using protocol $(protocol) packet size is bigger than usual: $(packetlen)</description>
+  </rule>
+  
+  <rule id="110085" level="14" frequency="10" timeframe="240" ignore="90">
+    <if_matched_sid>110084</if_matched_sid>
+	<same_srcip />
+	<description>Watchguard: firewall: Possible $(protocol) tunnel attack from $(srcip) on interface $(src) to $(dstip) on interface $(dst)</description>
+	<group>hidden_tunnel,pci_dss_10.6.1,pci_dss_11.4,gpg13_4.12,gdpr_IV_35.7.d,tsc_CC7.2,tsc_CC7.3,tsc_CC6.1,tsc_CC6.8,</group>
+  </rule>
+
+  <rule id="110086" level="14" frequency="10" timeframe="240" ignore="90"> <!-- NOOK -->
+    <if_matched_group>hidden_tunnel</if_matched_group>
+	<description>Watchguard: Possible multiple tunnel attacks ongoing. Please have a look</description>
+	<group>pci_dss_10.6.1,pci_dss_11.4,gpg13_4.12,gdpr_IV_35.7.d,tsc_CC7.2,tsc_CC7.3,tsc_CC6.1,tsc_CC6.8,</group>
+  </rule>
+    
+  <!-- ## PROXY FILTER RULES ## -->
+  
+  <!-- allowed proxy traffic is level 0 for disk space reasons -->
+  <rule id="110090" level="0">
+    <if_sid>110000</if_sid>
+	<id type="pcre2">[1-2][0-9A-F]FF-[0-F]{4}</id>
+	<action type="pcre2">[Aa]llow</action>
+	<description>Watchguard: proxy: $(action) from $(src) to $(dst), $(protocol) from $(srcip):$(srcport) to $(dstip):$(dstport) - $(reason)</description>
+	<group>proxy</group>
+  </rule>
+  
+  <!-- denied proxy traffic -->
+  <rule id="110091" level="3">
+    <if_sid>110000</if_sid>
+	<id type="pcre2">[1-2][0-9A-F]FF-[0-F]{4}</id>
+	<action type="pcre2">[Dd]eny</action>
+	<description>Watchguard: proxy: $(action) from $(src) to $(dst), $(protocol) from $(srcip):$(srcport) to $(dstip):$(dstport) - $(reason)</description>
+	<group>proxy</group>
+  </rule>
+  
+  <!-- Multiple proxy traffic -->
+  <rule id="110092" level="13" frequency="10" timeframe="240" ignore="90">
+    <if_matched_sid>110091</if_matched_sid>
+    <same_srcip />
+    <description>Watchguard: proxy: Multiple denied traffic from same source</description>
+    <group>proxy</group>
+  </rule>
+  
+  <!-- Possible DDoS or botnet attack NOOK -->
+  <rule id="110093" level="14" frequency="10" timeframe="240" ignore="90">
+    <if_matched_sid>110092</if_matched_sid>
+	<description>Watchguard: proxy: Multiple recidiving traffic sent from same sources. Possible DDoS attack</description>
+	<group>ids,pci_dss_11.4,gpg13_4.12,gdpr_IV_35.7.d,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
+  </rule>
+
+  <!-- APT THREAT -->
+  <rule id="110030" level="12">
+    <if_sid>110000</if_sid>
+    <id>0F01-0015</id>
+    <description>Watchguard: $(reason) from $(srcip):$(srcport) to $(dstip):$(dstport) - $(data)</description>
+	<group>ids,pci_dss_11.4,gpg13_4.12,gdpr_IV_35.7.d,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
+  </rule>
+  
+  <!-- ## UNHANDLED LOGS -->
+  <rule id="110100" level="3">
+    <if_sid>110000</if_sid>
+	<description>Watchguard: Unhandled $(id) log recorded</description>
+  </rule>
+  
+
+</group>
+
+<group name="syslog,watchguard,watchguard-auth">
+  <rule id="110200" level="0">
+    <decoded_as>watchguard-firebox-auth</decoded_as>
+    <description>Grouping of Watchguard Firebox firewall rules</description>
+  </rule>
+  
+  <rule id="110201" level="9">
+    <if_sid>110200</if_sid>
+    <id>1100-0005</id>
+    <status>rejected</status>
+    <description>Watchguard: $(account) user $(dstuser) login $(status) from $(srcip) - $(reason)</description>
+	<mitre>
+	  <id>T1133</id>
+	</mitre>
+    <group>wg_userloginfailed,authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.8,gdpr_IV_35.7.d,gdpr_IV_32.2,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
+  </rule>
+  
+    <rule id="110202" level="4">
+    <if_sid>110200</if_sid>
+    <id>5000-0001</id>
+    <status>rejected</status>
+    <description>Watchguard: $(account) user [$(dstuser)] login $(status) from $(srcip) - $(reason)</description>
+	<mitre>
+	  <id>T1133</id>
+	</mitre>
+    <group>wg_webloginfailed,authentication_failed,</group>
+  </rule>
+  
+  <rule id="110203" level="10" frequency="5" timeframe="60" ignore="240">
+    <if_matched_sid>110201</if_matched_sid>
+    <same_source_ip/>
+    <description>Watchguard: Multiple $(status) login for $(account) user $(dstuser) from $(srcip) - $(reason)</description>
+	<mitre>
+	  <id>T1110</id>
+	  <id>T1133</id>
+	</mitre>
+    <group>wg_loginforce,authentication_failures,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.8,gdpr_IV_35.7.d,gdpr_IV_32.2,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3</group>
+  </rule>
+  
+  <rule id="110204" level="10" frequency="5" timeframe="60" ignore="240">
+    <if_matched_sid>110202</if_matched_sid>
+    <same_source_ip/>
+    <description>Watchguard: Multiple $(status) login for $(account) user [$(dstuser)] from $(srcip) - $(reason)</description>
+    <mitre>
+	  <id>T1110</id>
+	  <id>T1133</id>
+	</mitre>
+    <group>wg_webloginforce,authentication_failures,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.8,gdpr_IV_35.7.d,gdpr_IV_32.2,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3</group>
+  </rule>
+
+  <rule id="110205" level="3">
+    <if_sid>110200</if_sid>
+    <id>3E00-0002</id>
+    <status>logged in</status>
+    <field name="account" negate="yes">SSL VPN</field>
+    <description>Watchguard: $(account) user [$(dstuser)] is $(status) from $(srcip)</description>
+    <mitre>
+	  <id>T1078</id>
+	  <id>T1133</id>
+	</mitre>
+    <group>wg_loginsuccess,authentication_success,pci_dss_10.2.5,gpg13_7.8,gdpr_IV_32.2,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
+  </rule>
+
+  <rule id="110206" level="3">
+    <if_sid>110200</if_sid>
+    <id>2500-0000</id>
+    <status>logged in</status>
+    <field name="virtip" negate="yes">0.0.0.0</field>
+    <description>Watchguard: Mobile VPN user [$(dstuser)] is $(status) from $(srcip) - Virtual IP is $(virtip)</description>
+	<mitre>
+	  <id>T1078</id>
+	  <id>T1133</id>
+	</mitre>
+    <group>wg_vpnloginsuccess,authentication_success,pci_dss_10.2.5,gpg13_7.8,gdpr_IV_32.2,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
+  </rule>
+
+  <rule id="110207" level="9">
+    <if_sid>110200</if_sid>
+    <id>SSL VPN</id> <!-- NOOK TO TET -->
+    <status>rejected</status>
+    <description>Watchguard: SSL VPN user [$(dstuser)] connection $(status) from $(srcip) - $(reason)</description>
+	<mitre>
+	  <id>T1133</id>
+	</mitre>
+    <group>wg_vpnloginfailed,authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.8,gdpr_IV_35.7.d,gdpr_IV_32.2,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
+  </rule>
+</group>
+
+<var name="SIGD_BAD_WORDS">[Ff]ailed|crash|shutdown</var>
+
+<group name="syslog,watchguard,watchguard-sigd">
+  <rule id="110300" level="0">
+    <decoded_as>watchguard-firebox-sigd</decoded_as>
+    <description>Grouping of Watchguard Firebox security event rules</description>
+  </rule>
+  
+  <!-- msg_id does not allow to determine the security event log level, hence we cannot decide of a reasonable alert level easily, we need to match keywords -->
+  <rule id="110301" level="9">
+    <if_sid>110300</if_sid>
+	<match type="pcre2">$SIGD_BAD_WORDS</match>
+	<description>Watchguard: Security event ERROR: $(reason)</description>
+	<group>system_error,pci_dss_10.6.1,pci_dss_11.4,gpg13_4.3,gdpr_IV_35.7.d,tsc_CC7.2,tsc_CC7.3,tsc_CC6.1,tsc_CC6.8,</group>
+	<mitre>
+	  <id>T1489</id>
+	</mitre>
+  </rule>
+
+  <rule id="110302" level="3">
+    <if_sid>110300</if_sid>
+	<description>Watchguard: Security event: $(reason)</description>
+  </rule>
+</group>
+  

--- a/rules/0710-watchguard-firebox-rules.xml
+++ b/rules/0710-watchguard-firebox-rules.xml
@@ -333,10 +333,10 @@ Default linux ping packet size + IPv6 Header + ICMP Header
     <if_sid>110060</if_sid>
     <protocol>icmp</protocol>
     <field name="packetlen" type="pcre2">([0-9]{4,}|[1-9]0[5-9]|1[1-9][0-9]|[2-9][0-9]{2})</field>
-    <description>Watchguard: firewall: $(action) from $(srcip) to $(dstip) using protocol $(protocol) packet size is bigger than usual: $(packetlen)</description>
+    <description>Watchguard: firewall: $(action) from $(srcip) to $(dstip) using protocol $(protocol) [icmp] packet size is bigger than usual: $(packetlen)</description>
   </rule>
   
-  <rule id="110081" level="14" frequency="10" timeframe="240" ignore="90">
+  <rule id="110081" level="13" frequency="10" timeframe="240" ignore="90">
     <if_matched_sid>110080</if_matched_sid>
     <same_srcip />
     <description>Watchguard: firewall: Possible $(protocol) tunnel attack from $(srcip) on interface $(src) to $(dstip) on interface $(dst)</description>
@@ -359,10 +359,10 @@ Mar 21 23:47:28 FW-125852 FVE1032175935 firewall: msg_id="3000-0148" Allow Fireb
     <if_sid>110060</if_sid>
     <dstport>53</dstport>
     <field name="packetlen" type="pcre2">([0-9]{4,}|[1-9]3[3-9]|1[4-9][0-9]|[2-9][0-9]{2})</field>
-    <description>Watchguard: firewall: $(action) from $(srcip) to $(dstip) using protocol $(protocol) packet size is bigger than usual: $(packetlen)</description>
+    <description>Watchguard: firewall: $(action) from $(srcip) to $(dstip) using protocol $(protocol):$(dstport) [dns] packet size is bigger than usual: $(packetlen)</description>
   </rule>
   
-  <rule id="110083" level="14" frequency="10" timeframe="240" ignore="90">
+  <rule id="110083" level="13" frequency="10" timeframe="240" ignore="90">
     <if_matched_sid>110082</if_matched_sid>
     <same_srcip />
     <description>Watchguard: firewall: Possible $(protocol) tunnel attack from $(srcip) on interface $(src) to $(dstip) on interface $(dst)</description>
@@ -382,10 +382,10 @@ Apr 15 12:10:53 FW-125852 FVE1032175935 firewall: msg_id="3000-0148" Allow Trust
     <if_sid>110060</if_sid>
     <dstport>123</dstport>
     <field name="packetlen" type="pcre2">([1-9][0-9]{2,}|[2-9][0-9]|1[0-9])[0-9]{1}|([9-9][7-9])</field>
-    <description>Watchguard: firewall: $(action) from $(srcip) to $(dstip) using protocol $(protocol) packet size is bigger than usual: $(packetlen)</description>
+    <description>Watchguard: firewall: $(action) from $(srcip) to $(dstip) using protocol $(protocol):$(dstport) [ntp] packet size is bigger than usual: $(packetlen)</description>
   </rule>
   
-  <rule id="110085" level="14" frequency="10" timeframe="240" ignore="90">
+  <rule id="110085" level="13" frequency="10" timeframe="240" ignore="90">
     <if_matched_sid>110084</if_matched_sid>
     <same_srcip />
     <description>Watchguard: firewall: Possible $(protocol) tunnel attack from $(srcip) on interface $(src) to $(dstip) on interface $(dst)</description>

--- a/rules/0710-watchguard-firebox-rules.xml
+++ b/rules/0710-watchguard-firebox-rules.xml
@@ -18,10 +18,16 @@
                                 - Authentication, VPN and traffic rules
 -->
 
+<!-- Using ID range 91000-91500 -->
+
+<!-- SETTING this to 1 fill filter FIN TCP connections that are very noisy -->
 <var name="NO_VERBOSE">1</var>
 
+<!-- Which words are used in security event logs that should produce a warning -->
+<var name="SIGD_BAD_WORDS">[Ff]ailed|crash|shutdown</var>
+
 <group name="syslog,firewall,watchguard,watchguard-fw">
-  <rule id="110000" level="0">
+  <rule id="91000" level="0">
     <decoded_as>watchguard-firebox-firewall</decoded_as>
     <description>Grouping of Watchguard Firebox authentication rules</description>
   </rule>
@@ -29,15 +35,15 @@
   <!-- ## BASIC RULES ## -->
   
   <!-- startup / shutdown rules -->
-  <rule id="110001" level="3">
-    <if_sid>110000</if_sid>
+  <rule id="91001" level="3">
+    <if_sid>91000</if_sid>
     <id type="pcre2">3000-002[7|8]</id>
     <description>Watchguard: $(reason)</description>
   </rule>
  
   <!-- licence / features missing or malfunction-->
-  <rule id="110002" level="12">
-    <if_sid>110000</if_sid>
+  <rule id="91002" level="12">
+    <if_sid>91000</if_sid>
      <id type="pcre2">(3000-000[4|5])|3000-003A</id>
     <description>Watchguard: $(reason)</description>
   </rule>
@@ -45,177 +51,177 @@
   <!-- ## ATTACK DETECTION RULES ## -->
   
   <!-- Port scan & Syn flood -->
-  <rule id="110011" level="9">
-    <if_sid>110000</if_sid>
+  <rule id="91011" level="9">
+    <if_sid>91000</if_sid>
     <id type="pcre2">3000-0(159|162)</id>
     <description>Watchguard: $(reason) detected from $(srcip) to $(dstip)</description>
     <group>port_scan</group>
   </rule>
   
   <!-- DDoS to -->
-  <rule id="110012" level="9">
-    <if_sid>110000</if_sid>
+  <rule id="91012" level="9">
+    <if_sid>91000</if_sid>
     <id>3000-0160</id>
     <description>Watchguard: $(reason) detected against $(dstip)</description>
     <group>ddos</group>
   </rule>
   
   <!-- DDoS from -->
-  <rule id="110013" level="9">
-    <if_sid>110000</if_sid>
+  <rule id="91013" level="9">
+    <if_sid>91000</if_sid>
     <id>3000-0161</id>
     <description>Watchguard: $(reason) detected from $(dstip)</description>
     <group>ddos</group>
   </rule>
   
   <!-- Unwanted traffic rules -->
-  <rule id="110014" level="9">
-    <if_sid>110000</if_sid>
+  <rule id="91014" level="9">
+    <if_sid>91000</if_sid>
     <id>3000-0168</id>
     <description>Watchguard: Blocked site: Traffic detected from $(srcip) to $(dstip)</description>
     <group>unwanted_traffic,access_denied,pci_dss_10.2.4,pci_dss_11.4,gpg13_4.12,gdpr_IV_35.7.d,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
   </rule>
   
-  <rule id="110015" level="10" frequency="10" timeframe="240" ignore="90">
-    <if_matched_sid>110014</if_matched_sid>
+  <rule id="91015" level="10" frequency="10" timeframe="240" ignore="90">
+    <if_matched_sid>91014</if_matched_sid>
     <same_srcip />
     <description>Watchguard: Blocked site: Recidiving traffic received from $(srcip)</description>
     <group>unwanted_traffic,access_denied,pci_dss_10.2.4,pci_dss_11.4,gpg13_4.12,gdpr_IV_35.7.d,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
   </rule>
   
-  <rule id="110016" level="9">
-    <if_sid>110000</if_sid>
+  <rule id="91016" level="9">
+    <if_sid>91000</if_sid>
     <id>3000-0169</id>
     <description>Watchguard: IP spoofing: Traffic detected from $(srcip) to $(dstip)</description>
     <group>unwanted_traffic,access_denied,pci_dss_10.2.4,pci_dss_11.4,gpg13_4.12,gdpr_IV_35.7.d,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
   </rule>
   
-  <rule id="110017" level="10" frequency="10" timeframe="240" ignore="90">
-    <if_matched_sid>110016</if_matched_sid>
+  <rule id="91017" level="10" frequency="10" timeframe="240" ignore="90">
+    <if_matched_sid>91016</if_matched_sid>
     <same_srcip />
     <description>Watchguard: IP spoofing: Recidiving traffic received from $(srcip)</description>
     <group>unwanted_traffic,access_denied,pci_dss_10.2.4,pci_dss_11.4,gpg13_4.12,gdpr_IV_35.7.d,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
   </rule>
   
-  <rule id="110018" level="9">
-    <if_sid>110000</if_sid>
+  <rule id="91018" level="9">
+    <if_sid>91000</if_sid>
     <id>3000-0172</id>
     <description>Watchguard: Blocked port: Traffic detected from $(srcip) to $(dstip) on port $(dstport)</description>
     <group>unwanted_traffic,access_denied,pci_dss_10.2.4,pci_dss_11.4,gpg13_4.12,gdpr_IV_35.7.d,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
   </rule>
   
-  <rule id="110019" level="10" frequency="10" timeframe="240" ignore="90">
-    <if_matched_sid>110018</if_matched_sid>
+  <rule id="91019" level="10" frequency="10" timeframe="240" ignore="90">
+    <if_matched_sid>91018</if_matched_sid>
     <same_srcip />
     <description>Watchguard: Blocked port: Recidiving traffic received from $(srcip)</description>
     <group>unwanted_traffic,access_denied,pci_dss_10.2.4,pci_dss_11.4,gpg13_4.12,gdpr_IV_35.7.d,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
   </rule>
   
   <!-- correlation rule for unwanted traffic -->
-  <rule id="110020" level="14" frequency="10" timeframe="240" ignore="90">
+  <rule id="91020" level="14" frequency="10" timeframe="240" ignore="90">
     <if_matched_group>unwanted_traffic</if_matched_group>
     <description>Watchguard: Multiple unwanted traffic received. Possible attack ongoing</description>
     <group>unwanted_traffic,access_denied,pci_dss_10.2.4,pci_dss_11.4,gpg13_4.12,gdpr_IV_35.7.d,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
   </rule>
   
-  <rule id="110021" level="10">
-    <if_sid>110000</if_sid>
+  <rule id="91021" level="10">
+    <if_sid>91000</if_sid>
     <id>3000-012C</id>
     <description>Watchguard: ARP spoofing attack detected, ip=$(srcip), mac=$(srcmac), interface=$(src)</description>
     <group>spoofing,pci_dss_10.6.1,gpg13_4.12,gdpr_IV_35.7.d,tsc_CC7.2,tsc_CC7.3,</group>
   </rule>
   
-  <rule id="110022" level="14">
-    <if_matched_sid>110021</if_matched_sid>
+  <rule id="91022" level="14">
+    <if_matched_sid>91021</if_matched_sid>
     <description>Watchguard: Multiple ARP spoofing attacks detected. Possible attack ongoing</description>
     <group>spoofing,pci_dss_10.6.1,gpg13_4.12,gdpr_IV_35.7.d,tsc_CC7.2,tsc_CC7.3,</group>
   </rule>
   
-  <rule id="110023" level="9">
-    <if_sid>110000</if_sid>
+  <rule id="91023" level="9">
+    <if_sid>91000</if_sid>
     <id>3000-012E</id>
     <description>Watchguard: Cannot relearn system MAC address, possible loop or MAC spoofing, ip=$(srcip), mac=$(srcmac), interface=$(src)</description>
     <group>spoofing,pci_dss_10.6.1,gpg13_4.12,gdpr_IV_35.7.d,tsc_CC7.2,tsc_CC7.3,</group>
   </rule>
   
-  <rule id="110024" level="14">
-    <if_matched_sid>110023</if_matched_sid>
+  <rule id="91024" level="14">
+    <if_matched_sid>91023</if_matched_sid>
     <description>Watchguard: Multiple possible loops or MAC spoofing. Possible attack ongoing</description>
     <group>spoofing,pci_dss_10.6.1,gpg13_4.12,gdpr_IV_35.7.d,tsc_CC7.2,tsc_CC7.3,</group>
   </rule>
   
   <!-- ## DIAGNOSTIC RULES ## -->
-  <rule id="110040" level="6">
-    <if_sid>110000</if_sid>
+  <rule id="91040" level="6">
+    <if_sid>91000</if_sid>
     <id type="pcre2">3000-00C[9|B]</id>
     <description>Watchguard: Load Balance Server $(dstip) is offline, protocol $(protocol)</description>
     <group>service_availability,pci_dss_10.6.1,gpg13_4.12,gdpr_IV_35.7.d,tsc_CC7.2,tsc_CC7.3,</group>
   </rule>
 
-  <rule id="110041" level="7">
-    <if_sid>110000</if_sid>
+  <rule id="91041" level="7">
+    <if_sid>91000</if_sid>
     <id type="pcre2">4900-0001</id>
     <description>Watchguard: Link Monitor: $(src) unable to resolve domain name $(dst)</description>
     <group>service_availability,pci_dss_10.6.1,gpg13_4.12,gdpr_IV_35.7.d,tsc_CC7.2,tsc_CC7.3,</group>
   </rule>
   
-  <rule id="110042" level="7">
-    <if_sid>110000</if_sid>
+  <rule id="91042" level="7">
+    <if_sid>91000</if_sid>
     <id type="pcre2">4900-0002</id>
     <description>Watchguard: Link Monitor: No response received on $(src) from $(protocol) host $(dstip) $(dstport)</description>
     <group>service_availability,pci_dss_10.6.1,gpg13_4.12,gdpr_IV_35.7.d,tsc_CC7.2,tsc_CC7.3,</group>
   </rule>
   
-  <rule id="110043" level="7">
-    <if_sid>110000</if_sid>
+  <rule id="91043" level="7">
+    <if_sid>91000</if_sid>
     <id type="pcre2">4900-0003</id>
     <description>Watchguard: Link Monitor: $(src) interface $(reason)</description>
     <group>service_availability,pci_dss_10.6.1,gpg13_4.12,gdpr_IV_35.7.d,tsc_CC7.2,tsc_CC7.3,</group>
   </rule>
   
   <!-- ## BLOCKED SITE NORMAL OPERATIONS ## -->
-  <rule id="110050" level="3">
-    <if_sid>110000</if_sid>
+  <rule id="91050" level="3">
+    <if_sid>91000</if_sid>
     <id>3000-0029</id>
     <description>Watchguard: $(srcip) will not be added to the blocked sites list because it is exempt</description>
   </rule>
   
-  <rule id="110051" level="3">
-    <if_sid>110000</if_sid>
+  <rule id="91051" level="3">
+    <if_sid>91000</if_sid>
     <id>3000-0040</id>
     <description>Watchguard: Idle timeout has occurred for blocked site $(srcip)</description>
   </rule>
  
-  <rule id="110052" level="12">
-    <if_sid>110000</if_sid>
+  <rule id="91052" level="12">
+    <if_sid>91000</if_sid>
     <id>3000-1002</id>
     <description>Watchguard: The Temporary Blocked Sites list is full (capacity=1000). The oldest entry $(srcip) was removed</description>
     <group>unwanted_traffic,access_denied,pci_dss_10.2.4,pci_dss_11.4,gpg13_4.12,gdpr_IV_35.7.d,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
   </rule>
   
-  <rule id="110053" level="14" frequency="10" timeframe="240" ignore="90">
-    <if_matched_sid>110052</if_matched_sid>
+  <rule id="91053" level="14" frequency="10" timeframe="240" ignore="90">
+    <if_matched_sid>91052</if_matched_sid>
     <description>Watchguard: The Temporary Blocked Sites list cannot hold all the blocked sites. Probable DDoS attack ongoing</description>
     <group>unwanted_traffic,access_denied,pci_dss_10.2.4,pci_dss_11.4,gpg13_4.12,gdpr_IV_35.7.d,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
     <group>ddos</group>
   </rule>
  
-  <rule id="110054" level="12">
-    <if_sid>110000</if_sid>
+  <rule id="91054" level="12">
+    <if_sid>91000</if_sid>
     <id>3001-1001</id>
     <description>Watchguard: Temporarily blocking host $(srcip) - $(reason)</description>
     <group>unwanted_traffic,access_denied,pci_dss_10.2.4,pci_dss_11.4,gpg13_4.12,gdpr_IV_35.7.d,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
   </rule>
   
-  <rule id="110055" level="14" frequency="10" timeframe="240" ignore="90">
-    <if_matched_sid>110054</if_matched_sid>
+  <rule id="91055" level="14" frequency="10" timeframe="240" ignore="90">
+    <if_matched_sid>91054</if_matched_sid>
     <description>Watchguard: Multiple blocked hosts in short timespan. Probable DDoS attack ongoing</description>
     <group>unwanted_traffic,access_denied,pci_dss_10.2.4,pci_dss_11.4,gpg13_4.12,gdpr_IV_35.7.d,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
     <group>ddos</group>
   </rule>
   
-  <rule id="110056" level="3">
-    <if_sid>110000</if_sid>
+  <rule id="91056" level="3">
+    <if_sid>91000</if_sid>
     <id>3001-1002</id>
     <description>Watchguard: Removing temporarily blocked host $(srcip) from list</description>
   </rule>
@@ -224,8 +230,8 @@
   
   <!-- Normal allowed traffic -->
   <!-- For the sake of disk space, we will match Allow packets with level 0 NOOK nolaert -->
-  <rule id="110060" level="0">
-    <if_sid>110000</if_sid>
+  <rule id="91060" level="0">
+    <if_sid>91000</if_sid>
     <id>3000-0148</id>
     <action type="pcre2">[Aa]llow</action>
     <description>Watchguard: firewall: $(action) $(src) $(dst) packetlen=$(packetlen) $(protocol) iphlen=$(iphlen) ttl=$(ttl) from $(srcip):$(srcport) to $(dstip):$(dstport) - $(reason)</description>
@@ -233,8 +239,8 @@
   </rule>
 
   <!-- layer 2 denied traffic / don't bother to keep, so set level=0 -->
-  <rule id="110061" level="0">
-    <if_sid>110000</if_sid>
+  <rule id="91061" level="0">
+    <if_sid>91000</if_sid>
     <id>3000-0148</id>
     <action type="pcre2">[Dd]eny</action>
     <match type="pcre2">0.0.0.0\s0.0.0.0\s0\s0</match>
@@ -243,8 +249,8 @@
   </rule>
  
   <!-- Normal denied traffic -->
-  <rule id="110062" level="3">
-    <if_sid>110000</if_sid>
+  <rule id="91062" level="3">
+    <if_sid>91000</if_sid>
     <id>3000-0148</id>
     <action type="pcre2">[Dd]eny</action>
     <description>Watchguard: firewall: $(action) $(src) $(dst) packetlen=$(packetlen) $(protocol) iphlen=$(iphlen) ttl=$(ttl) from $(srcip):$(srcport) to $(dstip):$(dstport) - $(reason)</description>
@@ -252,8 +258,8 @@
   </rule>
   
     <!-- allowed App Control -->
-  <rule id="110063" level="0">
-    <if_sid>110000</if_sid>
+  <rule id="91063" level="0">
+    <if_sid>91000</if_sid>
     <id>3000-0149</id>
     <action type="pcre2">[Aa]llow</action>
     <description>Watchguard: App control: $(action) $(src) $(dst) packetlen=$(packetlen) $(protocol) iphlen=$(iphlen) ttl=$(ttl) from $(srcip):$(srcport) to $(dstip):$(dstport) - $(reason)</description>
@@ -261,8 +267,8 @@
   </rule>
   
     <!--denied  App Control -->
-  <rule id="110064" level="3">
-    <if_sid>110000</if_sid>
+  <rule id="91064" level="3">
+    <if_sid>91000</if_sid>
     <id>3000-0149</id>
     <action type="pcre2">[Dd]eny</action>
     <description>Watchguard: App control: $(action) $(src) $(dst) packetlen=$(packetlen) $(protocol) iphlen=$(iphlen) ttl=$(ttl) from $(srcip):$(srcport) to $(dstip):$(dstport) - $(reason)</description>
@@ -270,8 +276,8 @@
   </rule>
   
   <!-- allowed IPS Traffic -->
-  <rule id="110065" level="0">
-    <if_sid>110000</if_sid>
+  <rule id="91065" level="0">
+    <if_sid>91000</if_sid>
     <id>3000-0150</id>
     <action type="pcre2">[Aa]llow</action>
     <description>Watchguard: App control: $(action) $(src) $(dst) packetlen=$(packetlen) $(protocol) iphlen=$(iphlen) ttl=$(ttl) from $(srcip):$(srcport) to $(dstip):$(dstport) - $(reason)</description>
@@ -279,8 +285,8 @@
   </rule>
   
   <!-- denied IPS Traffic -->
-  <rule id="110066" level="3">
-    <if_sid>110000</if_sid>
+  <rule id="91066" level="3">
+    <if_sid>91000</if_sid>
     <id>3000-0150</id>
     <action type="pcre2">[Dd]eny</action>
     <description>Watchguard: App control: $(action) $(src) $(dst) packetlen=$(packetlen) $(protocol) iphlen=$(iphlen) ttl=$(ttl) from $(srcip):$(srcport) to $(dstip):$(dstport) - $(reason)</description>
@@ -288,32 +294,32 @@
   </rule>
   
   <!-- Multiple denied generic traffic -->
-  <rule id="110067" level="13" frequency="5" timeframe="300">
+  <rule id="91067" level="13" frequency="5" timeframe="300">
     <if_matched_group>packet_filter_deny</if_matched_group>
     <same_srcip />
     <description>Watchguard: firewall: Multiple denied traffic from same source $(srcip)</description>
     <group>firewall,access_denied,pci_dss_10.2.4,pci_dss_11.4,gpg13_4.12,gdpr_IV_35.7.d,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
   </rule>
   
-  <!-- Traffic connection terminated, very verbose, hence noalert NOOK -->
-  <rule id="110068" level="3" noalert="$NO_VERBOSE">
-    <if_sid>110000</if_sid>
+  <!-- Traffic connection terminated, very verbose, hence noalert -->
+  <rule id="91068" level="3" noalert="$NO_VERBOSE">
+    <if_sid>91000</if_sid>
     <id>3000-0151</id>
     <description>Watchguard: firewall: Traffic connection terminated: $(action) $(src) $(dst)  $(protocol) from $(srcip):$(srcport) to $(dstip):$(dstport) - $(reason)</description>
     <group>firewall</group>
   </rule>
   
   <!-- Hostile traffic -->
-  <rule id="110069" level="9">
-    <if_sid>110000</if_sid>
+  <rule id="91069" level="9">
+    <if_sid>91000</if_sid>
     <id>3000-0178</id>
     <description>Watchguard: firewall: Hostile traffic $(action) $(src) $(dst) packetlen=$(packetlen) $(protocol) iphlen=$(iphlen) ttl=$(ttl) from $(srcip):$(srcport) to $(dstip):$(dstport) - $(reason)</description>
     <group>firewall</group>
   </rule>
   
   <!-- Multiple hostile traffic -->
-  <rule id="110070" level="13" frequency="10" timeframe="240" ignore="90">
-    <if_matched_sid>110069</if_matched_sid>
+  <rule id="91070" level="13" frequency="10" timeframe="240" ignore="90">
+    <if_matched_sid>91069</if_matched_sid>
     <same_srcip />
     <description>Watchguard: firewall: Multiple hostile traffic from same source</description>
     <group>firewall,access_denied,pci_dss_10.2.4,pci_dss_11.4,gpg13_4.12,gdpr_IV_35.7.d,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
@@ -329,15 +335,15 @@ Default linux ping packet size + IPv6 Header + ICMP Header
 2021 Mar 21 22:01:42 FW-125852->192.168.100.254 Mar 21 23:01:42 FW-125852 FVE1032175935 firewall: msg_id="3000-0148" Allow Trusted Firebox 1300 icmp 20 128 192.168.100.99 192.168.100.254 8 0 id=1 seq=2  (Ping-00)
 2021 Mar 21 22:01:42 FW-125852->192.168.100.254 Mar 21 23:01:42 FW-125852 FVE1032175935 firewall: msg_id="3000-0148" Allow Trusted Firebox 60 icmp 20 128 192.168.100.99 192.168.100.254 8 0 id=1 seq=2  (Ping-00)
 -->
-  <rule id="110080" level="4">
-    <if_sid>110060</if_sid>
+  <rule id="91080" level="4">
+    <if_sid>91060</if_sid>
     <protocol>icmp</protocol>
     <field name="packetlen" type="pcre2">([0-9]{4,}|[1-9]0[5-9]|1[1-9][0-9]|[2-9][0-9]{2})</field>
     <description>Watchguard: firewall: $(action) from $(srcip) to $(dstip) using protocol $(protocol) [icmp] packet size is bigger than usual: $(packetlen)</description>
   </rule>
   
-  <rule id="110081" level="13" frequency="10" timeframe="240" ignore="90">
-    <if_matched_sid>110080</if_matched_sid>
+  <rule id="91081" level="13" frequency="10" timeframe="240" ignore="90">
+    <if_matched_sid>91080</if_matched_sid>
     <same_srcip />
     <description>Watchguard: firewall: Possible $(protocol) tunnel attack from $(srcip) on interface $(src) to $(dstip) on interface $(dst)</description>
     <group>hidden_tunnel,pci_dss_10.6.1,pci_dss_11.4,gpg13_4.12,gdpr_IV_35.7.d,tsc_CC7.2,tsc_CC7.3,tsc_CC6.1,tsc_CC6.8,</group>
@@ -355,15 +361,15 @@ Mar 21 23:43:20 FW-125852 FVE1032175935 firewall: msg_id="3000-0148" Allow Fireb
 Mar 21 23:47:28 FW-125852 FVE1032175935 firewall: msg_id="3000-0148" Allow Firebox External 60 udp 20 64 fe80::20c:29ff:fe59:7afa ac::d0:::1 47189 53  (Any From Firebox-00)
 -->
 
-  <rule id="110082" level="4">
-    <if_sid>110060</if_sid>
+  <rule id="91082" level="4">
+    <if_sid>91060</if_sid>
     <dstport>53</dstport>
     <field name="packetlen" type="pcre2">([0-9]{4,}|[1-9]3[3-9]|1[4-9][0-9]|[2-9][0-9]{2})</field>
     <description>Watchguard: firewall: $(action) from $(srcip) to $(dstip) using protocol $(protocol):$(dstport) [dns] packet size is bigger than usual: $(packetlen)</description>
   </rule>
   
-  <rule id="110083" level="13" frequency="10" timeframe="240" ignore="90">
-    <if_matched_sid>110082</if_matched_sid>
+  <rule id="91083" level="13" frequency="10" timeframe="240" ignore="90">
+    <if_matched_sid>91082</if_matched_sid>
     <same_srcip />
     <description>Watchguard: firewall: Possible $(protocol) tunnel attack from $(srcip) on interface $(src) to $(dstip) on interface $(dst)</description>
     <group>hidden_tunnel,pci_dss_10.6.1,pci_dss_11.4,gpg13_4.12,gdpr_IV_35.7.d,tsc_CC7.2,tsc_CC7.3,tsc_CC6.1,tsc_CC6.8,</group>
@@ -378,21 +384,21 @@ Apr 15 12:10:53 FW-125852 FVE1032175935 firewall: msg_id="3000-0148" Allow Trust
 Apr 15 12:10:53 FW-125852 FVE1032175935 firewall: msg_id="3000-0148" Allow Trusted External 76 udp 20 63 fe80::20c:29ff:fe59:7afa ac::d0:::1 48216 123  (Outgoing-00)
 -->
 
-  <rule id="110084" level="4">
-    <if_sid>110060</if_sid>
+  <rule id="91084" level="4">
+    <if_sid>91060</if_sid>
     <dstport>123</dstport>
     <field name="packetlen" type="pcre2">([1-9][0-9]{2,}|[2-9][0-9]|1[0-9])[0-9]{1}|([9-9][7-9])</field>
     <description>Watchguard: firewall: $(action) from $(srcip) to $(dstip) using protocol $(protocol):$(dstport) [ntp] packet size is bigger than usual: $(packetlen)</description>
   </rule>
   
-  <rule id="110085" level="13" frequency="10" timeframe="240" ignore="90">
-    <if_matched_sid>110084</if_matched_sid>
+  <rule id="91085" level="13" frequency="10" timeframe="240" ignore="90">
+    <if_matched_sid>91084</if_matched_sid>
     <same_srcip />
     <description>Watchguard: firewall: Possible $(protocol) tunnel attack from $(srcip) on interface $(src) to $(dstip) on interface $(dst)</description>
     <group>hidden_tunnel,pci_dss_10.6.1,pci_dss_11.4,gpg13_4.12,gdpr_IV_35.7.d,tsc_CC7.2,tsc_CC7.3,tsc_CC6.1,tsc_CC6.8,</group>
   </rule>
 
-  <rule id="110086" level="14" frequency="3" timeframe="240" ignore="90"> <!-- NOOK -->
+  <rule id="91086" level="14" frequency="3" timeframe="240" ignore="90"> <!-- NOOK -->
     <if_matched_group>hidden_tunnel</if_matched_group>
     <description>Watchguard: Possible multiple tunnel attacks ongoing. Please have a look</description>
     <group>pci_dss_10.6.1,pci_dss_11.4,gpg13_4.12,gdpr_IV_35.7.d,tsc_CC7.2,tsc_CC7.3,tsc_CC6.1,tsc_CC6.8,</group>
@@ -402,8 +408,8 @@ Apr 15 12:10:53 FW-125852 FVE1032175935 firewall: msg_id="3000-0148" Allow Trust
   <!-- ## PROXY FILTER RULES ## -->
   
   <!-- allowed proxy traffic is level 0 for disk space reasons -->
-  <rule id="110090" level="0">
-    <if_sid>110000</if_sid>
+  <rule id="91090" level="0">
+    <if_sid>91000</if_sid>
     <id type="pcre2">[1-2][0-9A-F]FF-[0-F]{4}</id>
     <action type="pcre2">[Aa]llow</action>
     <description>Watchguard: proxy: $(action) from $(src) to $(dst), $(protocol) from $(srcip):$(srcport) to $(dstip):$(dstport) - $(reason)</description>
@@ -411,8 +417,8 @@ Apr 15 12:10:53 FW-125852 FVE1032175935 firewall: msg_id="3000-0148" Allow Trust
   </rule>
   
   <!-- denied proxy traffic -->
-  <rule id="110091" level="3">
-    <if_sid>110000</if_sid>
+  <rule id="91091" level="3">
+    <if_sid>91000</if_sid>
     <id type="pcre2">[1-2][0-9A-F]FF-[0-F]{4}</id>
     <action type="pcre2">[Dd]eny</action>
     <description>Watchguard: proxy: $(action) from $(src) to $(dst), $(protocol) from $(srcip):$(srcport) to $(dstip):$(dstport) - $(reason)</description>
@@ -420,31 +426,31 @@ Apr 15 12:10:53 FW-125852 FVE1032175935 firewall: msg_id="3000-0148" Allow Trust
   </rule>
   
   <!-- Multiple denied proxy traffic -->
-  <rule id="110092" level="13" frequency="10" timeframe="240" ignore="90">
-    <if_matched_sid>110091</if_matched_sid>
+  <rule id="91092" level="13" frequency="10" timeframe="240" ignore="90">
+    <if_matched_sid>91091</if_matched_sid>
     <same_srcip />
     <description>Watchguard: proxy: Multiple denied traffic from same source $(srcip) on interface $(src)</description>
     <group>proxy,access_denied,pci_dss_10.2.4,pci_dss_11.4,gpg13_4.12,gdpr_IV_35.7.d,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
   </rule>
   
   <!-- Possible DDoS or botnet attack NOOK -->
-  <rule id="110093" level="14" frequency="3" timeframe="240" ignore="90">
-    <if_matched_sid>110092</if_matched_sid>
+  <rule id="91093" level="14" frequency="3" timeframe="240" ignore="90">
+    <if_matched_sid>91092</if_matched_sid>
     <description>Watchguard: proxy: Multiple recidiving traffic sent from same sources. Possible DDoS attack</description>
     <group>proxy,ids,pci_dss_11.4,gpg13_4.12,gdpr_IV_35.7.d,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
   </rule>
 
   <!-- APT THREAT -->
-  <rule id="110030" level="12">
-    <if_sid>110000</if_sid>
+  <rule id="91030" level="12">
+    <if_sid>91000</if_sid>
     <id>0F01-0015</id>
     <description>Watchguard: $(reason) from $(srcip):$(srcport) to $(dstip):$(dstport) - $(data)</description>
     <group>ids,pci_dss_11.4,gpg13_4.12,gdpr_IV_35.7.d,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
   </rule>
   
   <!-- ## UNHANDLED LOGS -->
-  <rule id="110100" level="3">
-    <if_sid>110000</if_sid>
+  <rule id="91100" level="3">
+    <if_sid>91000</if_sid>
     <description>Watchguard: Unhandled $(id) log recorded</description>
     <group>firewall</group>
   </rule>
@@ -453,13 +459,13 @@ Apr 15 12:10:53 FW-125852 FVE1032175935 firewall: msg_id="3000-0148" Allow Trust
 </group>
 
 <group name="syslog,watchguard,watchguard-auth">
-  <rule id="110200" level="0">
+  <rule id="91200" level="0">
     <decoded_as>watchguard-firebox-auth</decoded_as>
     <description>Grouping of Watchguard Firebox firewall rules</description>
   </rule>
   
-  <rule id="110201" level="9">
-    <if_sid>110200</if_sid>
+  <rule id="91201" level="9">
+    <if_sid>91200</if_sid>
     <id type="pcre2">1100-0005|5000-0001</id>
     <action>rejected</action>
     <description>Watchguard: $(account_type) $(srcuser) login $(action) from $(srcip) - $(reason)</description>
@@ -469,8 +475,8 @@ Apr 15 12:10:53 FW-125852 FVE1032175935 firewall: msg_id="3000-0148" Allow Trust
     <group>wg_userloginfailed,authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.8,gdpr_IV_35.7.d,gdpr_IV_32.2,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
   </rule>
   
-  <rule id="110202" level="10" frequency="5" timeframe="60" ignore="240">
-    <if_matched_sid>110201</if_matched_sid>
+  <rule id="91202" level="10" frequency="5" timeframe="60" ignore="240">
+    <if_matched_sid>91201</if_matched_sid>
     <same_source_ip/>
     <description>Watchguard: Multiple $(action) login for $(account_type) $(srcuser) from $(srcip) - $(reason)</description>
     <mitre>
@@ -480,8 +486,8 @@ Apr 15 12:10:53 FW-125852 FVE1032175935 firewall: msg_id="3000-0148" Allow Trust
     <group>wg_loginforce,authentication_failures,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.8,gdpr_IV_35.7.d,gdpr_IV_32.2,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3</group>
   </rule>
 
-  <rule id="110205" level="3">
-    <if_sid>110200</if_sid>
+  <rule id="91205" level="3">
+    <if_sid>91200</if_sid>
     <id>3E00-0002</id>
     <action>logged in</action>
     <field name="account_type" negate="yes">SSL VPN</field>
@@ -493,8 +499,8 @@ Apr 15 12:10:53 FW-125852 FVE1032175935 firewall: msg_id="3000-0148" Allow Trust
     <group>wg_loginsuccess,authentication_success,pci_dss_10.2.5,gpg13_7.8,gdpr_IV_32.2,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
   </rule>
 
-  <rule id="110206" level="3">
-    <if_sid>110200</if_sid>
+  <rule id="91206" level="3">
+    <if_sid>91200</if_sid>
     <id>2500-0000</id>
     <action>logged in</action>
     <description>Watchguard: Mobile VPN user $(srcuser) login $(action) from $(srcip) - Virtual IP is $(dstip)</description>
@@ -505,8 +511,8 @@ Apr 15 12:10:53 FW-125852 FVE1032175935 firewall: msg_id="3000-0148" Allow Trust
     <group>wg_vpnloginsuccess,authentication_success,pci_dss_10.2.5,gpg13_7.8,gdpr_IV_32.2,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
   </rule>
 
-  <rule id="110207" level="9">
-    <if_sid>110200</if_sid>
+  <rule id="91207" level="9">
+    <if_sid>91200</if_sid>
     <id>SSL VPN</id>
     <action>rejected</action>
     <description>Watchguard: SSL VPN user $(srcuser) connection $(action) from $(srcip) - $(reason)</description>
@@ -517,17 +523,15 @@ Apr 15 12:10:53 FW-125852 FVE1032175935 firewall: msg_id="3000-0148" Allow Trust
   </rule>
 </group>
 
-<var name="SIGD_BAD_WORDS">[Ff]ailed|crash|shutdown</var>
-
 <group name="syslog,watchguard,watchguard-sigd">
-  <rule id="110300" level="0">
+  <rule id="91300" level="0">
     <decoded_as>watchguard-firebox-sigd</decoded_as>
     <description>Grouping of Watchguard Firebox security event rules</description>
   </rule>
   
   <!-- msg_id does not allow to determine the security event log level, hence we cannot decide of a reasonable alert level easily, we need to match keywords -->
-  <rule id="110301" level="9">
-    <if_sid>110300</if_sid>
+  <rule id="91301" level="9">
+    <if_sid>91300</if_sid>
     <match type="pcre2">$SIGD_BAD_WORDS</match>
     <description>Watchguard: Security event ERROR: $(reason)</description>
     <group>system_error,pci_dss_10.6.1,pci_dss_11.4,gpg13_4.3,gdpr_IV_35.7.d,tsc_CC7.2,tsc_CC7.3,tsc_CC6.1,tsc_CC6.8,</group>
@@ -536,8 +540,8 @@ Apr 15 12:10:53 FW-125852 FVE1032175935 firewall: msg_id="3000-0148" Allow Trust
     </mitre>
   </rule>
 
-  <rule id="110302" level="3">
-    <if_sid>110300</if_sid>
+  <rule id="91302" level="3">
+    <if_sid>91300</if_sid>
     <description>Watchguard: Security event: $(reason)</description>
   </rule>
 </group>

--- a/rules/0710-watchguard-firebox-rules.xml
+++ b/rules/0710-watchguard-firebox-rules.xml
@@ -6,6 +6,8 @@
 
    Changelog
    2021/07/08 - Orsiris de Jong - Added security event rules
+                                - Added TSC compliance mapping
+                                - Various sanitizations
    2021/07/05 - Orsiris de Jong - Added various correlation rules
                                 - Added possible traffic and proxy rules
    2021/06/10 - Orsiris de Jong - Added various attack rules (port scan, ddos, ids, flooding, spoofing)
@@ -15,6 +17,8 @@
    2021/04/21 - ph3nix          - Initial release
                                 - Authentication, VPN and traffic rules
 -->
+
+<var name="NO_VERBOSE">1</var>
 
 <group name="syslog,firewall,watchguard,watchguard-fw">
   <rule id="110000" level="0">
@@ -145,28 +149,28 @@
     <if_sid>110000</if_sid>
     <id type="pcre2">3000-00C[9|B]</id>
     <description>Watchguard: Load Balance Server $(dstip) is offline, protocol $(protocol)</description>
-	<group>service_availability,pci_dss_10.6.1,gpg13_4.12,gdpr_IV_35.7.d,tsc_CC7.2,tsc_CC7.3,</group>
+    <group>service_availability,pci_dss_10.6.1,gpg13_4.12,gdpr_IV_35.7.d,tsc_CC7.2,tsc_CC7.3,</group>
   </rule>
 
   <rule id="110041" level="7">
     <if_sid>110000</if_sid>
     <id type="pcre2">4900-0001</id>
     <description>Watchguard: Link Monitor: $(src) unable to resolve domain name $(dst)</description>
-	<group>service_availability,pci_dss_10.6.1,gpg13_4.12,gdpr_IV_35.7.d,tsc_CC7.2,tsc_CC7.3,</group>
+    <group>service_availability,pci_dss_10.6.1,gpg13_4.12,gdpr_IV_35.7.d,tsc_CC7.2,tsc_CC7.3,</group>
   </rule>
   
   <rule id="110042" level="7">
     <if_sid>110000</if_sid>
     <id type="pcre2">4900-0002</id>
     <description>Watchguard: Link Monitor: No response received on $(src) from $(protocol) host $(dstip) $(dstport)</description>
-	<group>service_availability,pci_dss_10.6.1,gpg13_4.12,gdpr_IV_35.7.d,tsc_CC7.2,tsc_CC7.3,</group>
+    <group>service_availability,pci_dss_10.6.1,gpg13_4.12,gdpr_IV_35.7.d,tsc_CC7.2,tsc_CC7.3,</group>
   </rule>
   
   <rule id="110043" level="7">
     <if_sid>110000</if_sid>
     <id type="pcre2">4900-0003</id>
     <description>Watchguard: Link Monitor: $(src) interface $(reason)</description>
-	<group>service_availability,pci_dss_10.6.1,gpg13_4.12,gdpr_IV_35.7.d,tsc_CC7.2,tsc_CC7.3,</group>
+    <group>service_availability,pci_dss_10.6.1,gpg13_4.12,gdpr_IV_35.7.d,tsc_CC7.2,tsc_CC7.3,</group>
   </rule>
   
   <!-- ## BLOCKED SITE NORMAL OPERATIONS ## -->
@@ -186,13 +190,13 @@
     <if_sid>110000</if_sid>
     <id>3000-1002</id>
     <description>Watchguard: The Temporary Blocked Sites list is full (capacity=1000). The oldest entry $(srcip) was removed</description>
-	<group>unwanted_traffic,access_denied,pci_dss_10.2.4,pci_dss_11.4,gpg13_4.12,gdpr_IV_35.7.d,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
+    <group>unwanted_traffic,access_denied,pci_dss_10.2.4,pci_dss_11.4,gpg13_4.12,gdpr_IV_35.7.d,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
   </rule>
   
   <rule id="110053" level="14" frequency="10" timeframe="240" ignore="90">
     <if_matched_sid>110052</if_matched_sid>
     <description>Watchguard: The Temporary Blocked Sites list cannot hold all the blocked sites. Probable DDoS attack ongoing</description>
-	<group>unwanted_traffic,access_denied,pci_dss_10.2.4,pci_dss_11.4,gpg13_4.12,gdpr_IV_35.7.d,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
+    <group>unwanted_traffic,access_denied,pci_dss_10.2.4,pci_dss_11.4,gpg13_4.12,gdpr_IV_35.7.d,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
     <group>ddos</group>
   </rule>
  
@@ -200,13 +204,13 @@
     <if_sid>110000</if_sid>
     <id>3001-1001</id>
     <description>Watchguard: Temporarily blocking host $(srcip) - $(reason)</description>
-	<group>unwanted_traffic,access_denied,pci_dss_10.2.4,pci_dss_11.4,gpg13_4.12,gdpr_IV_35.7.d,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
+    <group>unwanted_traffic,access_denied,pci_dss_10.2.4,pci_dss_11.4,gpg13_4.12,gdpr_IV_35.7.d,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
   </rule>
   
   <rule id="110055" level="14" frequency="10" timeframe="240" ignore="90">
     <if_matched_sid>110054</if_matched_sid>
     <description>Watchguard: Multiple blocked hosts in short timespan. Probable DDoS attack ongoing</description>
-	<group>unwanted_traffic,access_denied,pci_dss_10.2.4,pci_dss_11.4,gpg13_4.12,gdpr_IV_35.7.d,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
+    <group>unwanted_traffic,access_denied,pci_dss_10.2.4,pci_dss_11.4,gpg13_4.12,gdpr_IV_35.7.d,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
     <group>ddos</group>
   </rule>
   
@@ -218,9 +222,8 @@
   
   <!-- ## PACKET FILTER RULES ## -->
   
-  <!-- For the sake of disk space, we will match Allow packets with level 0 -->
-  
   <!-- Normal allowed traffic -->
+  <!-- For the sake of disk space, we will match Allow packets with level 0 NOOK nolaert -->
   <rule id="110060" level="0">
     <if_sid>110000</if_sid>
     <id>3000-0148</id>
@@ -228,7 +231,7 @@
     <description>Watchguard: firewall: $(action) $(src) $(dst) packetlen=$(packetlen) $(protocol) iphlen=$(iphlen) ttl=$(ttl) from $(srcip):$(srcport) to $(dstip):$(dstport) - $(reason)</description>
     <group>packet_filter</group>
   </rule>
-  
+
   <!-- layer 2 denied traffic / don't bother to keep, so set level=0 -->
   <rule id="110061" level="0">
     <if_sid>110000</if_sid>
@@ -289,11 +292,11 @@
     <if_matched_group>packet_filter_deny</if_matched_group>
     <same_srcip />
     <description>Watchguard: firewall: Multiple denied traffic from same source $(srcip)</description>
-    <group>firewall</group>
+    <group>firewall,access_denied,pci_dss_10.2.4,pci_dss_11.4,gpg13_4.12,gdpr_IV_35.7.d,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
   </rule>
   
-  <!-- Traffic connection terminated, very verbose, hence level=0 -->
-  <rule id="110068" level="0">
+  <!-- Traffic connection terminated, very verbose, hence noalert NOOK -->
+  <rule id="110068" level="3" noalert="$NO_VERBOSE">
     <if_sid>110000</if_sid>
     <id>3000-0151</id>
     <description>Watchguard: firewall: Traffic connection terminated: $(action) $(src) $(dst)  $(protocol) from $(srcip):$(srcport) to $(dstip):$(dstport) - $(reason)</description>
@@ -313,37 +316,38 @@
     <if_matched_sid>110069</if_matched_sid>
     <same_srcip />
     <description>Watchguard: firewall: Multiple hostile traffic from same source</description>
-    <group>firewall</group>
+    <group>firewall,access_denied,pci_dss_10.2.4,pci_dss_11.4,gpg13_4.12,gdpr_IV_35.7.d,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
   </rule>
   
   <!-- ICMP hidden tunnel detection when too much packets are larger than standard ICMP packet size
 
-  Generic ping max packet size
-  PING = 56 + 40 + 8 = 104
-   Default LINUX size + IPv6 Header + ICMP Header
+Generic ping max packet size calculation
+PING = 56 + 40 + 8 = 104
+Windows ping packet size is smaller than on linux, hence we'll use the latter
+Default linux ping packet size + IPv6 Header + ICMP Header
 
 2021 Mar 21 22:01:42 FW-125852->192.168.100.254 Mar 21 23:01:42 FW-125852 FVE1032175935 firewall: msg_id="3000-0148" Allow Trusted Firebox 1300 icmp 20 128 192.168.100.99 192.168.100.254 8 0 id=1 seq=2  (Ping-00)
 2021 Mar 21 22:01:42 FW-125852->192.168.100.254 Mar 21 23:01:42 FW-125852 FVE1032175935 firewall: msg_id="3000-0148" Allow Trusted Firebox 60 icmp 20 128 192.168.100.99 192.168.100.254 8 0 id=1 seq=2  (Ping-00)
 -->
   <rule id="110080" level="4">
-    <if_matched_sid>110060</if_matched_sid>
-	<protocol>icmp</protocol>
+    <if_sid>110060</if_sid>
+    <protocol>icmp</protocol>
     <field name="packetlen" type="pcre2">([0-9]{4,}|[1-9]0[5-9]|1[1-9][0-9]|[2-9][0-9]{2})</field>
-	<description>Watchguard: firewall: $(action) from $(srcip) to $(dstip) using protocol $(protocol) packet size is bigger than usual: $(packetlen)</description>
+    <description>Watchguard: firewall: $(action) from $(srcip) to $(dstip) using protocol $(protocol) packet size is bigger than usual: $(packetlen)</description>
   </rule>
   
   <rule id="110081" level="14" frequency="10" timeframe="240" ignore="90">
     <if_matched_sid>110080</if_matched_sid>
-	<same_srcip />
-	<description>Watchguard: firewall: Possible $(protocol) tunnel attack from $(srcip) on interface $(src) to $(dstip) on interface $(dst)</description>
-	<group>hidden_tunnel,pci_dss_10.6.1,pci_dss_11.4,gpg13_4.12,gdpr_IV_35.7.d,tsc_CC7.2,tsc_CC7.3,tsc_CC6.1,tsc_CC6.8,</group>
+    <same_srcip />
+    <description>Watchguard: firewall: Possible $(protocol) tunnel attack from $(srcip) on interface $(src) to $(dstip) on interface $(dst)</description>
+    <group>hidden_tunnel,pci_dss_10.6.1,pci_dss_11.4,gpg13_4.12,gdpr_IV_35.7.d,tsc_CC7.2,tsc_CC7.3,tsc_CC6.1,tsc_CC6.8,</group>
   </rule>
   
    <!--DNS hidden tunnel detection when too much packets are larger than standard DNS request size
   
-DNS Nom de domaine < 63 caractères 
-Taille de la requête IPv4 = 112
-IPv4 + IPv6 = 112 + 20 = 132
+IPv4 request size = 112 
+Adding IPv6 20 bytes header = 112 + 20 = 132
+Domain names are max 63 characters
 (63 letters).(63 letters).(63 letters).(62 letters) = 260 IPv4 (FQDN max length)
 https://devblogs.microsoft.com/oldnewthing/20120412-00/?p=7873
 
@@ -352,81 +356,82 @@ Mar 21 23:47:28 FW-125852 FVE1032175935 firewall: msg_id="3000-0148" Allow Fireb
 -->
 
   <rule id="110082" level="4">
-    <if_matched_sid>110060</if_matched_sid>
-	<protocol>dns</protocol>
+    <if_sid>110060</if_sid>
+    <dstport>53</dstport>
     <field name="packetlen" type="pcre2">([0-9]{4,}|[1-9]3[3-9]|1[4-9][0-9]|[2-9][0-9]{2})</field>
-	<description>Watchguard: firewall: $(action) from $(srcip) to $(dstip) using protocol $(protocol) packet size is bigger than usual: $(packetlen)</description>
+    <description>Watchguard: firewall: $(action) from $(srcip) to $(dstip) using protocol $(protocol) packet size is bigger than usual: $(packetlen)</description>
   </rule>
   
   <rule id="110083" level="14" frequency="10" timeframe="240" ignore="90">
     <if_matched_sid>110082</if_matched_sid>
-	<same_srcip />
-	<description>Watchguard: firewall: Possible $(protocol) tunnel attack from $(srcip) on interface $(src) to $(dstip) on interface $(dst)</description>
-	<group>hidden_tunnel,pci_dss_10.6.1,pci_dss_11.4,gpg13_4.12,gdpr_IV_35.7.d,tsc_CC7.2,tsc_CC7.3,tsc_CC6.1,tsc_CC6.8,</group>
+    <same_srcip />
+    <description>Watchguard: firewall: Possible $(protocol) tunnel attack from $(srcip) on interface $(src) to $(dstip) on interface $(dst)</description>
+    <group>hidden_tunnel,pci_dss_10.6.1,pci_dss_11.4,gpg13_4.12,gdpr_IV_35.7.d,tsc_CC7.2,tsc_CC7.3,tsc_CC6.1,tsc_CC6.8,</group>
   </rule>
 
   <!--NTP hidden tunnel detection when too much packets are larger than standard NTP packet size
 
-NTP Taille de la requête = 76
-Taille de la requête + Entête IPv6 = 96
+NTP request size IPv4 = 76
+Adding IPv6 20 bytes header = 76 + 20 = 96
 
-Apr 15 12:10:53 FW-125852 FVE1032175935 firewall: msg_id="3000-0148" Allow Trusted External 76 udp 20 63 192.168.100.250 162.159.200.123 48216 123  (Outgoing-00)
+Apr 15 12:10:53 FW-125852 FVE1032175935 firewall: msg_id="3000-0148" Allow Trusted External 176 udp 20 63 192.168.100.250 162.159.200.123 48216 123  (Outgoing-00)
 Apr 15 12:10:53 FW-125852 FVE1032175935 firewall: msg_id="3000-0148" Allow Trusted External 76 udp 20 63 fe80::20c:29ff:fe59:7afa ac::d0:::1 48216 123  (Outgoing-00)
 -->
 
   <rule id="110084" level="4">
-    <if_matched_sid>110060</if_matched_sid>
-	<protocol>ntp</protocol>
+    <if_sid>110060</if_sid>
+    <dstport>123</dstport>
     <field name="packetlen" type="pcre2">([1-9][0-9]{2,}|[2-9][0-9]|1[0-9])[0-9]{1}|([9-9][7-9])</field>
-	<description>Watchguard: firewall: $(action) from $(srcip) to $(dstip) using protocol $(protocol) packet size is bigger than usual: $(packetlen)</description>
+    <description>Watchguard: firewall: $(action) from $(srcip) to $(dstip) using protocol $(protocol) packet size is bigger than usual: $(packetlen)</description>
   </rule>
   
   <rule id="110085" level="14" frequency="10" timeframe="240" ignore="90">
     <if_matched_sid>110084</if_matched_sid>
-	<same_srcip />
-	<description>Watchguard: firewall: Possible $(protocol) tunnel attack from $(srcip) on interface $(src) to $(dstip) on interface $(dst)</description>
-	<group>hidden_tunnel,pci_dss_10.6.1,pci_dss_11.4,gpg13_4.12,gdpr_IV_35.7.d,tsc_CC7.2,tsc_CC7.3,tsc_CC6.1,tsc_CC6.8,</group>
+    <same_srcip />
+    <description>Watchguard: firewall: Possible $(protocol) tunnel attack from $(srcip) on interface $(src) to $(dstip) on interface $(dst)</description>
+    <group>hidden_tunnel,pci_dss_10.6.1,pci_dss_11.4,gpg13_4.12,gdpr_IV_35.7.d,tsc_CC7.2,tsc_CC7.3,tsc_CC6.1,tsc_CC6.8,</group>
   </rule>
 
-  <rule id="110086" level="14" frequency="10" timeframe="240" ignore="90"> <!-- NOOK -->
+  <rule id="110086" level="14" frequency="3" timeframe="240" ignore="90"> <!-- NOOK -->
     <if_matched_group>hidden_tunnel</if_matched_group>
-	<description>Watchguard: Possible multiple tunnel attacks ongoing. Please have a look</description>
-	<group>pci_dss_10.6.1,pci_dss_11.4,gpg13_4.12,gdpr_IV_35.7.d,tsc_CC7.2,tsc_CC7.3,tsc_CC6.1,tsc_CC6.8,</group>
+    <description>Watchguard: Possible multiple tunnel attacks ongoing. Please have a look</description>
+    <group>pci_dss_10.6.1,pci_dss_11.4,gpg13_4.12,gdpr_IV_35.7.d,tsc_CC7.2,tsc_CC7.3,tsc_CC6.1,tsc_CC6.8,</group>
   </rule>
+
     
   <!-- ## PROXY FILTER RULES ## -->
   
   <!-- allowed proxy traffic is level 0 for disk space reasons -->
   <rule id="110090" level="0">
     <if_sid>110000</if_sid>
-	<id type="pcre2">[1-2][0-9A-F]FF-[0-F]{4}</id>
-	<action type="pcre2">[Aa]llow</action>
-	<description>Watchguard: proxy: $(action) from $(src) to $(dst), $(protocol) from $(srcip):$(srcport) to $(dstip):$(dstport) - $(reason)</description>
-	<group>proxy</group>
+    <id type="pcre2">[1-2][0-9A-F]FF-[0-F]{4}</id>
+    <action type="pcre2">[Aa]llow</action>
+    <description>Watchguard: proxy: $(action) from $(src) to $(dst), $(protocol) from $(srcip):$(srcport) to $(dstip):$(dstport) - $(reason)</description>
+    <group>proxy</group>
   </rule>
   
   <!-- denied proxy traffic -->
   <rule id="110091" level="3">
     <if_sid>110000</if_sid>
-	<id type="pcre2">[1-2][0-9A-F]FF-[0-F]{4}</id>
-	<action type="pcre2">[Dd]eny</action>
-	<description>Watchguard: proxy: $(action) from $(src) to $(dst), $(protocol) from $(srcip):$(srcport) to $(dstip):$(dstport) - $(reason)</description>
-	<group>proxy</group>
-  </rule>
-  
-  <!-- Multiple proxy traffic -->
-  <rule id="110092" level="13" frequency="10" timeframe="240" ignore="90">
-    <if_matched_sid>110091</if_matched_sid>
-    <same_srcip />
-    <description>Watchguard: proxy: Multiple denied traffic from same source</description>
+    <id type="pcre2">[1-2][0-9A-F]FF-[0-F]{4}</id>
+    <action type="pcre2">[Dd]eny</action>
+    <description>Watchguard: proxy: $(action) from $(src) to $(dst), $(protocol) from $(srcip):$(srcport) to $(dstip):$(dstport) - $(reason)</description>
     <group>proxy</group>
   </rule>
   
+  <!-- Multiple denied proxy traffic -->
+  <rule id="110092" level="13" frequency="10" timeframe="240" ignore="90">
+    <if_matched_sid>110091</if_matched_sid>
+    <same_srcip />
+    <description>Watchguard: proxy: Multiple denied traffic from same source $(srcip) on interface $(src)</description>
+    <group>proxy,access_denied,pci_dss_10.2.4,pci_dss_11.4,gpg13_4.12,gdpr_IV_35.7.d,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
+  </rule>
+  
   <!-- Possible DDoS or botnet attack NOOK -->
-  <rule id="110093" level="14" frequency="10" timeframe="240" ignore="90">
+  <rule id="110093" level="14" frequency="3" timeframe="240" ignore="90">
     <if_matched_sid>110092</if_matched_sid>
-	<description>Watchguard: proxy: Multiple recidiving traffic sent from same sources. Possible DDoS attack</description>
-	<group>ids,pci_dss_11.4,gpg13_4.12,gdpr_IV_35.7.d,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
+    <description>Watchguard: proxy: Multiple recidiving traffic sent from same sources. Possible DDoS attack</description>
+    <group>proxy,ids,pci_dss_11.4,gpg13_4.12,gdpr_IV_35.7.d,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
   </rule>
 
   <!-- APT THREAT -->
@@ -434,13 +439,14 @@ Apr 15 12:10:53 FW-125852 FVE1032175935 firewall: msg_id="3000-0148" Allow Trust
     <if_sid>110000</if_sid>
     <id>0F01-0015</id>
     <description>Watchguard: $(reason) from $(srcip):$(srcport) to $(dstip):$(dstport) - $(data)</description>
-	<group>ids,pci_dss_11.4,gpg13_4.12,gdpr_IV_35.7.d,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
+    <group>ids,pci_dss_11.4,gpg13_4.12,gdpr_IV_35.7.d,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
   </rule>
   
   <!-- ## UNHANDLED LOGS -->
   <rule id="110100" level="3">
     <if_sid>110000</if_sid>
-	<description>Watchguard: Unhandled $(id) log recorded</description>
+    <description>Watchguard: Unhandled $(id) log recorded</description>
+    <group>firewall</group>
   </rule>
   
 
@@ -454,82 +460,59 @@ Apr 15 12:10:53 FW-125852 FVE1032175935 firewall: msg_id="3000-0148" Allow Trust
   
   <rule id="110201" level="9">
     <if_sid>110200</if_sid>
-    <id>1100-0005</id>
-    <status>rejected</status>
-    <description>Watchguard: $(account) user $(dstuser) login $(status) from $(srcip) - $(reason)</description>
-	<mitre>
-	  <id>T1133</id>
-	</mitre>
+    <id type="pcre2">1100-0005|5000-0001</id>
+    <action>rejected</action>
+    <description>Watchguard: $(account_type) $(srcuser) login $(action) from $(srcip) - $(reason)</description>
+    <mitre>
+      <id>T1133</id>
+    </mitre>
     <group>wg_userloginfailed,authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.8,gdpr_IV_35.7.d,gdpr_IV_32.2,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
   </rule>
   
-    <rule id="110202" level="4">
-    <if_sid>110200</if_sid>
-    <id>5000-0001</id>
-    <status>rejected</status>
-    <description>Watchguard: $(account) user [$(dstuser)] login $(status) from $(srcip) - $(reason)</description>
-	<mitre>
-	  <id>T1133</id>
-	</mitre>
-    <group>wg_webloginfailed,authentication_failed,</group>
-  </rule>
-  
-  <rule id="110203" level="10" frequency="5" timeframe="60" ignore="240">
+  <rule id="110202" level="10" frequency="5" timeframe="60" ignore="240">
     <if_matched_sid>110201</if_matched_sid>
     <same_source_ip/>
-    <description>Watchguard: Multiple $(status) login for $(account) user $(dstuser) from $(srcip) - $(reason)</description>
-	<mitre>
-	  <id>T1110</id>
-	  <id>T1133</id>
-	</mitre>
-    <group>wg_loginforce,authentication_failures,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.8,gdpr_IV_35.7.d,gdpr_IV_32.2,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3</group>
-  </rule>
-  
-  <rule id="110204" level="10" frequency="5" timeframe="60" ignore="240">
-    <if_matched_sid>110202</if_matched_sid>
-    <same_source_ip/>
-    <description>Watchguard: Multiple $(status) login for $(account) user [$(dstuser)] from $(srcip) - $(reason)</description>
+    <description>Watchguard: Multiple $(action) login for $(account_type) $(srcuser) from $(srcip) - $(reason)</description>
     <mitre>
-	  <id>T1110</id>
-	  <id>T1133</id>
-	</mitre>
-    <group>wg_webloginforce,authentication_failures,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.8,gdpr_IV_35.7.d,gdpr_IV_32.2,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3</group>
+      <id>T1110</id>
+      <id>T1133</id>
+    </mitre>
+    <group>wg_loginforce,authentication_failures,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.8,gdpr_IV_35.7.d,gdpr_IV_32.2,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3</group>
   </rule>
 
   <rule id="110205" level="3">
     <if_sid>110200</if_sid>
     <id>3E00-0002</id>
-    <status>logged in</status>
-    <field name="account" negate="yes">SSL VPN</field>
-    <description>Watchguard: $(account) user [$(dstuser)] is $(status) from $(srcip)</description>
+    <action>logged in</action>
+    <field name="account_type" negate="yes">SSL VPN</field>
+    <description>Watchguard: $(account_type) $(srcuser) login $(action) from $(srcip)</description>
     <mitre>
-	  <id>T1078</id>
-	  <id>T1133</id>
-	</mitre>
+      <id>T1078</id>
+      <id>T1133</id>
+    </mitre>
     <group>wg_loginsuccess,authentication_success,pci_dss_10.2.5,gpg13_7.8,gdpr_IV_32.2,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
   </rule>
 
   <rule id="110206" level="3">
     <if_sid>110200</if_sid>
     <id>2500-0000</id>
-    <status>logged in</status>
-    <field name="virtip" negate="yes">0.0.0.0</field>
-    <description>Watchguard: Mobile VPN user [$(dstuser)] is $(status) from $(srcip) - Virtual IP is $(virtip)</description>
-	<mitre>
-	  <id>T1078</id>
-	  <id>T1133</id>
-	</mitre>
+    <action>logged in</action>
+    <description>Watchguard: Mobile VPN user $(srcuser) login $(action) from $(srcip) - Virtual IP is $(dstip)</description>
+    <mitre>
+      <id>T1078</id>
+      <id>T1133</id>
+    </mitre>
     <group>wg_vpnloginsuccess,authentication_success,pci_dss_10.2.5,gpg13_7.8,gdpr_IV_32.2,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
   </rule>
 
   <rule id="110207" level="9">
     <if_sid>110200</if_sid>
-    <id>SSL VPN</id> <!-- NOOK TO TET -->
-    <status>rejected</status>
-    <description>Watchguard: SSL VPN user [$(dstuser)] connection $(status) from $(srcip) - $(reason)</description>
-	<mitre>
-	  <id>T1133</id>
-	</mitre>
+    <id>SSL VPN</id>
+    <action>rejected</action>
+    <description>Watchguard: SSL VPN user $(srcuser) connection $(action) from $(srcip) - $(reason)</description>
+    <mitre>
+      <id>T1133</id>
+    </mitre>
     <group>wg_vpnloginfailed,authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.8,gdpr_IV_35.7.d,gdpr_IV_32.2,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
   </rule>
 </group>
@@ -545,17 +528,17 @@ Apr 15 12:10:53 FW-125852 FVE1032175935 firewall: msg_id="3000-0148" Allow Trust
   <!-- msg_id does not allow to determine the security event log level, hence we cannot decide of a reasonable alert level easily, we need to match keywords -->
   <rule id="110301" level="9">
     <if_sid>110300</if_sid>
-	<match type="pcre2">$SIGD_BAD_WORDS</match>
-	<description>Watchguard: Security event ERROR: $(reason)</description>
-	<group>system_error,pci_dss_10.6.1,pci_dss_11.4,gpg13_4.3,gdpr_IV_35.7.d,tsc_CC7.2,tsc_CC7.3,tsc_CC6.1,tsc_CC6.8,</group>
-	<mitre>
-	  <id>T1489</id>
-	</mitre>
+    <match type="pcre2">$SIGD_BAD_WORDS</match>
+    <description>Watchguard: Security event ERROR: $(reason)</description>
+    <group>system_error,pci_dss_10.6.1,pci_dss_11.4,gpg13_4.3,gdpr_IV_35.7.d,tsc_CC7.2,tsc_CC7.3,tsc_CC6.1,tsc_CC6.8,</group>
+    <mitre>
+      <id>T1489</id>
+    </mitre>
   </rule>
 
   <rule id="110302" level="3">
     <if_sid>110300</if_sid>
-	<description>Watchguard: Security event: $(reason)</description>
+    <description>Watchguard: Security event: $(reason)</description>
   </rule>
 </group>
   


### PR DESCRIPTION
I've written a fairly complex decoder & ruleset for Watchguard firewalls, according to the watchguard log catalog available [here](https://www.watchguard.com/help/docs/fireware/12/en-US/log_catalog/Log-Catalog_v12_7.pdf)

Was tested on a couple of firewalls, and should:
- Decode almost any log message (thanks watchguard for creating non standard logs)
- Have rules for firewall traffic
- Have rules for proxy traffic
- Have rules for any IPS related events, including DoS, portscan, blocked lists...
- Have rules for APT related events
- Correlate on too much bigger than usual ICMP, NTP and DNS traffic
- Catch all security related logs
- Catch all licensing related logs

All provided example logs are anonymized.
Please note that still Wazuh 4.2.1 is released, the 'NO_VERBOSE' variable won't work because of https://github.com/wazuh/wazuh/issues/9276

Note this is my first ruleset for Wazuh, so I have chosen an arbitrary ID range that isn't in use.

Greetz.