### PR TITLE
Improve syslog rule 1002 description and MITRE mapping

### DIFF
--- a/rules/0020-syslog_rules.xml
+++ b/rules/0020-syslog_rules.xml
@@ -24,7 +24,8 @@
 
   <rule id="1002" level="2">
     <match>$BAD_WORDS</match>
-    <description>Unknown problem somewhere in the system.</description>
+    <description>Generic syslog message indicating a potential system issue or misconfiguration.</description>
+    <mitre>T1082</mitre>
     <group>gpg13_4.3,</group>
   </rule>
 


### PR DESCRIPTION
Improves the clarity of syslog rule 1002 by updating its description and adding a relevant MITRE ATT&CK technique mapping.

No functional behavior has been changed.